### PR TITLE
Fix/oef channel

### DIFF
--- a/aea/agent.py
+++ b/aea/agent.py
@@ -23,7 +23,7 @@
 import logging
 import time
 
-from abc import abstractmethod
+from abc import abstractmethod, ABC
 from enum import Enum
 from typing import Dict, Optional
 
@@ -57,7 +57,7 @@ class Liveness:
         return self._is_stopped
 
 
-class Agent:
+class Agent(ABC):
     """This class implements a template agent."""
 
     def __init__(self, name: str,

--- a/aea/channel/oef.py
+++ b/aea/channel/oef.py
@@ -467,7 +467,7 @@ class OEFConnection(Connection):
 
         :return: None
         """
-        while not self._connected:
+        while self._connected:
             try:
                 msg = self.out_queue.get(block=True, timeout=1.0)
                 self.send(msg)
@@ -483,10 +483,10 @@ class OEFConnection(Connection):
         if self._stopped and not self._connected:
             self._stopped = False
             self._core.run_threaded()
-            self.bridge.connect()
+            assert self.bridge.connect()
+            self._connected = True
             self.out_thread = Thread(target=self._fetch)
             self.out_thread.start()
-            self._connected = True
 
     def disconnect(self) -> None:
         """

--- a/aea/channel/oef.py
+++ b/aea/channel/oef.py
@@ -449,19 +449,12 @@ class OEFConnection(Connection):
         """
         super().__init__()
         core = AsyncioCore(logger=logger)
-        core.run_threaded()
         self._core = core  # type: Optional[AsyncioCore]
         self.bridge = OEFChannel(public_key, oef_addr, oef_port, core=core, in_queue=self.in_queue)
 
         self._stopped = True
         self._connected = False
-        self.in_thread = Thread(target=self.bridge.run)
-        self.out_thread = Thread(target=self._fetch)
-
-    @property
-    def is_active(self) -> bool:
-        """Get active status."""
-        return self._core is not None
+        self.out_thread = None  # type: Optional[Thread]
 
     @property
     def is_established(self) -> bool:
@@ -474,7 +467,7 @@ class OEFConnection(Connection):
 
         :return: None
         """
-        while not self._stopped:
+        while not self._connected:
             try:
                 msg = self.out_queue.get(block=True, timeout=1.0)
                 self.send(msg)
@@ -487,10 +480,11 @@ class OEFConnection(Connection):
 
         :return: None
         """
-        if self._stopped:
+        if self._stopped and not self._connected:
             self._stopped = False
+            self._core.run_threaded()
             self.bridge.connect()
-            self.in_thread.start()
+            self.out_thread = Thread(target=self._fetch)
             self.out_thread.start()
             self._connected = True
 
@@ -500,18 +494,13 @@ class OEFConnection(Connection):
 
         :return: None
         """
-        self._stopped = True
-        if self.is_active:
-            self.bridge.stop()
-
-        self.in_thread.join()
-        self.out_thread.join()
-        self.in_thread = Thread(target=self.bridge.run)
-        self.out_thread = Thread(target=self._fetch)
-        self.bridge.disconnect()
-        self._connected = False
-        self._core.stop()
-        self._core = None
+        if not self._stopped and self._connected:
+            self._connected = False
+            self.out_thread.join()
+            self.out_thread = None
+            self.bridge.disconnect()
+            self._core.stop()
+            self._stopped = True
 
     def send(self, envelope: Envelope):
         """
@@ -519,7 +508,8 @@ class OEFConnection(Connection):
 
         :return: None
         """
-        self.bridge.send(envelope)
+        if self._connected:
+            self.bridge.send(envelope)
 
 
 class OEFMailBox(MailBox):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,7 @@ def _stop_oef_search_images():
     client = docker.from_env()
     for container in client.containers.list():
         if "fetchai/oef-search:latest" in container.image.tags:
+            logger.info("Stopping existing Docker image...")
             container.stop()
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -29,24 +29,30 @@ from aea.protocols.default.serialization import DefaultSerializer
 
 
 class TAgent(Agent):
+    """Implement a test agent."""
 
     def setup(self) -> None:
+        """Set up the agent."""
         pass
 
     def act(self) -> None:
+        """Do actions."""
         pass
 
     def react(self) -> None:
+        """Do reactions."""
         pass
 
     def update(self) -> None:
+        """Update the agent's state."""
         pass
 
     def teardown(self) -> None:
         pass
 
 
-def test_connect_agent(network_node):
+def test_start_agent(network_node):
+    """Test that the start method works as expected."""
     crypto = Crypto()
     mailbox = OEFMailBox(crypto.public_key, oef_addr="127.0.0.1", oef_port=10000)
     agent = TAgent("my_agent", oef_addr="127.0.0.1", oef_port=10000)
@@ -61,6 +67,7 @@ def test_connect_agent(network_node):
 
 
 def test_send_message(network_node):
+    """Test that an agent can send a message."""
     crypto = Crypto()
     mailbox = OEFMailBox(crypto.public_key, oef_addr="127.0.0.1", oef_port=10000)
     mailbox.connect()
@@ -69,13 +76,14 @@ def test_send_message(network_node):
 
     job = Thread(target=agent.start)
     job.start()
-    time.sleep(5.0)
 
     msg = DefaultMessage(type=DefaultMessage.Type.BYTES, content=b"hello")
     agent.outbox.put_message(to=crypto.public_key, sender=crypto.public_key, protocol_id=DefaultMessage.protocol_id,
                              message=DefaultSerializer().encode(msg))
+    envelope = agent.inbox.get(block=True, timeout=5.0)
+    actual_message = DefaultSerializer().decode(envelope.message)
+    assert actual_message.get("content") == b"hello"
 
-    msg = agent.inbox.get(block=True, timeout=5.0)
     agent.stop()
     job.join()
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -48,6 +48,7 @@ class TAgent(Agent):
         pass
 
     def teardown(self) -> None:
+        """Teardown the agent."""
         pass
 
 
@@ -70,7 +71,6 @@ def test_send_message(network_node):
     """Test that an agent can send a message."""
     crypto = Crypto()
     mailbox = OEFMailBox(crypto.public_key, oef_addr="127.0.0.1", oef_port=10000)
-    mailbox.connect()
     agent = TAgent("my_agent", oef_addr="127.0.0.1", oef_port=10000)
     agent.mailbox = mailbox
 
@@ -86,7 +86,3 @@ def test_send_message(network_node):
 
     agent.stop()
     job.join()
-
-
-
-

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This test module contains the tests for the OEF communication using an OEF."""
+import time
+from threading import Thread
+
+from aea.agent import Agent
+from aea.channel.oef import OEFMailBox
+from aea.crypto.base import Crypto
+from aea.protocols.default.message import DefaultMessage
+from aea.protocols.default.serialization import DefaultSerializer
+
+
+class TAgent(Agent):
+
+    def setup(self) -> None:
+        pass
+
+    def act(self) -> None:
+        pass
+
+    def react(self) -> None:
+        pass
+
+    def update(self) -> None:
+        pass
+
+    def teardown(self) -> None:
+        pass
+
+
+def test_connect_agent(network_node):
+    crypto = Crypto()
+    mailbox = OEFMailBox(crypto.public_key, oef_addr="127.0.0.1", oef_port=10000)
+    agent = TAgent("my_agent", oef_addr="127.0.0.1", oef_port=10000)
+    agent.mailbox = mailbox
+
+    job = Thread(target=agent.start)
+    job.start()
+
+    time.sleep(3.0)
+    assert agent.mailbox.is_connected
+    agent.stop()
+
+
+def test_send_message(network_node):
+    crypto = Crypto()
+    mailbox = OEFMailBox(crypto.public_key, oef_addr="127.0.0.1", oef_port=10000)
+    mailbox.connect()
+    agent = TAgent("my_agent", oef_addr="127.0.0.1", oef_port=10000)
+    agent.mailbox = mailbox
+
+    job = Thread(target=agent.start)
+    job.start()
+    time.sleep(5.0)
+
+    msg = DefaultMessage(type=DefaultMessage.Type.BYTES, content=b"hello")
+    agent.outbox.put_message(to=crypto.public_key, sender=crypto.public_key, protocol_id=DefaultMessage.protocol_id,
+                             message=DefaultSerializer().encode(msg))
+
+    msg = agent.inbox.get(block=True, timeout=5.0)
+    agent.stop()
+    job.join()
+
+
+
+


### PR DESCRIPTION
## Proposed changes

Update the OEF Channel to the latest `oef` version (`0.6.2`). In particular, clean up some parts of the implementation of the `OEFConnection` class, especially the `connect()` and `disconnect()` methods.

Here are some key points worth mentioning:
- the thread handling the incoming messages is not needed anymore since the receiving loop is implemented in the `oef.core.Connection` class. The `AsyncioCore` object must be run in order to schedule the connection receiving loop.
- An instance of the `AsyncioCore` class is instantiated in the `OEFConnection` constructor. It is started in threaded mode in the `connect()`, and stopped in the `disconnect()`.
- Miscellaneous cleanups of the `OEFConnection` class.
- Added some more tests on the `Agent` APIs and the `Default` protocol.


## Fixes

None.

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

None.
