### PR TITLE
(WIP) Test `aea.cli.*` modules.

### DIFF
--- a/aea/cli/add.py
+++ b/aea/cli/add.py
@@ -54,7 +54,6 @@ def connection(click_context, connection_name):
     if connection_name in ctx.agent_config.connections:
         logger.error("A connection with name '{}' already exists. Aborting...".format(connection_name))
         exit(-1)
-        return
 
     # check that the provided path points to a proper connection directory -> look for connection.yaml file.
     # first check in aea dir
@@ -67,7 +66,6 @@ def connection(click_context, connection_name):
         if not connection_configuration_filepath.exists():
             logger.error("Cannot find connection: '{}'.".format(connection_name))
             exit(-1)
-            return
 
     # try to load the connection configuration file
     try:
@@ -76,7 +74,6 @@ def connection(click_context, connection_name):
     except ValidationError as e:
         logger.error("Connection configuration file not valid: {}".format(str(e)))
         exit(-1)
-        return
 
     # copy the connection package into the agent's supported connections.
     src = str(Path(os.path.join(registry_path, "connections", connection_name)).absolute())
@@ -85,7 +82,7 @@ def connection(click_context, connection_name):
     try:
         shutil.copytree(src, dest)
     except Exception as e:
-        logger.error(e)
+        logger.error(str(e))
         exit(-1)
 
     # make the 'connections' folder a Python package.
@@ -112,7 +109,7 @@ def protocol(click_context, protocol_name):
     logger.debug("Protocols already supported by the agent: {}".format(ctx.agent_config.protocols))
     if protocol_name in ctx.agent_config.protocols:
         logger.error("A protocol with name '{}' already exists. Aborting...".format(protocol_name))
-        return
+        exit(-1)
 
     # check that the provided path points to a proper protocol directory -> look for protocol.yaml file.
     # first check in aea dir
@@ -125,7 +122,6 @@ def protocol(click_context, protocol_name):
         if not protocol_configuration_filepath.exists():
             logger.error("Cannot find protocol: '{}'.".format(protocol_name))
             exit(-1)
-            return
 
     # # try to load the connection configuration file
     # try:
@@ -143,7 +139,7 @@ def protocol(click_context, protocol_name):
     try:
         shutil.copytree(src, dest)
     except Exception as e:
-        logger.error(e)
+        logger.error(str(e))
         exit(-1)
 
     # make the 'protocols' folder a Python package.
@@ -162,7 +158,6 @@ def protocol(click_context, protocol_name):
 def skill(click_context, skill_name):
     """Add a skill to the agent."""
     ctx = cast(Context, click_context.obj)
-    registry_path = AEA_DIR
     agent_name = ctx.agent_config.agent_name
     logger.debug("Adding skill {} to the agent {}...".format(skill_name, agent_name))
 
@@ -171,7 +166,6 @@ def skill(click_context, skill_name):
     if skill_name in ctx.agent_config.skills:
         logger.error("A skill with name '{}' already exists. Aborting...".format(skill_name))
         exit(-1)
-        return
 
     # check that the provided path points to a proper skill directory -> look for skill.yaml file.
     # first check in aea dir
@@ -184,7 +178,6 @@ def skill(click_context, skill_name):
         if not skill_configuration_filepath.exists():
             logger.error("Cannot find skill: '{}'.".format(skill_name))
             exit(-1)
-            return
 
     # try to load the skill configuration file
     try:
@@ -192,7 +185,6 @@ def skill(click_context, skill_name):
     except ValidationError as e:
         logger.error("Skill configuration file not valid: {}".format(str(e)))
         exit(-1)
-        return
 
     # copy the skill package into the agent's supported skills.
     src = str(Path(os.path.join(registry_path, "skills", skill_name)).absolute())
@@ -201,7 +193,7 @@ def skill(click_context, skill_name):
     try:
         shutil.copytree(src, dest)
     except Exception as e:
-        logger.error(e)
+        logger.error(str(e))
         exit(-1)
 
     # make the 'skills' folder a Python package.

--- a/aea/cli/remove.py
+++ b/aea/cli/remove.py
@@ -53,16 +53,13 @@ def connection(ctx: Context, connection_name):
         shutil.rmtree(connection_folder)
     except BaseException:
         logger.exception("An error occurred while deleting '{}'.".format(connection_folder))
-        return
-
-    ctx.agent_config.connections.remove(connection_name)
+        exit(-1)
 
     # removing the connection to the configurations.
     logger.debug("Removing the connection from {}".format(DEFAULT_AEA_CONFIG_FILE))
     if connection_name in ctx.agent_config.connections:
         ctx.agent_config.connections.remove(connection_name)
-
-    ctx.agent_loader.dump(ctx.agent_config, open(DEFAULT_AEA_CONFIG_FILE, "w"))
+        ctx.agent_loader.dump(ctx.agent_config, open(DEFAULT_AEA_CONFIG_FILE, "w"))
 
 
 @remove.command()
@@ -75,7 +72,7 @@ def protocol(ctx: Context, protocol_name):
                 .format(agent_name=agent_name, protocol_name=protocol_name))
 
     if protocol_name not in ctx.agent_config.protocols:
