### PR TITLE
Add channel extras for the Gym channel and the OEF channel.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,13 @@ with open('README.md', 'r') as f:
     readme = f.read()
 
 extras = {
+    "oef-channel": [
+        "colorlog",
+        "oef",
+    ],
+    "gym-channel": [
+        "gym"
+    ],
     "cli": [
         "click",
         "click_log",
@@ -66,8 +73,6 @@ setup(
         'Programming Language :: Python :: 3.7',
     ],
     install_requires=[
-        "colorlog",
-        "oef",
         "cryptography",
         "base58"
     ],


### PR DESCRIPTION
## Proposed changes

This PR aims to split the dependencies of the channel supported by the framework.

In particular, the dependencies for the `GymChannel` in `aea.channel.gym` and the `OEFChannel` in `aea.channel.oef` have been put in two different extra dependencies, installable via `pip install aea[gym-channel]` and `pip install aea[oef-channel]`, respectively.

## Fixes

None.

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

None. 
