### PR TITLE
Add gym protocol and channel

### DIFF
--- a/aea/channel/gym.py
+++ b/aea/channel/gym.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Gym connector and gym channel."""
+import logging
+import queue
+import threading
+from queue import Queue
+from threading import Thread
+from typing import Dict, Optional
+
+from aea.mail.base import Envelope, Connection
+from aea.protocols.gym.message import GymMessage
+from aea.protocols.gym.serialization import GymSerializer
+
+logger = logging.getLogger(__name__)
+
+
+"""default 'to' field for Gym envelopes."""
+DEFAULT_GYM = "gym"
+
+gym_Env = object  # typing stub for gym.Env
+
+
+class GymChannel:
+    """A ."""
+
+    def __init__(self, gym_env: gym_Env):
+        """Initialize a gym channel."""
+        self.gym_env = gym_env
+        self._lock = threading.Lock()
+
+        self._queues = {}  # type: Dict[str, Queue]
+
+    def connect(self, public_key: str) -> Optional[Queue]:
+        """
+        Connect a public key to the gym.
+
+        :param public_key: the public key of the agent.
+        :return: an asynchronous queue, that constitutes the communication channel.
+        """
+        if public_key in self._queues:
+            return None
+
+        assert len(self._queues.keys()) <= 1, "Only one public key can register to a gym."
+        q = Queue()
+        self._queues[public_key] = q
+        return q
+
+    def send_envelope(self, envelope: Envelope) -> None:
+        """
+        Process the envelopes to the gym.
+
+        :return: None
+        """
+        sender = envelope.sender
+        logger.debug("Processing message from {}: {}".format(sender, envelope))
+        self._decode_envelope(envelope)
+
+    def _decode_envelope(self, envelope: Envelope) -> None:
+        """
+        Decode the envelope.
+
+        :param envelope: the envelope
+        :return: None
+        """
+        if envelope.protocol_id == "gym":
+            self.handle_gym_message(envelope)
+        else:
+            raise ValueError('This protocol is not valid for gym.')
+
+    def handle_gym_message(self, envelope: Envelope) -> None:
+        """
+        Forward a message to gym.
+
+        :param envelope: the envelope
+        :return: None
+        """
+        gym_message = GymSerializer().decode(envelope.message)
+        performative = gym_message.get("performative")
+        assert GymMessage.Performative(performative) == GymMessage.Performative.ACT, "This is not a valid message."
+        action = gym_message.get("action")
+        observation, reward, done, info = self.gym_env.step(action)
+        msg = GymMessage(performative=GymMessage.Performative.PERCEPT, observation=observation, reward=reward, done=done, info=info)
+        msg_bytes = GymSerializer().encode(msg)
+        envelope = Envelope(to=envelope.sender, sender=DEFAULT_GYM, protocol_id=GymMessage.protocol_id, message=msg_bytes)
+        self._send(envelope)
+
+    def _send(self, envelope: Envelope) -> None:
+        """Send a message.
+
+        :param envelope: the envelope
+        :return: None
+        """
+        destination = envelope.to
+        self._queues[destination].put_nowait(envelope)
+
+    def disconnect(self, public_key: str) -> None:
+        """
+        Disconnect.
+
+        :param public_key: the public key
+        :return: None
+        """
+        with self._lock:
+            self._queues.pop(public_key, None)
+
+
+class GymConnection(Connection):
+    """Proxy to the functionality of the gym."""
+
+    def __init__(self, public_key: str, gym_channel: GymChannel):
+        """
+        Initialize a connection to a local gym environment.
+
+        :param public_key: the public key used in the protocols.
+        :param gym: the gym environment.
+        """
+        super().__init__()
+        self.public_key = public_key
+        self.gym_channel = gym_channel
+
+        self._connection = None  # type: Optional[Queue]
+
+        self._stopped = True
+        self.in_thread = None
+        self.out_thread = None
+
+    def _fetch(self) -> None:
+        """
+        Fetch the envelopes from the outqueue and send them.
+
+        :return: None
+        """
+        while not self._stopped:
+            try:
+                envelope = self.out_queue.get(block=True, timeout=2.0)
+                self.send(envelope)
+            except queue.Empty:
+                pass
+
+    def _receive_loop(self) -> None:
+        """
+        Receive messages.
+
+        :return: None
+        """
+        while not self._stopped:
+            try:
+                data = self._connection.get(timeout=2.0)
+                self.in_queue.put_nowait(data)
+            except queue.Empty:
+                pass
+
+    @property
+    def is_established(self) -> bool:
+        """Return True if the connection has been established, False otherwise."""
+        return self._connection is not None
+
+    def connect(self) -> None:
+        """
+        Connect to the gym.
+
+        :return: None
+        """
+        if self._stopped:
+            self._stopped = False
+            self._connection = self.gym_channel.connect(self.public_key)
+            self.in_thread = Thread(target=self._receive_loop)
+            self.out_thread = Thread(target=self._fetch)
+            self.in_thread.start()
+            self.out_thread.start()
+
+    def disconnect(self) -> None:
+        """
+        Disconnect from the gym.
+
+        :return: None
+        """
+        if not self._stopped:
+            self._stopped = True
+            self.in_thread.join()
+            self.out_thread.join()
+            self.in_thread = None
+            self.out_thread = None
+            self.gym_channel.disconnect(self.public_key)
+            self.stop()
+
+    def send(self, envelope: Envelope) -> None:
+        """
+        Send an envelope.
+
+        :param envelope: the envelop
+        :return: None
+        """
+        if not self.is_established:
+            raise ConnectionError("Connection not established yet. Please use 'connect()'.")
+        self.gym_channel.send_envelope(envelope)
+
+    def stop(self) -> None:
+        """
+        Tear down the connection.
+
+        :return: None
+        """
+        self._connection = None

--- a/aea/protocols/gym/__init__.py
+++ b/aea/protocols/gym/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 # ------------------------------------------------------------------------------
 #
 #   Copyright 2018-2019 Fetch.AI Limited
@@ -17,4 +18,4 @@
 #
 # ------------------------------------------------------------------------------
 
-"""The test protocols module contains the tests of the AEA protocols."""
+"""This module contains the support resources for the Gym protocol."""

--- a/aea/protocols/gym/message.py
+++ b/aea/protocols/gym/message.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the FIPA message definition."""
+from enum import Enum
+from typing import Optional, Union
+
+from aea.protocols.base.message import Message
+
+
+class GymMessage(Message):
+    """The Gym message class."""
+
+    protocol_id = "gym"
+
+    class Performative(Enum):
+        """Gym performatives."""
+
+        ACT = 'act'
+        PERCEPT = 'percept'
+
+        def __str__(self):
+            """Get string representation."""
+            return self.value
+
+    def __init__(self, performative: Optional[Union[str, Performative]] = None, **kwargs):
+        """
+        Initialize.
+
+        :param type: the type.
+        """
+        super().__init__(performative=GymMessage.Performative(performative), **kwargs)
+
+    def check_consistency(self) -> bool:
+        """Check that the data is consistent."""
+        try:
+            assert self.is_set("performative")
+            performative = GymMessage.Performative(self.get("performative"))
+            if performative == GymMessage.Performative.ACT:
+                assert self.is_set("action")
+            elif performative == GymMessage.Performative.PERCEPT:
+                assert self.is_set("observation")
+                assert self.is_set("reward")
+                assert self.is_set("done")
+                assert self.is_set("info")
+            else:
+                raise ValueError("Performative not recognized.")
+
+        except (AssertionError, ValueError, KeyError):
+            return False
+
+        return True