-        logger.warning("Protocol '{}' not found.".format(protocol_name))
+        logger.error("Protocol '{}' not found.".format(protocol_name))
         exit(-1)
 
     protocol_folder = os.path.join("protocols", protocol_name)
@@ -83,13 +80,13 @@ def protocol(ctx: Context, protocol_name):
         shutil.rmtree(protocol_folder)
     except BaseException:
         logger.exception("An error occurred.")
-        return
+        exit(-1)
 
     # removing the protocol to the configurations.
     logger.debug("Removing the protocol from {}".format(DEFAULT_AEA_CONFIG_FILE))
     if protocol_name in ctx.agent_config.protocols:
         ctx.agent_config.protocols.remove(protocol_name)
-    ctx.agent_loader.dump(ctx.agent_config, open(DEFAULT_AEA_CONFIG_FILE, "w"))
+        ctx.agent_loader.dump(ctx.agent_config, open(DEFAULT_AEA_CONFIG_FILE, "w"))
 
 
 @remove.command()
@@ -102,7 +99,7 @@ def skill(ctx: Context, skill_name):
                 .format(agent_name=agent_name, skill_name=skill_name))
 
     if skill_name not in ctx.agent_config.skills:
-        logger.warning("The skill '{}' is not supported.".format(skill_name))
+        logger.error("The skill '{}' is not supported.".format(skill_name))
         exit(-1)
 
     skill_folder = os.path.join("skills", skill_name)
@@ -110,10 +107,10 @@ def skill(ctx: Context, skill_name):
         shutil.rmtree(skill_folder)
     except BaseException:
         logger.exception("An error occurred.")
-        return
+        exit(-1)
 
     # removing the protocol to the configurations.
     logger.debug("Removing the skill from {}".format(DEFAULT_AEA_CONFIG_FILE))
     if skill_name in ctx.agent_config.skills:
         ctx.agent_config.skills.remove(skill_name)
-    ctx.agent_loader.dump(ctx.agent_config, open(DEFAULT_AEA_CONFIG_FILE, "w"))
+        ctx.agent_loader.dump(ctx.agent_config, open(DEFAULT_AEA_CONFIG_FILE, "w"))

--- a/tests/test_cli/test_commands/test_add/__init__.py
+++ b/tests/test_cli/test_commands/test_add/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This test module contains the tests for the `aea add` sub-command."""

--- a/tests/test_cli/test_commands/test_add/test_connection.py
+++ b/tests/test_cli/test_commands/test_add/test_connection.py
@@ -67,7 +67,6 @@ class TestAddConnectionFailsWhenConnectionAlreadyExists:
         s = "A connection with name '{}' already exists. Aborting...".format(self.connection_name)
         self.mocked_logger_error.assert_called_once_with(s)
 
-
     @classmethod
     def teardown_class(cls):
         """Teardowm the test."""
@@ -109,7 +108,6 @@ class TestAddConnectionFailsWhenConnectionNotInRegistry:
         """
         s = "Cannot find connection: '{}'.".format(self.connection_name)
         self.mocked_logger_error.assert_called_once_with(s)
-
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_cli/test_commands/test_add/test_connection.py
+++ b/tests/test_cli/test_commands/test_add/test_connection.py
@@ -29,9 +29,8 @@ from jsonschema import ValidationError
 
 import aea
 import aea.cli.common
-from aea.cli import cli
-from aea.configurations.loader import ConfigLoader
 import aea.configurations.base
+from aea.cli import cli
 
 
 class TestAddConnectionFailsWhenConnectionAlreadyExists:

--- a/tests/test_cli/test_commands/test_add/test_connection.py
+++ b/tests/test_cli/test_commands/test_add/test_connection.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This test module contains the tests for the `aea add connection` sub-command."""
+import os
+import shutil
+import tempfile
+import unittest.mock
+from pathlib import Path
+
+from click.testing import CliRunner
+from jsonschema import ValidationError
+
+import aea
+import aea.cli.common
+from aea.cli import cli
+from aea.configurations.loader import ConfigLoader
+import aea.configurations.base
+
+
+class TestAddConnectionFailsWhenConnectionAlreadyExists:
+    """Test that the command 'aea add connection' fails when the connection already exists."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        cls.runner = CliRunner()
+        cls.agent_name = "myagent"
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        cls.connection_name = "local"
+        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
+        cls.mocked_logger_error = cls.patch.__enter__()
+
+        os.chdir(cls.t)
+        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        assert result.exit_code == 0
+        os.chdir(cls.agent_name)
+        result = cls.runner.invoke(cli, ["add", "connection", cls.connection_name])
+        assert result.exit_code == 0
+        cls.result = cls.runner.invoke(cli, ["add", "connection", cls.connection_name])
+
+    def test_exit_code_equal_to_minus_1(self):
+        """Test that the exit code is equal to minus 1."""
+        assert self.result.exit_code == -1
+
+    def test_error_message_connection_already_existing(self):
+        """Test that the log error message is fixed.
+
+        The expected message is: 'A connection with name '{connection_name}' already exists. Aborting...'
+        """
+        s = "A connection with name '{}' already exists. Aborting...".format(self.connection_name)
+        self.mocked_logger_error.assert_called_once_with(s)
+
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardowm the test."""
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass
+
+
+class TestAddConnectionFailsWhenConnectionNotInRegistry:
+    """Test that the command 'aea add connection' fails when the connection is not in the registry."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        cls.runner = CliRunner()
+        cls.agent_name = "myagent"
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        cls.connection_name = "unknown_connection"
+        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
+        cls.mocked_logger_error = cls.patch.__enter__()
+
+        os.chdir(cls.t)
+        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        assert result.exit_code == 0
+        os.chdir(cls.agent_name)
+        cls.result = cls.runner.invoke(cli, ["add", "connection", cls.connection_name])
+
+    def test_exit_code_equal_to_minus_1(self):
+        """Test that the exit code is equal to minus 1."""
+        assert self.result.exit_code == -1
+
+    def test_error_message_connection_already_existing(self):
+        """Test that the log error message is fixed.
+
+        The expected message is: 'Cannot find connection: '{connection_name}''
+        """
+        s = "Cannot find connection: '{}'.".format(self.connection_name)
+        self.mocked_logger_error.assert_called_once_with(s)
+
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardowm the test."""
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass
+
+
+class TestAddConnectionFailsWhenConfigFileIsNotCompliant:
+    """Test that the command 'aea add connection' fails when the configuration file is not compliant with the schema."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        cls.runner = CliRunner()
+        cls.agent_name = "myagent"
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        cls.connection_name = "local"
+        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
+        cls.mocked_logger_error = cls.patch.__enter__()
+
+        os.chdir(cls.t)
+        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        assert result.exit_code == 0
+
+        # change the serialization of the AgentConfig class so to make the parsing to fail.
+        cls.patch = unittest.mock.patch.object(aea.configurations.base.ConnectionConfig, "from_json",
+                                               side_effect=ValidationError("test error message"))
+        cls.patch.__enter__()
+
+        os.chdir(cls.agent_name)
+        cls.result = cls.runner.invoke(cli, ["add", "connection", cls.connection_name])
+
+    def test_exit_code_equal_to_minus_1(self):
+        """Test that the exit code is equal to minus 1."""
+        assert self.result.exit_code == -1
+
+    def test_configuration_file_not_valid(self):
+        """Test that the log error message is fixed.
+
+        The expected message is: 'Cannot find connection: '{connection_name}''
+        """
+        self.mocked_logger_error.assert_called_once_with("Connection configuration file not valid: test error message")
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardowm the test."""
+        cls.patch.__exit__()
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass
+
+
+class TestAddConnectionFailsWhenDirectoryAlreadyExists:
+    """Test that the command 'aea add connection' fails when the destination directory already exists."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        cls.runner = CliRunner()
+        cls.agent_name = "myagent"
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        cls.connection_name = "local"
+        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
+        cls.mocked_logger_error = cls.patch.__enter__()
+
+        os.chdir(cls.t)
+        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        assert result.exit_code == 0
+
+        os.chdir(cls.agent_name)
+        Path("connections", cls.connection_name).mkdir(parents=True, exist_ok=True)
+        cls.result = cls.runner.invoke(cli, ["add", "connection", cls.connection_name])
+
+    def test_exit_code_equal_to_minus_1(self):
+        """Test that the exit code is equal to minus 1."""
+        assert self.result.exit_code == -1
+
+    def test_file_exists_error(self):
+        """Test that the log error message is fixed.
+
+        The expected message is: 'Cannot find connection: '{connection_name}''
+        """
+        s = "[Errno 17] File exists: './connections/{}'".format(self.connection_name)
+        self.mocked_logger_error.assert_called_once_with(s)
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardowm the test."""
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass

--- a/tests/test_cli/test_commands/test_add/test_protocol.py
+++ b/tests/test_cli/test_commands/test_add/test_protocol.py
@@ -65,7 +65,6 @@ class TestAddProtocolFailsWhenProtocolAlreadyExists:
         s = "A protocol with name '{}' already exists. Aborting...".format(self.protocol_name)
         self.mocked_logger_error.assert_called_once_with(s)
 
-
     @classmethod
     def teardown_class(cls):
         """Teardowm the test."""
@@ -107,7 +106,6 @@ class TestAddProtocolFailsWhenProtocolNotInRegistry:
         """
         s = "Cannot find protocol: '{}'.".format(self.protocol_name)
         self.mocked_logger_error.assert_called_once_with(s)
-
 
     @classmethod
     def teardown_class(cls):
