### PR TITLE
Fix/tests

### DIFF
--- a/aea/channel/oef.py
+++ b/aea/channel/oef.py
@@ -380,10 +380,11 @@ class OEFChannel(OEFAgent, Channel):
         performative = FIPAMessage.Performative(fipa_message.get("performative"))
         if performative == FIPAMessage.Performative.CFP:
             query = fipa_message.get("query")
+            query = b"" if query is None else query
             self.send_cfp(id, dialogue_id, destination, target, query)
         elif performative == FIPAMessage.Performative.PROPOSE:
             proposal = cast(List[Description], fipa_message.get("proposal"))
-            proposal_b = pickle.dumps([OEFObjectTranslator.to_oef_description(p) for p in proposal])  # type: bytes
+            proposal_b = pickle.dumps(proposal)  # type: bytes
             self.send_propose(id, dialogue_id, destination, target, proposal_b)
         elif performative == FIPAMessage.Performative.ACCEPT:
             self.send_accept(id, dialogue_id, destination, target)

--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -38,6 +38,7 @@ class ConnectionConfig:
     """Handle connection configuration."""
 
     def __init__(self, name: str, type: str, **config):
+        """Initialize a connection configuration object."""
         self.name = name
         self.type = type
         self.config = config
@@ -84,7 +85,6 @@ class AgentConfig(object):
 
     def dump(self, file):
         """Dump data to an agent configuration file."""
-
         result = vars(self)
         result["connections"] = [{"connection": vars(c)} for c in result["connections"].values()]
 

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -50,18 +50,16 @@ def _setup_connection(connection_name: str, ctx: Context) -> Connection:
 
     connection_configuration = available_connections[connection_name]
     connection_type = connection_configuration.type
+    agent_name = cast(str, ctx.agent_config.agent_name)
     if connection_type == "oef":
-        agent_name = ctx.agent_config.agent_name
         oef_addr = connection_configuration.config.get("addr", "127.0.0.1")
         oef_port = connection_configuration.config.get("port", 10000)
         return OEFConnection(agent_name, oef_addr, oef_port)
     elif connection_type == "local":
-        agent_name = ctx.agent_config.agent_name
         local_node = LocalNode()
         return OEFLocalConnection(agent_name, local_node)
     elif connection_type == "gym":
-        agent_name = ctx.agent_config.agent_name
-        gym_env_package = connection_configuration.config.get("env")
+        gym_env_package = cast(str, connection_configuration.config.get("env"))
         gym_env = locate(gym_env_package)
         return GymConnection(agent_name, gym_env)
     else:

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -21,14 +21,14 @@
 
 from pathlib import Path
 from pydoc import locate
-from typing import cast, Type, Dict
+from typing import cast
 
 import click
 
 from aea.aea import AEA
-from aea.channel.oef import OEFConnection
 from aea.channel.gym import GymConnection
 from aea.channel.local import OEFLocalConnection, LocalNode
+from aea.channel.oef import OEFConnection
 from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config, AEAConfigException
 from aea.mail.base import MailBox, Connection
 
@@ -94,4 +94,3 @@ def run(ctx: Context, connection_name):
         raise
     finally:
         agent.stop()
-

--- a/aea/protocols/default/serialization.py
+++ b/aea/protocols/default/serialization.py
@@ -68,4 +68,4 @@ class DefaultSerializer(Serializer):
         else:
             raise ValueError("Type not recognized.")
 
-        return DefaultMessage(body=body)
+        return DefaultMessage(type=msg_type, body=body)

--- a/aea/protocols/gym/serialization.py
+++ b/aea/protocols/gym/serialization.py
@@ -94,5 +94,5 @@ class GymSerializer(Serializer):
             new_body["info"] = info
         new_body["step_id"] = json_msg["step_id"]
 
-        gym_message = Message(body=new_body)
+        gym_message = GymMessage(performative=performative, body=new_body)
         return gym_message

--- a/aea/protocols/oef/serialization.py
+++ b/aea/protocols/oef/serialization.py
@@ -93,5 +93,5 @@ class OEFSerializer(Serializer):
             operation = json_msg["operation"]
             new_body["operation"] = OEFMessage.OEFErrorOperation(operation)
 
-        oef_message = Message(body=new_body)
+        oef_message = OEFMessage(oef_type=oef_type, body=new_body)
         return oef_message

--- a/aea/protocols/tac/serialization.py
+++ b/aea/protocols/tac/serialization.py
@@ -224,5 +224,5 @@ class TACSerializer(Serializer):
             raise ValueError("Type not recognized.")
 
         new_body["type"] = TACMessage.Type(new_body["type"])