--- a/aea/protocols/gym/serialization.py
+++ b/aea/protocols/gym/serialization.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Serialization for the FIPA protocol."""
+import base58
+import copy
+import json
+import pickle
+from typing import Any
+
+from aea.protocols.base.message import Message
+from aea.protocols.base.serialization import Serializer
+from aea.protocols.gym.message import GymMessage
+
+
+class GymSerializer(Serializer):
+    """Serialization for the Gym protocol."""
+
+    def encode(self, msg: Message) -> bytes:
+        """
+        Decode the message.
+
+        :param msg: the message object
+        :return: the bytes
+        """
+        performative = GymMessage.Performative(msg.get("performative"))
+        new_body = copy.copy(msg.body)
+        new_body["performative"] = performative.value
+
+        if performative == GymMessage.Performative.ACT:
+            action = msg.body["action"]  # type: Any
+            action_bytes = base58.b58encode(pickle.dumps(action)).decode("utf-8")
+            new_body["action"] = action_bytes
+        elif performative == GymMessage.Performative.PERCEPT:
+            # observation, reward and info are gym implementation specific, done is boolean
+            observation = msg.body["observation"]  # type: Any
+            observation_bytes = base58.b58encode(pickle.dumps(observation)).decode("utf-8")
+            new_body["observation"] = observation_bytes
+            reward = msg.body["reward"]  # type: Any
+            reward_bytes = base58.b58encode(pickle.dumps(reward)).decode("utf-8")
+            new_body["reward"] = reward_bytes
+            info = msg.body["info"]  # type: Any
+            info_bytes = base58.b58encode(pickle.dumps(info)).decode("utf-8")
+            new_body["info"] = info_bytes
+
+        gym_message_bytes = json.dumps(new_body).encode("utf-8")
+        return gym_message_bytes
+
+    def decode(self, obj: bytes) -> Message:
+        """
+        Decode the message.
+
+        :param obj: the bytes object
+        :return: the message
+        """
+        json_msg = json.loads(obj.decode("utf-8"))
+        performative = GymMessage.Performative(json_msg["performative"])
+        new_body = copy.copy(json_msg)
+        new_body["type"] = performative
+
+        if performative == GymMessage.Performative.ACT:
+            action_bytes = base58.b58decode(json_msg["action"])
+            action = pickle.loads(action_bytes)
+            new_body["action"] = action   # type: Any
+        elif performative == GymMessage.Performative.PERCEPT:
+            # observation, reward and info are gym implementation specific, done is boolean
+            observation_bytes = base58.b58decode(json_msg["observation"])
+            observation = pickle.loads(observation_bytes)
+            new_body["observation"] = observation  # type: Any
+            reward_bytes = base58.b58decode(json_msg["reward"])
+            reward = pickle.loads(reward_bytes)
+            new_body["reward"] = reward  # type: Any
+            info_bytes = base58.b58decode(json_msg["info"])
+            info = pickle.loads(info_bytes)
+            new_body["info"] = info  # type: Any
+
+        gym_message = Message(body=new_body)
+        return gym_message

--- a/tests/test_channel/test_gym.py
+++ b/tests/test_channel/test_gym.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This test module contains the tests for the Gym channel and connection."""
+
+import time
+from typing import Any, Tuple
+
+from aea.channel.gym import GymChannel, GymConnection, DEFAULT_GYM
+from aea.mail.base import Envelope, MailBox
+from aea.protocols.gym.message import GymMessage
+from aea.protocols.gym.serialization import GymSerializer
+
+
+Action = Any
+Observation = Any
+Reward = Any
+Done = bool
+Info = Any
+Feedback = Tuple[Observation, Reward, Done, Info]
+
+
+class GymEnvStub:
+    """Stubs a Gym Env."""
+
+    def step(self, action: Action) -> Feedback:
+        """Take a step."""
+        return None, 1, False, {}
+
+
+def test_connection():
+    """Test that two mailbox can connect to the node."""
+    channel = GymChannel(GymEnvStub())
+    mailbox = MailBox(GymConnection("agent_public_key", channel))
+
+    mailbox.connect()
+
+    mailbox.disconnect()
+
+
+def test_communication():
+    """Test that the gym can be communicated with."""
+    channel = GymChannel(GymEnvStub())
+    mailbox = MailBox(GymConnection("agent_public_key", channel))
+
+    mailbox.connect()
+
+    msg = GymMessage(performative=GymMessage.Performative.ACT, action='some_action')
+    msg_bytes = GymSerializer().encode(msg)
+    envelope = Envelope(to=DEFAULT_GYM, sender="agent_public_key", protocol_id=GymMessage.protocol_id, message=msg_bytes)
+    mailbox.send(envelope)
+
+    time.sleep(1.0)
+
+    envelope = mailbox.inbox.get(block=True, timeout=1.0)
+    assert envelope.sender == DEFAULT_GYM
+    assert envelope.to == "agent_public_key"
+    msg = GymSerializer().decode(envelope.message)
+    assert envelope.protocol_id == "gym"
+    assert msg.get("observation") is None
+    assert msg.get("reward") == 1
+    assert msg.get("done") is False
+    assert msg.get("info") == {}
+
+    mailbox.disconnect()