@@ -152,7 +150,6 @@ class TestAddProtocolFailsWhenDirectoryAlreadyExists:
         """
         s = "[Errno 17] File exists: './protocols/{}'".format(self.protocol_name)
         self.mocked_logger_error.assert_called_once_with(s)
-
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_cli/test_commands/test_add/test_protocol.py
+++ b/tests/test_cli/test_commands/test_add/test_protocol.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This test module contains the tests for the `aea add protocol` sub-command."""
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+from click.testing import CliRunner
+
+import aea
+import aea.cli.common
+import unittest.mock
+
+from aea.cli import cli
+
+
+class TestAddProtocolFailsWhenProtocolAlreadyExists:
+    """Test that the command 'aea add protocol' fails when the protocol already exists."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        cls.runner = CliRunner()
+        cls.agent_name = "myagent"
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        cls.protocol_name = "oef"
+        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
+        cls.mocked_logger_error = cls.patch.__enter__()
+
+        os.chdir(cls.t)
+        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        assert result.exit_code == 0
+        os.chdir(cls.agent_name)
+        result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+        assert result.exit_code == 0
+        cls.result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+
+    def test_exit_code_equal_to_minus_1(self):
+        """Test that the exit code is equal to minus 1."""
+        assert self.result.exit_code == -1
+
+    def test_error_message_protocol_already_existing(self):
+        """Test that the log error message is fixed.
+
+        The expected message is: 'A protocol with name '{protocol_name}' already exists. Aborting...'
+        """
+        s = "A protocol with name '{}' already exists. Aborting...".format(self.protocol_name)
+        self.mocked_logger_error.assert_called_once_with(s)
+
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardowm the test."""
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass
+
+
+class TestAddProtocolFailsWhenProtocolNotInRegistry:
+    """Test that the command 'aea add protocol' fails when the protocol is not in the registry."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        cls.runner = CliRunner()
+        cls.agent_name = "myagent"
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        cls.protocol_name = "unknown_protocol"
+        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
+        cls.mocked_logger_error = cls.patch.__enter__()
+
+        os.chdir(cls.t)
+        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        assert result.exit_code == 0
+        os.chdir(cls.agent_name)
+        cls.result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+
+    def test_exit_code_equal_to_minus_1(self):
+        """Test that the exit code is equal to minus 1."""
+        assert self.result.exit_code == -1
+
+    def test_error_message_protocol_already_existing(self):
+        """Test that the log error message is fixed.
+
+        The expected message is: 'Cannot find protocol: '{protocol_name}''
+        """
+        s = "Cannot find protocol: '{}'.".format(self.protocol_name)
+        self.mocked_logger_error.assert_called_once_with(s)
+
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardowm the test."""
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass
+
+
+class TestAddProtocolFailsWhenDirectoryAlreadyExists:
+    """Test that the command 'aea add protocol' fails when the destination directory already exists."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        cls.runner = CliRunner()
+        cls.agent_name = "myagent"
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        cls.protocol_name = "oef"
+        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
+        cls.mocked_logger_error = cls.patch.__enter__()
+
+        os.chdir(cls.t)
+        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        assert result.exit_code == 0
+
+        os.chdir(cls.agent_name)
+        Path("protocols", cls.protocol_name).mkdir(parents=True, exist_ok=True)
+        cls.result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+
+    def test_exit_code_equal_to_minus_1(self):
+        """Test that the exit code is equal to minus 1."""
+        assert self.result.exit_code == -1
+
+    def test_file_exists_error(self):
+        """Test that the log error message is fixed.
+
+        The expected message is: 'Cannot find protocol: '{protocol_name}''
+        """
+        s = "[Errno 17] File exists: './protocols/{}'".format(self.protocol_name)
+        self.mocked_logger_error.assert_called_once_with(s)
+
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardowm the test."""
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass

--- a/tests/test_cli/test_commands/test_add/test_skill.py
+++ b/tests/test_cli/test_commands/test_add/test_skill.py
@@ -76,7 +76,6 @@ class TestAddSkillFailsWhenSkillAlreadyExists:
         s = "A skill with name '{}' already exists. Aborting...".format(self.skill_name)
         self.mocked_logger_error.assert_called_once_with(s)
 
-
     @classmethod
     def teardown_class(cls):
         """Teardowm the test."""
@@ -118,7 +117,6 @@ class TestAddSkillFailsWhenSkillNotInRegistry:
         """
         s = "Cannot find skill: '{}'.".format(self.skill_name)
         self.mocked_logger_error.assert_called_once_with(s)
-
 
     @classmethod
     def teardown_class(cls):
@@ -221,7 +219,6 @@ class TestAddSkillFailsWhenDirectoryAlreadyExists:
         """
         s = "[Errno 17] File exists: './skills/{}'".format(self.skill_name)
         self.mocked_logger_error.assert_called_once_with(s)
-
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_cli/test_commands/test_add/test_skill.py
+++ b/tests/test_cli/test_commands/test_add/test_skill.py
@@ -18,10 +18,10 @@
 # ------------------------------------------------------------------------------
 
 """This test module contains the tests for the `aea add skill` sub-command."""
-import json
 import os
 import shutil
 import tempfile
+import unittest.mock
 from pathlib import Path
 
 import yaml
@@ -30,8 +30,6 @@ from jsonschema import ValidationError
 
 import aea
 import aea.cli.common
-import unittest.mock
-
 from aea.cli import cli
 from aea.configurations.base import AgentConfig, DEFAULT_AEA_CONFIG_FILE
 from ....conftest import ROOT_DIR

