### PR TITLE
Add 'docs' and 'docs-serve' environments in tox.ini.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,14 @@ pipeline {
 
                 } // static type check
 
+                stage('Docs') {
+
+                    steps {
+                        sh 'tox -e docs'
+                    }
+
+                } // docs
+
                 stage('Unit Tests: Python 3.6') {
 
                     steps {

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-clean: clean-build clean-pyc clean-test
+clean: clean-build clean-pyc clean-test clean-docs
 
 clean-build:
 	rm -fr build/
@@ -6,6 +6,9 @@ clean-build:
 	rm -fr .eggs/
 	find . -name '*.egg-info' -exec rm -fr {} +
 	find . -name '*.egg' -exec rm -fr {} +
+
+clean-docs:
+	rm -fr site/
 
 clean-pyc:
 	find . -name '*.pyc' -exec rm -f {} +

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, mypy, py37, py36
+envlist = flake8, mypy, py37, py36, docs
 skipsdist = True
 ignore_basepython_conflict = True
 
@@ -26,3 +26,17 @@ commands = flake8 aea examples scripts tests --exclude=.md,aea/*_pb2.py,aea/__in
 basepython = python3.7
 deps = mypy
 commands = mypy aea examples tests scripts
+
+[testenv:docs]
+description = Build the documentation.
+basepython = python3.7
+deps = mkdocs
+commands = mkdocs build --clean
+
+[testenv:docs-serve]
+description = Run a development server for working on documentation.
+basepython = python3.7
+deps = mkdocs
+commands = mkdocs build --clean
+           python -c 'print("###### Starting local server. Press Control+C to stop server ######")'
+           mkdocs serve -a localhost:8080


### PR DESCRIPTION
## Proposed changes

This PR adds two test environments:
- `docs`: checks that the documentation can be built without errors.
- `docs-serve`: builds the documentations and serves it using `mkdocs serve` This is just for development purposes.

They can be run, respectively, with `tox -e docs` and `tox -e docs-serve`.

`tox` will run `docs`, but not `docs-serve`.

Moreover, the documentation building has been added to the CI pipeline.

## Fixes

None.

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Inspired by [this page](https://tox.readthedocs.io/en/latest/example/documentation.html#mkdocs).

Also, worth investigating the `mkdocs gh-deploy` command used in the linked page.