--- a/tests/test_channel/test_local/test_misc.py
+++ b/tests/test_channel/test_local/test_misc.py
@@ -26,9 +26,6 @@ from aea.protocols.default.message import DefaultMessage
 from aea.protocols.default.serialization import DefaultSerializer
 from aea.protocols.fipa.message import FIPAMessage
 from aea.protocols.fipa.serialization import FIPASerializer
-from aea.protocols.oef.message import OEFMessage
-from aea.protocols.oef.models import Query, Description, DataModel
-from aea.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
 
 
 def test_connection():
@@ -103,4 +100,3 @@ def test_communication():
 
     mailbox1.disconnect()
     mailbox2.disconnect()
-

--- a/tests/test_channel/test_local/test_search_services.py
+++ b/tests/test_channel/test_local/test_search_services.py
@@ -109,6 +109,7 @@ class TestSimpleSearchResult:
 
     @classmethod
     def teardown_class(cls):
+        """Teardown the test."""
         cls.mailbox1.disconnect()
 
 
@@ -166,6 +167,6 @@ class TestFilteredSearchResult:
 
     @classmethod
     def teardown_class(cls):
+        """Teardown the test."""
         cls.mailbox1.disconnect()
         cls.mailbox2.disconnect()
-

--- a/tests/test_channel/test_oef.py
+++ b/tests/test_channel/test_oef.py
@@ -73,8 +73,7 @@ class TestTranslator:
                 ]),
                 Constraint("foo", LtEq(2)),
             ])
