### PR TITLE
Add `ProtocolConfig` class and parsing of protocol configuration files.

### DIFF
--- a/aea/cli/add.py
+++ b/aea/cli/add.py
@@ -20,6 +20,7 @@
 """Implementation of the 'aea add' subcommand."""
 
 import os
+import pprint
 import shutil
 from pathlib import Path
 from typing import cast
@@ -123,16 +124,16 @@ def protocol(click_context, protocol_name):
             logger.error("Cannot find protocol: '{}'.".format(protocol_name))
             exit(-1)
 
-    # # try to load the connection configuration file
-    # try:
-    #     connection_configuration = ctx.connection_loader.load(open(str(connection_configuration_filepath)))
-    #     logger.info("Connection supports the following protocols: {}".format(connection_configuration.supported_protocols))
-    # except ValidationError as e:
-    #     logger.error("Connection configuration file not valid: {}".format(str(e)))
-    #     exit(-1)
-    #     return
+    # try to load the protocol configuration file
+    try:
+        protocol_configuration = ctx.protocol_loader.load(open(str(protocol_configuration_filepath)))
+        logger.info("Protocol loaded: {}".format(pprint.pformat(protocol_configuration.json)))
+    except ValidationError as e:
+        logger.error("Protocol configuration file not valid: {}".format(str(e)))
+        exit(-1)
+        return
 
-    # copy the connection package into the agent's supported connections.
+    # copy the protocol package into the agent's supported connections.
     src = str(Path(os.path.join(registry_path, "protocols", protocol_name)).absolute())
     dest = os.path.join(ctx.cwd, "protocols", protocol_name)
     logger.info("Copying protocol modules. src={} dst={}".format(src, dest))

--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -30,7 +30,8 @@ import click
 import click_log
 import jsonschema  # type: ignore
 
-from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig, SkillConfig, ConnectionConfig
+from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig, SkillConfig, ConnectionConfig, ProtocolConfig, \
+    DEFAULT_PROTOCOL_CONFIG_FILE
 from aea.configurations.loader import ConfigLoader
 
 logger = logging.getLogger("aea")
@@ -48,6 +49,7 @@ class Context(object):
         self.agent_loader = ConfigLoader("aea-config_schema.json", AgentConfig)
         self.skill_loader = ConfigLoader("skill-config_schema.json", SkillConfig)
         self.connection_loader = ConfigLoader("connection-config_schema.json", ConnectionConfig)
+        self.protocol_loader = ConfigLoader("protocol-config_schema.json", ProtocolConfig)
         self.cwd = cwd
 
     def set_config(self, key, value) -> None:
@@ -83,9 +85,10 @@ def _try_to_load_protocols(ctx: Context):
     try:
         for protocol_name in ctx.agent_config.protocols:
             logger.debug("Processing protocol {}".format(protocol_name))
-            # protocol_config = ctx.protocol_loader.load(open(os.path.join(directory, DEFAULT_PROTOCOL_CONFIG_FILE)))
-            # if protocol_config is None:
-            #     exit(-1)
+            protocol_config = ctx.protocol_loader.load(open(os.path.join("protocols", DEFAULT_PROTOCOL_CONFIG_FILE)))
+            if protocol_config is None:
+                logger.debug("Protocol configuration file for protocl {} not found.".format(protocol_name))
+                exit(-1)
 
             protocol_spec = importlib.util.spec_from_file_location(protocol_name, os.path.join(ctx.agent_config.registry_path, "protocols", protocol_name, "__init__.py"))
             if protocol_spec is None:

--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -82,12 +82,12 @@ def _try_to_load_agent_config(ctx: Context):
 
 
 def _try_to_load_protocols(ctx: Context):
-    try:
-        for protocol_name in ctx.agent_config.protocols:
+    for protocol_name in ctx.agent_config.protocols:
+        try:
             logger.debug("Processing protocol {}".format(protocol_name))
-            protocol_config = ctx.protocol_loader.load(open(os.path.join("protocols", DEFAULT_PROTOCOL_CONFIG_FILE)))
+            protocol_config = ctx.protocol_loader.load(open(os.path.join("protocols", protocol_name, DEFAULT_PROTOCOL_CONFIG_FILE)))
             if protocol_config is None:
