### PR TITLE
Parse channel and protocols extra dependencies on-the-fly.

### DIFF
--- a/aea/channel/__init__.py
+++ b/aea/channel/__init__.py
@@ -18,3 +18,8 @@
 # ------------------------------------------------------------------------------
 
 """This module contains the channel modules."""
+from typing import List
+
+gym_dependencies = []  # type: List[str]
+local_dependencies = []  # type: List[str]
+oef_dependencies = ["colorlog", "oef"]  # type: List[str]

--- a/aea/protocols/__init__.py
+++ b/aea/protocols/__init__.py
@@ -18,3 +18,10 @@
 # ------------------------------------------------------------------------------
 
 """This module contains the protocol modules."""
+from typing import List
+
+default_dependencies = []  # type: List[str]
+fipa_dependencies = ["protobuf"]  # type: List[str]
+gym_dependencies = []  # type: List[str]
+oef_dependencies = ["colorlog", "oef"]  # type: List[str]
+tac_dependencies = ["protobuf"]  # type: List[str]

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,47 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
+import importlib
 import os
+import re
+from typing import List, Dict
 
 from setuptools import setup, find_packages
 
 PACKAGE_NAME = "aea"
+
+
+def get_aea_extras() -> Dict[str, List[str]]:
+    """Parse extra dependencies from aea channels and protocols."""
+    result = {}
+
+    # parse channel dependencies
+    channel_module = importlib.import_module("aea.channel")
+    channel_dependencies = {k.split("_")[0] + "-channel": v for k, v in vars(channel_module).items() if re.match(".+_dependencies", k)}
+    result.update(channel_dependencies)
+
+    # parse protocols dependencies
+    protocols_module = importlib.import_module("aea.protocols")
+    protocols_dependencies = {k.split("_")[0] + "-protocol": v for k, v in vars(protocols_module).items() if re.match(".+_dependencies", k)}
+    result.update(protocols_dependencies)
+
+    return result
+
+
+def get_all_extras() -> Dict:
+    extras = {
+        "cli": [
+            "click",
+            "click_log",
+            "PyYAML"
+        ],
+    }
+    extras.update(get_aea_extras())
+
+    # add "all" extras
+    extras["all"] = list(set(dep for e in extras.values() for dep in e))
+    return extras
+
 
 here = os.path.abspath(os.path.dirname(__file__))
 about = {}
@@ -31,30 +67,6 @@ with open(os.path.join(here, PACKAGE_NAME, '__version__.py'), 'r') as f:
 
 with open('README.md', 'r') as f:
     readme = f.read()
-
-extras = {
-    "oef-channel": [
-        "colorlog",
-        "oef",
-    ],
-    "gym-channel": [
-        "gym"
-    ],
-    "cli": [
-        "click",
-        "click_log",
-        "PyYAML"
-    ],
-    "fipa": [
-        "protobuf"
-    ],
-    "tac": [
-        "protobuf"
-    ],
-}
-
-# add "all" extras
-extras["all"] = [dep for e in extras.values() for dep in e]
 
 setup(
     name=about['__title__'],
@@ -77,7 +89,7 @@ setup(
         "base58"
     ],
     tests_require=["tox"],
-    extras_require=extras,
+    extras_require=get_all_extras(),
     entry_points={
         'console_scripts': ["aea=aea.cli:cli"],
     },


### PR DESCRIPTION

## Proposed changes

Declare channel dependencies and protocols dependencies in the __init__.py of each macro module (i.e. aea/channel/__init__.py and aea/protocols/__init__.py).
Parse the declared dependencies in the setup.py script, and add them as extras setuptools dependencies.
In particular, the channel extras dependencies can be installed by using the string `"aea[${channel_name}-channel]"`, whereas the protocol extras dependencies with `"aea[${protocol_name}-protocol]"`.

## Fixes

Fixes #22 

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

None.
