### PR TITLE
fix mypy errors when getting the current frame of a module.

### DIFF
--- a/aea/__init__.py
+++ b/aea/__init__.py
@@ -24,4 +24,4 @@ import os
 from aea.__version__ import __title__, __description__, __url__, __version__
 from aea.__version__ import __author__, __license__, __copyright__
 
-AEA_DIR = os.path.dirname(inspect.getfile(inspect.currentframe()))
+AEA_DIR = os.path.dirname(inspect.getfile(inspect.currentframe()))  # type: ignore

--- a/aea/configurations/loader.py
+++ b/aea/configurations/loader.py
@@ -29,7 +29,7 @@ from jsonschema import validate
 
 from aea.configurations.base import AgentConfig, SkillConfig, ConnectionConfig
 
-_CUR_DIR = os.path.dirname(inspect.getfile(inspect.currentframe()))
+_CUR_DIR = os.path.dirname(inspect.getfile(inspect.currentframe()))  # type: ignore
 _SCHEMAS_DIR = os.path.join(_CUR_DIR, "schemas")
 
 T = TypeVar('T', AgentConfig, SkillConfig, ConnectionConfig)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ from oef.agents import AsyncioCore, OEFAgent
 
 logger = logging.getLogger(__name__)
 
-CUR_PATH = os.path.dirname(inspect.getfile(inspect.currentframe()))
+CUR_PATH = os.path.dirname(inspect.getfile(inspect.currentframe()))  # type: ignore
 ROOT_DIR = os.path.join(CUR_PATH, "..")
 
 CONFIGURATION_SCHEMA_DIR = os.path.join(ROOT_DIR, "aea", "configurations", "schemas")


### PR DESCRIPTION
## Proposed changes

Due to the upgrade of MyPy from version 0.720 to 0.730, MyPy raised errors about how we get the current path of a module. Add 'type: ignore' to solve the issue, since the risk is minimal.

## Fixes

Fixes #140 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.