-                logger.debug("Protocol configuration file for protocl {} not found.".format(protocol_name))
+                logger.debug("Protocol configuration file for protocol {} not found.".format(protocol_name))
                 exit(-1)
 
             protocol_spec = importlib.util.spec_from_file_location(protocol_name, os.path.join(ctx.agent_config.registry_path, "protocols", protocol_name, "__init__.py"))
@@ -97,9 +97,9 @@ def _try_to_load_protocols(ctx: Context):
 
             protocol_module = importlib.util.module_from_spec(protocol_spec)
             sys.modules[protocol_spec.name + "_protocol"] = protocol_module
-    except FileNotFoundError:
-        logger.error("Protocols not found in registry")
-        exit(-1)
+        except FileNotFoundError:
+            logger.error("Protocol {} not found in registry".format(protocol_name))
+            exit(-1)
 
 
 class AEAConfigException(Exception):

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -152,6 +152,45 @@ class ConnectionConfig(Configuration):
         )
 
 
+class ProtocolConfig(Configuration):
+    """Handle protocol configuration."""
+
+    def __init__(self,
+                 name: str = "",
+                 authors: str = "",
+                 version: str = "",
+                 license: str = "",
+                 url: str = ""):
+        """Initialize a connection configuration object."""
+        self.name = name
+        self.authors = authors
+        self.version = version
+        self.license = license
+        self.url = url
+
+    @property
+    def json(self) -> Dict:
+        """Return the JSON representation."""
+        return {
+            "name": self.name,
+            "authors": self.authors,
+            "version": self.version,
+            "license": self.license,
+            "url": self.url
+        }
+
+    @classmethod
+    def from_json(cls, obj: Dict):
+        """Initialize from a JSON object."""
+        return ProtocolConfig(
+            name=cast(str, obj.get("name")),
+            authors=cast(str, obj.get("authors")),
+            version=cast(str, obj.get("version")),
+            license=cast(str, obj.get("license")),
+            url=cast(str, obj.get("url"))
+        )
+
+
 class HandlerConfig(Configuration):
     """Handle a skill handler configuration."""
 
@@ -289,7 +328,7 @@ class SkillConfig(Configuration):
             skill_config.behaviours.create(behaviour_config.class_name, behaviour_config)
 
         for t in obj.get("tasks"):  # type: ignore
-            task_config = BehaviourConfig.from_json(t["task"])
+            task_config = TaskConfig.from_json(t["task"])
             skill_config.tasks.create(task_config.class_name, task_config)
 
         handler = HandlerConfig.from_json(obj.get("handler"))  # type: ignore

--- a/aea/configurations/loader.py
+++ b/aea/configurations/loader.py
@@ -27,12 +27,12 @@ from typing import TextIO, Type, TypeVar, Generic
 import yaml
 from jsonschema import validate
 
-from aea.configurations.base import AgentConfig, SkillConfig, ConnectionConfig
+from aea.configurations.base import AgentConfig, SkillConfig, ConnectionConfig, ProtocolConfig
 
 _CUR_DIR = os.path.dirname(inspect.getfile(inspect.currentframe()))  # type: ignore
 _SCHEMAS_DIR = os.path.join(_CUR_DIR, "schemas")
 
-T = TypeVar('T', AgentConfig, SkillConfig, ConnectionConfig)
+T = TypeVar('T', AgentConfig, SkillConfig, ConnectionConfig, ProtocolConfig)
 
 
 class ConfigLoader(Generic[T]):

--- a/aea/configurations/schemas/connection-config_schema.json
+++ b/aea/configurations/schemas/connection-config_schema.json
@@ -3,7 +3,16 @@
     "description": "Schema for the connection configuration file.",
     "additionalProperties": false,
     "type": "object",
