### PR TITLE
fix docs testenv.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,8 @@ commands = mypy aea examples tests scripts
 description = Build the documentation.
 basepython = python3.7
 deps = mkdocs
+       mkdocs-material
+       pymdown-extensions
 commands = mkdocs build --clean
 
 [testenv:docs-serve]


### PR DESCRIPTION


## Proposed changes

The 'docs' test environment in `tox.ini` didn't explicitly declare all the `mkdocs` dependencies to build the documentation. In particular, `mkdocs-material` and `pymdown-extentions`.

This PR adds the above-mentioned dependencies, making `tox -e docs` work again.

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

An alternative might be to run a `pipenv install --dev`  before `mkdocs build --clean`. But we don't need all the packages declared in the `Pipfile` to successfully run the tests.
