### PR TITLE
Add connections section in the configuration file.

### DIFF
--- a/aea/aea.py
+++ b/aea/aea.py
@@ -44,6 +44,7 @@ class AEA(Agent):
         Instantiate the agent.
 
         :param name: the name of the agent
+        :param mailbox: the mailbox of the agent.
         :param private_key_pem_path: the path to the private key of the agent.
         :param timeout: the time in (fractions of) seconds to time out an agent between act and react
         :param debug: if True, run the agent in debug mode.
@@ -65,7 +66,6 @@ class AEA(Agent):
     @property
     def context(self) -> Context:
         """Get context."""
-        assert self._context is not None, "Context not initialized."
         return self._context
 
     @property

--- a/aea/aea.py
+++ b/aea/aea.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Optional, cast
 
 from aea.agent import Agent
-from aea.mail.base import Envelope
+from aea.mail.base import Envelope, MailBox
 from aea.skills.base import Resources, Context
 from aea.skills.default.handler import DefaultHandler
 
@@ -34,6 +34,7 @@ class AEA(Agent):
     """This class implements an autonomous economic agent."""
 
     def __init__(self, name: str,
+                 mailbox: MailBox,
                  private_key_pem_path: Optional[str] = None,
                  timeout: float = 1.0,  # TODO we might want to set this to 0 for the aea and let the skills take care of slowing things down on a skill level
                  debug: bool = False,
@@ -57,12 +58,14 @@ class AEA(Agent):
         self.max_reactions = max_reactions
         self._directory = directory if directory else str(Path(".").absolute())
 
+        self.mailbox = mailbox
         self._context = Context(self.name, self.outbox)
         self._resources = None  # type: Optional[Resources]
 
     @property
     def context(self) -> Context:
         """Get context."""
+        assert self._context is not None, "Context not initialized."
         return self._context
 
     @property

--- a/aea/channel/oef.py
+++ b/aea/channel/oef.py
@@ -490,7 +490,7 @@ class OEFConnection(Connection):
             self._connected = False
             self.out_thread.join()
             self.out_thread = None
-            assert self.channel.disconnect(), "Cannot disconnect from OEFChannel."
+            self.channel.disconnect()
             self._core.stop()
             self._stopped = True
 

--- a/aea/cli/__main__.py
+++ b/aea/cli/__main__.py
@@ -23,16 +23,14 @@
 import os
 import shutil
 from pathlib import Path
-from typing import cast
 
 import click
 import click_log
 
-from aea.aea import AEA
-from aea.channel.oef import OEFMailBox
 from aea.cli.add import add
+from aea.cli.common import DEFAULT_AEA_CONFIG_FILE, AgentConfig, Context, pass_ctx, logger
 from aea.cli.remove import remove
-from aea.cli.common import DEFAULT_AEA_CONFIG_FILE, AgentConfig, Context, pass_ctx, _try_to_load_agent_config, logger
+from aea.cli.run import run
 
 
 @click.group()
@@ -88,28 +86,9 @@ def delete(ctx: Context, agent_name):
         return
 
 
-@cli.command()
-@click.argument('oef_addr', type=str, default="127.0.0.1")
-@click.argument('oef_port', type=int, default=10000)
-@pass_ctx
-def run(ctx: Context, oef_addr, oef_port):
-    """Run the agent."""
-    _try_to_load_agent_config(ctx)
-    agent_name = cast(str, ctx.agent_config.agent_name)
-    agent = AEA(agent_name, directory=str(Path(".")))
-    agent.mailbox = OEFMailBox(public_key=agent.crypto.public_key, oef_addr=oef_addr, oef_port=oef_port)
-    try:
-        agent.start()
-    except KeyboardInterrupt:
-        logger.info("Interrupted.")
-    except Exception:
-        raise
-    finally:
-        agent.stop()
-
-
 cli.add_command(add)
 cli.add_command(remove)
+cli.add_command(run)
 
 if __name__ == '__main__':
     cli()

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Implementation of the 'aea run' subcommand."""
+
+from pathlib import Path
+from pydoc import locate
+from typing import cast, Type, Dict
+
+import click
+
+from aea.aea import AEA
+from aea.channel.oef import OEFConnection
+from aea.channel.gym import GymConnection
+from aea.channel.local import OEFLocalConnection, LocalNode
+from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config, AEAConfigException
+from aea.mail.base import MailBox, Connection
+
+
+def _setup_connection(connection_name: str, ctx: Context) -> Connection:
+    """
+    Set up a connection.
+
+    :param connection_name: the name of the connection.
+    :param ctx: the CLI context object.
+    :return: a Connection object.
+    :raises AEAConfigException: if the connection name provided as argument is not declared in the configuration file,
+                              | or if the connection type is not supported by the framework.
+    """
+    available_connections = ctx.agent_config.connections
+    available_connection_names = available_connections.keys()
+    if connection_name not in available_connection_names:
+        raise AEAConfigException("Connection name '{}' not declared in the configuration file.".format(connection_name))
+
+    connection_configuration = available_connections[connection_name]
+    connection_type = connection_configuration.type
+    if connection_type == "oef":
+        agent_name = ctx.agent_config.agent_name
+        oef_addr = connection_configuration.config.get("addr", "127.0.0.1")
+        oef_port = connection_configuration.config.get("port", 10000)
+        return OEFConnection(agent_name, oef_addr, oef_port)
+    elif connection_type == "local":
+        agent_name = ctx.agent_config.agent_name
+        local_node = LocalNode()
+        return OEFLocalConnection(agent_name, local_node)
+    elif connection_type == "gym":
+        agent_name = ctx.agent_config.agent_name
+        gym_env_package = connection_configuration.config.get("env")
+        gym_env = locate(gym_env_package)
+        return GymConnection(agent_name, gym_env)
+    else:
+        raise AEAConfigException("Connection type '{}' not supported.".format(connection_type))
+
+
+@click.command()
+@click.option('--connection', 'connection_name', metavar="CONN_NAME", type=str, required=False, default=None,
+              help="The connection name. Must be declared in the agent's configuration file.")
+@pass_ctx
+def run(ctx: Context, connection_name):
+    """Run the agent."""
+    _try_to_load_agent_config(ctx)
+    agent_name = cast(str, ctx.agent_config.agent_name)
+    connection_name = ctx.agent_config.default_connection if connection_name is None else connection_name
+    try:
+        connection = _setup_connection(connection_name, ctx)
+    except AEAConfigException as e:
+        logger.error(str(e))
+        exit(-1)
+        return
+
+    mailbox = MailBox(connection)
+    agent = AEA(agent_name, mailbox, directory=str(Path(".")))
+    try:
+        agent.start()
+    except KeyboardInterrupt:
+        logger.info("Interrupted.")
+    except Exception:
+        raise
+    finally:
+        agent.stop()
+

--- a/examples/echo_skill/skill.yaml
+++ b/examples/echo_skill/skill.yaml
@@ -3,6 +3,14 @@ authors: Fetch.AI Limited
 version: 0.1.0
 license: Apache 2.0
 url: ""
+connections:
+  connection:
+    name: my-oef-connection
+    type: oef
+    config:
+      addr: 127.0.0.1
+      port: 10000
+default_connection:
 behaviours:
   - class_name: EchoBehaviour
     args:

--- a/examples/echo_skill/skill.yaml
+++ b/examples/echo_skill/skill.yaml
@@ -3,14 +3,6 @@ authors: Fetch.AI Limited
 version: 0.1.0
 license: Apache 2.0
 url: ""
-connections:
-  connection:
-    name: my-oef-connection
-    type: oef
-    config:
-      addr: 127.0.0.1
-      port: 10000
-default_connection:
 behaviours:
   - class_name: EchoBehaviour
     args:


### PR DESCRIPTION
## Proposed changes

This PR adds a new section to the agent's configuration file, `connections`, to explicitly declare which connections are available to an AEA agent.
Also, the user can switch between connections by using `aea run --connection <connection-name>`.

## Fixes

Fixes #41 

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.