-        ],
-        data_model_foobar)
+        ], data_model_foobar)
 
         oef_query = OEFObjectTranslator.to_oef_query(query)
         expected_query = OEFObjectTranslator.from_oef_query(oef_query)

--- a/tests/test_protocols/test_base.py
+++ b/tests/test_protocols/test_base.py
@@ -23,8 +23,8 @@ from aea.protocols.base.message import Message
 from aea.protocols.base.serialization import ProtobufSerializer, JSONSerializer
 
 
-class TestDefaultSerializations:
-    """Test that the default serializations work."""
+class TestBaseSerializations:
+    """Test that the base serializations work."""
 
     @classmethod
     def setup_class(cls):

--- a/tox.ini
+++ b/tox.ini
@@ -18,4 +18,4 @@ basepython = python3.7
 deps = flake8
        flake8-docstrings
        pydocstyle==3.0.0
-commands = flake8 aea --exclude=.md,aea/*_pb2.py,aea/__init__.py --ignore=E501,E701
+commands = flake8 aea tests --exclude=.md,aea/*_pb2.py,aea/__init__.py --ignore=E501,E701


### PR DESCRIPTION
## Proposed changes

This PR provides:
- a new 'gym' channel to connect the aea with a gym.Env
- a new 'gym' protocol for interaction with the 'gym' channel and environment

## Fixes

It addresses a feature request on fetchai/agents-tac (https://github.com/fetchai/agents-tac/issues/364)

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The gym protocol does not implement an error code. It is probably preferable to have the code fail loudly rather than implement error handling.
