### PR TITLE
make skill packages importable.

### DIFF
--- a/aea/skills/base/core.py
+++ b/aea/skills/base/core.py
@@ -24,6 +24,7 @@ import logging
 import os
 import pprint
 import re
+import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional, List, Dict, Any, Tuple, cast
@@ -360,11 +361,13 @@ class Skill:
         if skill_config is None:
             return None
 
-        skills_spec = importlib.util.spec_from_file_location("skill_module", os.path.join(directory, "__init__.py"))
+        skills_spec = importlib.util.spec_from_file_location(skill_config.name, os.path.join(directory, "__init__.py"))
         if skills_spec is None:
             logger.warning("No skill found.")
             return None
 
+        skill_module = importlib.util.module_from_spec(skills_spec)
+        sys.modules[skills_spec.name + "_skill"] = skill_module
         skills_packages = list(filter(lambda x: not x.startswith("__"), skills_spec.loader.contents()))  # type: ignore
         logger.debug("Processing the following skill package: {}".format(skills_packages))
 
@@ -545,8 +548,7 @@ class HandlerRegistry(Registry):
         """
         Register a handler.
 
-        :param protocol_id: the protocol id.
-        :param skill_id: the skill id.
+        :param ids: the pair (protocol id, skill id).
         :param handler: the handler.
         :return: None
         """

--- a/examples/gym_skill/handler.py
+++ b/examples/gym_skill/handler.py
@@ -25,7 +25,7 @@ from aea.skills.base.core import Handler
 from aea.protocols.gym.message import GymMessage
 from aea.protocols.gym.serialization import GymSerializer
 
-from .tasks import GymTask
+from gym_skill.tasks import GymTask
 
 
 class GymHandler(Handler):

--- a/examples/gym_skill/helpers.py
+++ b/examples/gym_skill/helpers.py
@@ -49,7 +49,6 @@ class ProxyEnv(gym.Env):
         Instantiate the proxy environment.
 
         :param skill_context: the skill context
-        :param queue: the queue
         :return: None
         """
         super().__init__()

--- a/examples/gym_skill/tasks.py
+++ b/examples/gym_skill/tasks.py
@@ -24,8 +24,8 @@ from threading import Thread
 
 from aea.skills.base.core import Task
 
-from .helpers import ProxyEnv
-from .rl_agent import MyRLAgent, NB_STEPS, NB_GOODS
+from gym_skill.helpers import ProxyEnv
+from gym_skill.rl_agent import MyRLAgent, NB_STEPS, NB_GOODS
 
 
 class GymTask(Task):


### PR DESCRIPTION

## Proposed changes

With this PR, the code from another module defined in the skill folder can be imported using the skill name + `_skill` as package name.

For example, if you want to import a function 'bar' defined in a module 'foo.py' in the skill 'foobar':
```
from foobar_skill.foo import bar
```

## Fixes

Solves a problem related to issue #48 .

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.