--- a/tests/test_cli/test_commands/test_add/test_skill.py
+++ b/tests/test_cli/test_commands/test_add/test_skill.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This test module contains the tests for the `aea add skill` sub-command."""
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+from jsonschema import ValidationError
+
+import aea
+import aea.cli.common
+import unittest.mock
+
+from aea.cli import cli
+from aea.configurations.base import AgentConfig, DEFAULT_AEA_CONFIG_FILE
+from ....conftest import ROOT_DIR
+
+
+class TestAddSkillFailsWhenSkillAlreadyExists:
+    """Test that the command 'aea add skill' fails when the skill already exists."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        cls.runner = CliRunner()
+        cls.agent_name = "myagent"
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        cls.skill_name = "gym"
+        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
+        cls.mocked_logger_error = cls.patch.__enter__()
+
+        os.chdir(cls.t)
+        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        assert result.exit_code == 0
+        os.chdir(cls.agent_name)
+
+        # change default registry path
+        config = AgentConfig.from_json(yaml.safe_load(open(DEFAULT_AEA_CONFIG_FILE)))
+        config.registry_path = os.path.join(ROOT_DIR, "examples")
+        yaml.safe_dump(config.json, open(DEFAULT_AEA_CONFIG_FILE, "w"))
+
+        result = cls.runner.invoke(cli, ["add", "skill", cls.skill_name])
+        assert result.exit_code == 0
+
+        cls.result = cls.runner.invoke(cli, ["add", "skill", cls.skill_name])
+
+    def test_exit_code_equal_to_minus_1(self):
+        """Test that the exit code is equal to minus 1."""
+        assert self.result.exit_code == -1
+
+    def test_error_message_skill_already_existing(self):
+        """Test that the log error message is fixed.
+
+        The expected message is: 'A skill with name '{skill_name}' already exists. Aborting...'
+        """
+        s = "A skill with name '{}' already exists. Aborting...".format(self.skill_name)
+        self.mocked_logger_error.assert_called_once_with(s)
+
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardowm the test."""
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass
+
+
+class TestAddSkillFailsWhenSkillNotInRegistry:
+    """Test that the command 'aea add skill' fails when the skill is not in the registry."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        cls.runner = CliRunner()
+        cls.agent_name = "myagent"
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        cls.skill_name = "unknown_skill"
+        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
+        cls.mocked_logger_error = cls.patch.__enter__()
+
+        os.chdir(cls.t)
+        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        assert result.exit_code == 0
+        os.chdir(cls.agent_name)
+        cls.result = cls.runner.invoke(cli, ["add", "skill", cls.skill_name])
+
+    def test_exit_code_equal_to_minus_1(self):
+        """Test that the exit code is equal to minus 1."""
+        assert self.result.exit_code == -1
+
+    def test_error_message_skill_already_existing(self):
+        """Test that the log error message is fixed.
+
+        The expected message is: 'Cannot find skill: '{skill_name}''
+        """
+        s = "Cannot find skill: '{}'.".format(self.skill_name)
+        self.mocked_logger_error.assert_called_once_with(s)
+
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardowm the test."""
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass
+
+
+class TestAddSkillFailsWhenConfigFileIsNotCompliant:
+    """Test that the command 'aea add connection' fails when the configuration file is not compliant with the schema."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        cls.runner = CliRunner()
+        cls.agent_name = "myagent"
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        cls.skill_name = "gym"
+        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
+        cls.mocked_logger_error = cls.patch.__enter__()
+
+        os.chdir(cls.t)
+        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        assert result.exit_code == 0
+        os.chdir(cls.agent_name)
+
+        # change default registry path
+        config = AgentConfig.from_json(yaml.safe_load(open(DEFAULT_AEA_CONFIG_FILE)))
+        config.registry_path = os.path.join(ROOT_DIR, "examples")
+        yaml.safe_dump(config.json, open(DEFAULT_AEA_CONFIG_FILE, "w"))
+
+        # change the serialization of the AgentConfig class so to make the parsing to fail.
+        cls.patch = unittest.mock.patch.object(aea.configurations.base.SkillConfig, "from_json",
+                                               side_effect=ValidationError("test error message"))
+        cls.patch.__enter__()
+
+        cls.result = cls.runner.invoke(cli, ["add", "skill", cls.skill_name])
+
+    def test_exit_code_equal_to_minus_1(self):
+        """Test that the exit code is equal to minus 1."""
+        assert self.result.exit_code == -1
+
+    def test_configuration_file_not_valid(self):
+        """Test that the log error message is fixed.
+
+        The expected message is: 'Cannot find skill: '{skill_name}''
+        """
+        self.mocked_logger_error.assert_called_once_with("Skill configuration file not valid: test error message")
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardowm the test."""
+        cls.patch.__exit__()
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass
+
+
+class TestAddSkillFailsWhenDirectoryAlreadyExists:
+    """Test that the command 'aea add skill' fails when the destination directory already exists."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        cls.runner = CliRunner()
+        cls.agent_name = "myagent"
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        cls.skill_name = "gym"
+        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
+        cls.mocked_logger_error = cls.patch.__enter__()
+
+        os.chdir(cls.t)
+        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        assert result.exit_code == 0
+        os.chdir(cls.agent_name)
+
+        # change default registry path
+        config = AgentConfig.from_json(yaml.safe_load(open(DEFAULT_AEA_CONFIG_FILE)))
+        config.registry_path = os.path.join(ROOT_DIR, "examples")
+        yaml.safe_dump(config.json, open(DEFAULT_AEA_CONFIG_FILE, "w"))
+
+        Path("skills", cls.skill_name).mkdir(parents=True, exist_ok=True)
+        cls.result = cls.runner.invoke(cli, ["add", "skill", cls.skill_name])
+
+    def test_exit_code_equal_to_minus_1(self):
+        """Test that the exit code is equal to minus 1."""
+        assert self.result.exit_code == -1
+
+    def test_file_exists_error(self):
+        """Test that the log error message is fixed.
+
+        The expected message is: 'Cannot find skill: '{skill_name}''
+        """
+        s = "[Errno 17] File exists: './skills/{}'".format(self.skill_name)
+        self.mocked_logger_error.assert_called_once_with(s)
+
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardowm the test."""
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass

--- a/tests/test_cli/test_commands/test_remove/__init__.py
+++ b/tests/test_cli/test_commands/test_remove/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This test module contains the tests for the `aea remove` sub-command."""