-        tac_message = TACMessage(body=new_body)
+        tac_message = TACMessage(tac_type=tac_type, body=new_body)
         return tac_message

--- a/aea/protocols/tac/serialization.py
+++ b/aea/protocols/tac/serialization.py
@@ -223,6 +223,7 @@ class TACSerializer(Serializer):
         else:
             raise ValueError("Type not recognized.")
 
-        new_body["type"] = TACMessage.Type(new_body["type"])
+        tac_type = TACMessage.Type(new_body["type"])
+        new_body["type"] = tac_type
         tac_message = TACMessage(tac_type=tac_type, body=new_body)
         return tac_message

--- a/aea/protocols/tac/serialization.py
+++ b/aea/protocols/tac/serialization.py
@@ -224,5 +224,5 @@ class TACSerializer(Serializer):
             raise ValueError("Type not recognized.")
 
         new_body["type"] = TACMessage.Type(new_body["type"])
-        tac_message = Message(body=new_body)
+        tac_message = TACMessage(body=new_body)
         return tac_message

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -417,7 +417,8 @@ class ProtocolRegistry(Registry):
         """
         protocols_spec = importlib.util.spec_from_file_location("protocols",
                                                                 os.path.join(directory, "protocols", "__init__.py"))
-        if protocols_spec is None or not os.path.exists(protocols_spec.origin):
+        path = cast(str, protocols_spec.origin)
+        if protocols_spec is None or not os.path.exists(path):
             logger.warning("No protocol found.")
             return
 

--- a/tests/test_protocols/test_default.py
+++ b/tests/test_protocols/test_default.py
@@ -33,7 +33,7 @@ def test_default_bytes_serialization():
 
 def test_default_error_serialization():
     """Test that the serialization for the 'simple' protocol works for the ERROR message."""
-    msg = DefaultMessage(type=DefaultMessage.Type.ERROR, error_code=-1, error_msg="An error")
+    msg = DefaultMessage(type=DefaultMessage.Type.ERROR, error_code=-1, error_msg="An error", error_data=None)
     msg_bytes = DefaultSerializer().encode(msg)
     actual_msg = DefaultSerializer().decode(msg_bytes)
     expected_msg = msg

--- a/tests/test_protocols/test_tac.py
+++ b/tests/test_protocols/test_tac.py
@@ -30,6 +30,8 @@ def test_register_serialization():
     tac_message = TACMessage(tac_type=TACMessage.Type.REGISTER, agent_name="my_agent")
     tac_message_bytes = TACSerializer().encode(tac_message)
     expected_tac_message = TACSerializer().decode(tac_message_bytes)
+    print(tac_message.body)
+    print(expected_tac_message.body)
     assert expected_tac_message == tac_message
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,4 +24,4 @@ commands = flake8 aea examples scripts tests --exclude=.md,aea/*_pb2.py,aea/__in
 [testenv:mypy]
 basepython = python3.7
 deps = mypy
-commands = mypy aea examples tests
+commands = mypy aea examples tests scripts

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py36
+envlist = flake8, mypy, py37, py36
 skipsdist = True
 ignore_basepython_conflict = True
 
@@ -20,3 +20,8 @@ deps = flake8
        flake8-docstrings
        pydocstyle==3.0.0
 commands = flake8 aea examples scripts tests --exclude=.md,aea/*_pb2.py,aea/__init__.py,aea/cli/__init__.py,tests/common//oef_search_pluto_scripts --ignore=E501,E701
+
+[testenv:mypy]
+basepython = python3.7
+deps = mypy
+commands = mypy aea examples

--- a/tox.ini
+++ b/tox.ini
@@ -24,4 +24,4 @@ commands = flake8 aea examples scripts tests --exclude=.md,aea/*_pb2.py,aea/__in
 [testenv:mypy]
 basepython = python3.7
 deps = mypy
-commands = mypy aea examples
+commands = mypy aea examples tests


### PR DESCRIPTION
## Proposed changes

- fix how the OEF channel sends messages of the FIPA protocol. In particular, how the query of a CFP is passed to the `send_cfp` method (handling the case when it's None) and how the proposal is encoded (use only the `bytes` propose type).
- fix the decoding of the Default protocol: not use only the body keyword in the constructor, but also the 'type' keyword argument. Otherwise, in the parent `Message` constructor, the values in the keyword of the child constructor overwrite the values in the body (in particular, `type=None` used to overwrite `body["type"])`, hence losing information about the default message type.
- fix default message test, to include the (now mandatory) error_data field in the Error message type.
- add the `mypy` tox environment, and run linters by default.

## Fixes

None.

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

None.
