### PR TITLE
Fix `step_id` field in Gym protocol.

### DIFF
--- a/aea/protocols/gym/serialization.py
+++ b/aea/protocols/gym/serialization.py
@@ -59,9 +59,8 @@ class GymSerializer(Serializer):
             info = msg.body["info"]  # type: Any
             info_bytes = base58.b58encode(pickle.dumps(info)).decode("utf-8")
             new_body["info"] = info_bytes
-        step_id = msg.body["step_id"]  # type: Any
-        step_id_bytes = base58.b58encode(pickle.dumps(step_id)).decode("utf-8")
-        new_body["action"] = step_id
+
+        new_body["step_id"] = msg.body["step_id"]  # type: int
 
         gym_message_bytes = json.dumps(new_body).encode("utf-8")
         return gym_message_bytes
@@ -93,9 +92,7 @@ class GymSerializer(Serializer):
             info_bytes = base58.b58decode(json_msg["info"])
             info = pickle.loads(info_bytes)
             new_body["info"] = info  # type: Any
-        step_id_bytes = base58.b58decode(json_msg["step_id"])
-        step_id = pickle.loads(step_id_bytes)
-        new_body["step_id"] = step_id # type: Any
+        new_body["step_id"] = json_msg["step_id"]
 
         gym_message = Message(body=new_body)
         return gym_message

--- a/tests/test_channel/test_gym.py
+++ b/tests/test_channel/test_gym.py
@@ -61,7 +61,7 @@ def test_communication():
 
     mailbox.connect()
 
-    msg = GymMessage(performative=GymMessage.Performative.ACT, action='some_action')
+    msg = GymMessage(performative=GymMessage.Performative.ACT, action='some_action', step_id=1)
     msg_bytes = GymSerializer().encode(msg)
     envelope = Envelope(to=DEFAULT_GYM, sender="agent_public_key", protocol_id=GymMessage.protocol_id, message=msg_bytes)
     mailbox.send(envelope)
@@ -77,5 +77,6 @@ def test_communication():
     assert msg.get("reward") == 1
     assert msg.get("done") is False
     assert msg.get("info") == {}
+    assert msg.get("step_id") == 1
 
     mailbox.disconnect()


### PR DESCRIPTION
## Proposed changes

This PR fixes the serialization module of the Gym protocol by handling the `step_id` field properly.

## Fixes

None.

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

None.