--- a/tests/test_cli/test_commands/test_remove/test_protocol.py
+++ b/tests/test_cli/test_commands/test_remove/test_protocol.py
@@ -17,22 +17,25 @@
 #
 # ------------------------------------------------------------------------------
 
-"""This test module contains the tests for the `aea add protocol` sub-command."""
+"""This test module contains the tests for the `aea remove protocol` sub-command."""
 import os
 import shutil
 import tempfile
 import unittest.mock
 from pathlib import Path
 
+import yaml
 from click.testing import CliRunner
 
 import aea
 import aea.cli.common
+import aea.configurations.base
 from aea.cli import cli
+from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE
 
 
-class TestAddProtocolFailsWhenProtocolAlreadyExists:
-    """Test that the command 'aea add protocol' fails when the protocol already exists."""
+class TestRemoveProtocol:
+    """Test that the command 'aea remove protocol' works correctly."""
 
     @classmethod
     def setup_class(cls):
@@ -51,20 +54,20 @@ class TestAddProtocolFailsWhenProtocolAlreadyExists:
         os.chdir(cls.agent_name)
         result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
         assert result.exit_code == 0
-        cls.result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+        cls.result = cls.runner.invoke(cli, ["remove", "protocol", cls.protocol_name])
 
-    def test_exit_code_equal_to_minus_1(self):
+    def test_exit_code_equal_to_zero(self):
         """Test that the exit code is equal to minus 1."""
-        assert self.result.exit_code == -1
+        assert self.result.exit_code == 0
 
-    def test_error_message_protocol_already_existing(self):
-        """Test that the log error message is fixed.
+    def test_directory_does_not_exist(self):
+        """Test that the directory of the removed protocol does not exist."""
+        assert not Path("protocols", self.protocol_name).exists()
 
-        The expected message is: 'A protocol with name '{protocol_name}' already exists. Aborting...'
-        """
-        s = "A protocol with name '{}' already exists. Aborting...".format(self.protocol_name)
-        self.mocked_logger_error.assert_called_once_with(s)
-
+    def test_protocol_not_present_in_agent_config(self):
+        """Test that the name of the removed protocol is not present in the agent configuration file."""
+        agent_config = aea.configurations.base.AgentConfig.from_json(yaml.safe_load(open(DEFAULT_AEA_CONFIG_FILE)))
+        assert self.protocol_name not in agent_config.protocols
 
     @classmethod
     def teardown_class(cls):
@@ -76,51 +79,8 @@ class TestAddProtocolFailsWhenProtocolAlreadyExists:
             pass
 
 
-class TestAddProtocolFailsWhenProtocolNotInRegistry:
-    """Test that the command 'aea add protocol' fails when the protocol is not in the registry."""
-
-    @classmethod
-    def setup_class(cls):
-        """Set the test up."""
-        cls.runner = CliRunner()
-        cls.agent_name = "myagent"
-        cls.cwd = os.getcwd()
-        cls.t = tempfile.mkdtemp()
-        cls.protocol_name = "unknown_protocol"
-        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
-        cls.mocked_logger_error = cls.patch.__enter__()
-
-        os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
-        assert result.exit_code == 0
-        os.chdir(cls.agent_name)
-        cls.result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
-
-    def test_exit_code_equal_to_minus_1(self):
-        """Test that the exit code is equal to minus 1."""
-        assert self.result.exit_code == -1
-
-    def test_error_message_protocol_already_existing(self):
-        """Test that the log error message is fixed.
-
-        The expected message is: 'Cannot find protocol: '{protocol_name}''
-        """
-        s = "Cannot find protocol: '{}'.".format(self.protocol_name)
-        self.mocked_logger_error.assert_called_once_with(s)
-
-
-    @classmethod
-    def teardown_class(cls):
-        """Teardowm the test."""
-        os.chdir(cls.cwd)
-        try:
-            shutil.rmtree(cls.t)
-        except (OSError, IOError):
-            pass
-
-
-class TestAddProtocolFailsWhenDirectoryAlreadyExists:
-    """Test that the command 'aea add protocol' fails when the destination directory already exists."""
+class TestRemoveProtocolFailsWhenProtocolDoesNotExist:
+    """Test that the command 'aea remove protocol' fails when the protocol does not exist."""
 
     @classmethod
     def setup_class(cls):