-    "required": ["name", "authors", "version", "license", "url", "class_name", "supported_protocols", "config"],
+    "required": [
+        "name",
+        "authors",
+        "version",
+        "license",
+        "url",
+        "class_name",
+        "supported_protocols",
+        "config"
+    ],
     "properties": {
         "name": {"type": "string"},
         "authors": {"type": "string"},

--- a/aea/configurations/schemas/protocol-config_schema.json
+++ b/aea/configurations/schemas/protocol-config_schema.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Schema for the protocol configuration file.",
+    "additionalProperties": false,
+    "type": "object",
+    "required": [
+        "name",
+        "authors",
+        "version",
+        "license",
+        "url"
+    ],
+    "properties": {
+        "name": {"type": "string"},
+        "authors": {"type": "string"},
+        "version": {"type": "string"},
+        "license": {"type": "string"},
+        "url": {"type": "string"}
+    }
+}

--- a/aea/protocols/base.py
+++ b/aea/protocols/base.py
@@ -210,7 +210,7 @@ class Protocol(ABC):
 
     @property
     def config(self) -> ProtocolConfig:
-        """Get the serializer."""
+        """Get the configuration."""
         return self._config
 
     def check(self, msg: Message) -> bool:

--- a/aea/protocols/base.py
+++ b/aea/protocols/base.py
@@ -27,6 +27,8 @@ from typing import Any, Dict, Optional
 
 from google.protobuf.struct_pb2 import Struct
 
+from aea.configurations.base import ProtocolConfig
+
 
 class Message:
     """This class implements a message."""
@@ -184,15 +186,17 @@ class Protocol(ABC):
     - a 'check' abstract method (to be implemented) to check if a message is allowed for the protocol.
     """
 
-    def __init__(self, id: str, serializer: Serializer):
+    def __init__(self, id: str, serializer: Serializer, config: ProtocolConfig):
         """
         Initialize the protocol manager.
 
         :param id: the protocol id.
         :param serializer: the serializer.
+        :param config: the protocol configurations.
         """
         self._id = id
         self._serializer = serializer
+        self._config = config
 
     @property
     def id(self):
@@ -203,6 +207,11 @@ class Protocol(ABC):
     def serializer(self) -> Serializer:
         """Get the serializer."""
         return self._serializer
+
+    @property
+    def config(self) -> ProtocolConfig:
+        """Get the serializer."""
+        return self._config
 
     def check(self, msg: Message) -> bool:
         """

--- a/aea/registries/base.py
+++ b/aea/registries/base.py
@@ -28,7 +28,10 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional, List, Dict, Any, Tuple, cast
 
-from aea.configurations.base import ProtocolId, SkillId
+import yaml
+
+from aea.configurations.base import ProtocolId, SkillId, ProtocolConfig, DEFAULT_PROTOCOL_CONFIG_FILE
+from aea.configurations.loader import ConfigLoader
 from aea.protocols.base import Protocol
 from aea.skills.base import Handler, Behaviour, Task, Skill, AgentContext
 
@@ -171,8 +174,11 @@ class ProtocolRegistry(Registry):
                      .format(serializer_class=serializer_class, protocol_name=protocol_name))
         serializer = serializer_class()
 
+        config_loader = ConfigLoader("protocol-config_schema.json", ProtocolConfig)
+        protocol_config = config_loader.load(open(Path(directory, "protocols", protocol_name, DEFAULT_PROTOCOL_CONFIG_FILE)))
+
         # instantiate the protocol manager.
-        protocol = Protocol(protocol_name, serializer)
+        protocol = Protocol(protocol_name, serializer, protocol_config)
         self.register((protocol_name, None), protocol)
 
 

--- a/aea/registries/base.py
+++ b/aea/registries/base.py
@@ -28,8 +28,6 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional, List, Dict, Any, Tuple, cast
 
-import yaml
-
 from aea.configurations.base import ProtocolId, SkillId, ProtocolConfig, DEFAULT_PROTOCOL_CONFIG_FILE
 from aea.configurations.loader import ConfigLoader
 from aea.protocols.base import Protocol


### PR DESCRIPTION
## Proposed changes

This PR adds the `ProtocolConfig` class (analogous to the other `*Config` classes) and the loading of such `protocols/<protocol_name>/protocol.yaml` configuration files during the AEA setup.

## Fixes

fixes #115 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Tests are missing.