### PR TITLE
add exception handling to OEFConnection.connect()

### DIFF
--- a/aea/aea.py
+++ b/aea/aea.py
@@ -158,4 +158,5 @@ class AEA(Agent):
 
         :return: None
         """
-        self.resources.teardown()
+        if self._resources is not None:
+            self._resources.teardown()

--- a/aea/channels/oef.py
+++ b/aea/channels/oef.py
@@ -471,14 +471,20 @@ class OEFConnection(Connection):
         Connect to the channel.
 
         :return: None
+        :raises ConnectionError if the connection to the OEF fails.
         """
         if self._stopped and not self._connected:
             self._stopped = False
             self._core.run_threaded()
-            assert self.channel.connect(), "Cannot connect to OEFChannel."
-            self._connected = True
-            self.out_thread = Thread(target=self._fetch)
-            self.out_thread.start()
+            try:
+                if not self.channel.connect():
+                    raise ConnectionError("Cannot connect to OEFChannel.")
+                self._connected = True
+                self.out_thread = Thread(target=self._fetch)
+                self.out_thread.start()
+            except ConnectionError as e:
+                self._core.stop()
+                raise e
 
     def disconnect(self) -> None:
         """

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -97,7 +97,7 @@ def run(ctx: Context, connection_name: str):
         agent.start()
     except KeyboardInterrupt:
         logger.info("Interrupted.")
-    except Exception:
-        raise
+    except Exception as e:
+        logger.exception(e)
     finally:
         agent.stop()


### PR DESCRIPTION
## Proposed changes

With this PR when the connection to the OEF node fails, a `ConnectionError` exception is raised.
This is useful because then the method can gracefully stop the AsyncioCore launched to make the attempt to establish the connection, in case an error occurs.

## Fixes

Fixes #85 

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

We could later add the `ConnectionError` exception to every `.+Connection.connect()` method.