@@ -136,27 +96,66 @@ class TestAddProtocolFailsWhenDirectoryAlreadyExists:
         os.chdir(cls.t)
         result = cls.runner.invoke(cli, ["create", cls.agent_name])
         assert result.exit_code == 0
-
         os.chdir(cls.agent_name)
-        Path("protocols", cls.protocol_name).mkdir(parents=True, exist_ok=True)
-        cls.result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+
+        cls.result = cls.runner.invoke(cli, ["remove", "protocol", cls.protocol_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
         assert self.result.exit_code == -1
 
-    def test_file_exists_error(self):
+    def test_error_message_protocol_not_existing(self):
         """Test that the log error message is fixed.
 
-        The expected message is: 'Cannot find protocol: '{protocol_name}''
+        The expected message is: 'Protocol '{protocol_name}' not found.'
         """
-        s = "[Errno 17] File exists: './protocols/{}'".format(self.protocol_name)
+        s = "Protocol '{}' not found.".format(self.protocol_name)
         self.mocked_logger_error.assert_called_once_with(s)
-
 
     @classmethod
     def teardown_class(cls):
         """Teardowm the test."""
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass
+
+
+class TestRemoveProtocolFailsWhenExceptionOccurs:
+    """Test that the command 'aea remove protocol' fails when an exception occurs while removing the directory."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        cls.runner = CliRunner()
+        cls.agent_name = "myagent"
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        cls.protocol_name = "oef"
+        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
+        cls.mocked_logger_error = cls.patch.__enter__()
+
+        os.chdir(cls.t)
+        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        assert result.exit_code == 0
+        os.chdir(cls.agent_name)
+        result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+        assert result.exit_code == 0
+
+        cls.patch = unittest.mock.patch("shutil.rmtree", side_effect=BaseException("an exception"))
+        cls.patch.__enter__()
+
+        cls.result = cls.runner.invoke(cli, ["remove", "protocol", cls.protocol_name])
+
+    def test_exit_code_equal_to_minus_1(self):
+        """Test that the exit code is equal to minus 1."""
+        assert self.result.exit_code == -1
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardowm the test."""
+        cls.patch.__exit__()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)

--- a/tests/test_cli/test_commands/test_remove/test_skill.py
+++ b/tests/test_cli/test_commands/test_remove/test_skill.py
@@ -17,22 +17,26 @@
 #
 # ------------------------------------------------------------------------------
 
-"""This test module contains the tests for the `aea add protocol` sub-command."""
+"""This test module contains the tests for the `aea remove skill` sub-command."""
 import os
 import shutil
 import tempfile
 import unittest.mock
 from pathlib import Path
 
+import yaml
 from click.testing import CliRunner
 
 import aea
 import aea.cli.common
+import aea.configurations.base
 from aea.cli import cli
+from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig
+from ....conftest import ROOT_DIR
 
 
-class TestAddProtocolFailsWhenProtocolAlreadyExists:
-    """Test that the command 'aea add protocol' fails when the protocol already exists."""
+class TestRemoveSkill:
+    """Test that the command 'aea remove skill' works correctly."""
 
     @classmethod
     def setup_class(cls):
@@ -41,7 +45,7 @@ class TestAddProtocolFailsWhenProtocolAlreadyExists:
         cls.agent_name = "myagent"
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
-        cls.protocol_name = "oef"
+        cls.skill_name = "gym"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
         cls.mocked_logger_error = cls.patch.__enter__()
 
@@ -49,22 +53,28 @@ class TestAddProtocolFailsWhenProtocolAlreadyExists:
         result = cls.runner.invoke(cli, ["create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
-        result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+
+        # change default registry path
+        config = AgentConfig.from_json(yaml.safe_load(open(DEFAULT_AEA_CONFIG_FILE)))
+        config.registry_path = os.path.join(ROOT_DIR, "examples")
+        yaml.safe_dump(config.json, open(DEFAULT_AEA_CONFIG_FILE, "w"))
+
+        result = cls.runner.invoke(cli, ["add", "skill", cls.skill_name])
         assert result.exit_code == 0
-        cls.result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+        cls.result = cls.runner.invoke(cli, ["remove", "skill", cls.skill_name])
 
-    def test_exit_code_equal_to_minus_1(self):
+    def test_exit_code_equal_to_zero(self):
         """Test that the exit code is equal to minus 1."""
-        assert self.result.exit_code == -1
+        assert self.result.exit_code == 0
 
-    def test_error_message_protocol_already_existing(self):
-        """Test that the log error message is fixed.
+    def test_directory_does_not_exist(self):
+        """Test that the directory of the removed skill does not exist."""
+        assert not Path("skills", self.skill_name).exists()
 
-        The expected message is: 'A protocol with name '{protocol_name}' already exists. Aborting...'
-        """
-        s = "A protocol with name '{}' already exists. Aborting...".format(self.protocol_name)
-        self.mocked_logger_error.assert_called_once_with(s)
-
+    def test_skill_not_present_in_agent_config(self):
+        """Test that the name of the removed skill is not present in the agent configuration file."""
+        agent_config = aea.configurations.base.AgentConfig.from_json(yaml.safe_load(open(DEFAULT_AEA_CONFIG_FILE)))
+        assert self.skill_name not in agent_config.skills
 
     @classmethod
     def teardown_class(cls):
@@ -76,8 +86,8 @@ class TestAddProtocolFailsWhenProtocolAlreadyExists:
             pass
 
 
-class TestAddProtocolFailsWhenProtocolNotInRegistry:
-    """Test that the command 'aea add protocol' fails when the protocol is not in the registry."""
+class TestRemoveSkillFailsWhenSkillIsNotSupported:
+    """Test that the command 'aea remove skill' fails when the skill is not supported."""
 
     @classmethod
     def setup_class(cls):
@@ -86,7 +96,7 @@ class TestAddProtocolFailsWhenProtocolNotInRegistry:
         cls.agent_name = "myagent"
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
-        cls.protocol_name = "unknown_protocol"
+        cls.skill_name = "gym"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
         cls.mocked_logger_error = cls.patch.__enter__()
 
@@ -94,20 +104,20 @@ class TestAddProtocolFailsWhenProtocolNotInRegistry:
         result = cls.runner.invoke(cli, ["create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
-        cls.result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+
+        cls.result = cls.runner.invoke(cli, ["remove", "skill", cls.skill_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
         assert self.result.exit_code == -1
 
-    def test_error_message_protocol_already_existing(self):
+    def test_error_message_skill_not_existing(self):
         """Test that the log error message is fixed.
 
-        The expected message is: 'Cannot find protocol: '{protocol_name}''
+        The expected message is: 'The skill '{skill_name}' is not supported.'
         """
-        s = "Cannot find protocol: '{}'.".format(self.protocol_name)
+        s = "The skill '{}' is not supported.".format(self.skill_name)
         self.mocked_logger_error.assert_called_once_with(s)
-
 
     @classmethod
     def teardown_class(cls):
@@ -119,8 +129,8 @@ class TestAddProtocolFailsWhenProtocolNotInRegistry:
             pass
 
 
-class TestAddProtocolFailsWhenDirectoryAlreadyExists:
-    """Test that the command 'aea add protocol' fails when the destination directory already exists."""
+class TestRemoveSkillFailsWhenExceptionOccurs:
+    """Test that the command 'aea remove skill' fails when an exception occurs while removing the directory."""
 
     @classmethod
     def setup_class(cls):
@@ -129,34 +139,36 @@ class TestAddProtocolFailsWhenDirectoryAlreadyExists:
         cls.agent_name = "myagent"
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
-        cls.protocol_name = "oef"
+        cls.skill_name = "gym"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
         result = cls.runner.invoke(cli, ["create", cls.agent_name])
         assert result.exit_code == 0
-
         os.chdir(cls.agent_name)
-        Path("protocols", cls.protocol_name).mkdir(parents=True, exist_ok=True)
-        cls.result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+
+        # change default registry path
+        config = AgentConfig.from_json(yaml.safe_load(open(DEFAULT_AEA_CONFIG_FILE)))
+        config.registry_path = os.path.join(ROOT_DIR, "examples")
+        yaml.safe_dump(config.json, open(DEFAULT_AEA_CONFIG_FILE, "w"))
+
+        result = cls.runner.invoke(cli, ["add", "skill", cls.skill_name])
+        assert result.exit_code == 0
+
+        cls.patch = unittest.mock.patch("shutil.rmtree", side_effect=BaseException("an exception"))
+        cls.patch.__enter__()
+
+        cls.result = cls.runner.invoke(cli, ["remove", "skill", cls.skill_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
         assert self.result.exit_code == -1
 
-    def test_file_exists_error(self):
-        """Test that the log error message is fixed.
-
-        The expected message is: 'Cannot find protocol: '{protocol_name}''
-        """
-        s = "[Errno 17] File exists: './protocols/{}'".format(self.protocol_name)
-        self.mocked_logger_error.assert_called_once_with(s)
-
-
     @classmethod
     def teardown_class(cls):
         """Teardowm the test."""
+        cls.patch.__exit__()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)


### PR DESCRIPTION
## Proposed changes

This PR aims to get 100% test coverage on the `aea.cli` modules.

- [x] `aea/cli/__main__.py`
- [x] `aea/cli/add.py`
- [ ] `aea/cli/common.py`
- [x] `aea/cli/remove.py`
- [ ] `aea/cli/run.py`
- [ ] `aea/cli/scaffold.py`

## Fixes

None.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

None.
