### PR TITLE
Add Docker image for AEA deployment

### DIFF
--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -17,10 +17,17 @@ RUN pip install aea[all]
 COPY ./packages /home/packages
 WORKDIR home
 
-RUN rm myagent -rf && \
-    aea create myagent &&\
-    cd myagent &&\
-    aea add skill echo
+ARG AGENT_REPO_URL=""
+
+RUN if [ -z ${AGENT_REPO_URL+x} ] ; then\
+        rm myagent -rf &&\
+        aea create myagent &&\
+        cd myagent &&\
+        aea add skill echo;\
+    else \
+        echo "cloning $AGENT_REPO_URL inside '$(pwd)/myagent'" &&\
+        git clone $AGENT_REPO_URL myagent;\
+    fi
 
 WORKDIR /home/myagent
 CMD ["/usr/local/bin/aea", "run"]

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.7-alpine
+
+RUN apk add --no-cache make git bash
+
+# cryptography: https://cryptography.io/en/latest/installation/#alpine
+RUN apk add --no-cache gcc musl-dev python3-dev libffi-dev openssl-dev
+
+# https://stackoverflow.com/a/57485724
+RUN apk add --update --no-cache py3-numpy py3-scipy py3-pillow py3-zmq
+ENV PYTHONPATH "$PYTHONPATH:/usr/lib/python3.7/site-packages"
+
+RUN pip install --upgrade pip
+# other oef dependences
+RUN pip install protobuf colorlog graphviz
+RUN pip install aea[all]
+
+CMD ["/bin/bash"]

--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -14,4 +14,13 @@ RUN pip install --upgrade pip
 RUN pip install protobuf colorlog graphviz
 RUN pip install aea[all]
 
-CMD ["/bin/bash"]
+COPY ./packages /home/packages
+WORKDIR home
+
+RUN rm myagent -rf && \
+    aea create myagent &&\
+    cd myagent &&\
+    aea add skill echo
+
+WORKDIR /home/myagent
+CMD ["/usr/local/bin/aea", "run"]

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -1,0 +1,25 @@
+# Docker Deployment image
+
+All the commands must be executed from the parent directory, if not stated otherwise.
+
+## Build
+
+    ./deploy-image/scripts/docker-build-img.sh
+    
+
+To pass immediate parameters to the `docker build` command:
+
+    ./deploy-image/scripts/docker-build-img.sh arg1 arg2 --    
+
+E.g.:
+
+    ./deploy-image/scripts/docker-build-img.sh --squash --cpus 4 --compress --    
+
+
+## Run
+
+    ./deploy-image/scripts/docker-run.sh -- /bin/bash
+ 
+As before, to pass params to the `docker run` command:
+
+    ./deploy-image/scripts/docker-run.sh -p 8080:80 -- /bin/bash

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -6,19 +6,19 @@ All the commands must be executed from the parent directory, if not stated other
 
 We recommend using the following command for building:
 
-    ./deploy-image/scripts/docker-build-img.sh -t aea-deploy:latest -- 
+    ./deploy-image/scripts/docker-build-img.sh \
+        -t aea-deploy:latest \
+        --build-arg AGENT_REPO_URL=https://github.com/username/repo.git --
     
-
-To pass immediate parameters to the `docker build` command:
-
-    ./deploy-image/scripts/docker-build-img.sh arg1 arg2 --    
 
 E.g.:
 
-    ./deploy-image/scripts/docker-build-img.sh --squash --cpus 4 --compress --    
+    ./deploy-image/scripts/docker-build-img.sh \
+        -t aea-deploy:latest \
+        --build-arg AGENT_REPO_URL=https://github.com/fetchai/echo_agent.git --    
 
 
 ## Run
 
-    docker run -it aea-develop:latest 
+    docker run -it aea-deploy:latest 
  

--- a/deploy-image/README.md
+++ b/deploy-image/README.md
@@ -4,7 +4,9 @@ All the commands must be executed from the parent directory, if not stated other
 
 ## Build
 
-    ./deploy-image/scripts/docker-build-img.sh
+We recommend using the following command for building:
+
+    ./deploy-image/scripts/docker-build-img.sh -t aea-deploy:latest -- 
     
 
 To pass immediate parameters to the `docker build` command:
@@ -18,8 +20,5 @@ E.g.:
 
 ## Run
 
-    ./deploy-image/scripts/docker-run.sh -- /bin/bash
+    docker run -it aea-develop:latest 
  
-As before, to pass params to the `docker run` command:
-
-    ./deploy-image/scripts/docker-run.sh -p 8080:80 -- /bin/bash

--- a/deploy-image/docker-env.sh
+++ b/deploy-image/docker-env.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+DOCKER_IMAGE_TAG=aea-deploy:0.1.5
+DOCKER_BUILD_CONTEXT_DIR=..
+DOCKERFILE=./Dockerfile

--- a/deploy-image/scripts
+++ b/deploy-image/scripts
@@ -1,0 +1,1 @@
+../docker-images/scripts


### PR DESCRIPTION
## Proposed changes

This PR adds a new Docker image for AEA deployment.

It contains all the dependencies needed to install the `aea` package, as well as some popular skill dependencies (e.g. the `gym` skill and the `oef` protocol.)

## Fixes

Fixes #141 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [X] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.