### PR TITLE
Gather dependencies and install them in 'aea run'. Add 'aea freeze'

### DIFF
--- a/aea/cli/__main__.py
+++ b/aea/cli/__main__.py
@@ -32,7 +32,7 @@ from jsonschema import ValidationError
 
 import aea
 from aea.cli.add import connection, add, skill
-from aea.cli.common import Context, pass_ctx, logger
+from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config
 from aea.cli.remove import remove
 from aea.cli.run import run
 from aea.cli.scaffold import scaffold
@@ -108,6 +108,15 @@ def delete(ctx: Context, agent_name):
     except OSError:
         logger.error("An error occurred while deleting the agent directory. Aborting...")
         exit(-1)
+
+
+@cli.command()
+@pass_ctx
+def freeze(ctx: Context):
+    """Get the dependencies."""
+    _try_to_load_agent_config(ctx)
+    for d in ctx.get_dependencies():
+        print(d)
 
 
 cli.add_command(add)

--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -22,9 +22,9 @@
 import importlib.util
 import logging
 import os
-from pathlib import Path
 import sys
-from typing import Dict, List
+from pathlib import Path
+from typing import Dict, List, cast
 
 import click
 import click_log
@@ -68,22 +68,24 @@ class Context(object):
 
         :return a list of dependency version specification. e.g. ["gym >= 1.0.0"]
         """
-
-        dependencies = []
+        dependencies = []  # type: List[str]
         for protocol_id in self.agent_config.protocols:
             path = str(Path("protocols", protocol_id, DEFAULT_PROTOCOL_CONFIG_FILE))
             protocol_config = self.protocol_loader.load(open(path))
-            dependencies.extend(protocol_config.dependencies)
+            deps = cast(List[str], protocol_config.dependencies)
+            dependencies.extend(deps)
 
         for connection_id in self.agent_config.connections:
             path = str(Path("connections", connection_id, DEFAULT_CONNECTION_CONFIG_FILE))
             connection_config = self.connection_loader.load(open(path))
-            dependencies.extend(connection_config.dependencies)
+            deps = cast(List[str], connection_config.dependencies)
+            dependencies.extend(deps)
 
         for skill_id in self.agent_config.skills:
             path = str(Path("skills", skill_id, DEFAULT_SKILL_CONFIG_FILE))
             skill_config = self.skill_loader.load(open(path))
-            dependencies.extend(skill_config.dependencies)
+            deps = cast(List[str], skill_config.dependencies)
+            dependencies.extend(deps)
 
         return sorted(set(dependencies))
 

--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -24,14 +24,14 @@ import logging
 import os
 from pathlib import Path
 import sys
-from typing import Dict
+from typing import Dict, List
 
 import click
 import click_log
 import jsonschema  # type: ignore
 
 from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig, SkillConfig, ConnectionConfig, ProtocolConfig, \
-    DEFAULT_PROTOCOL_CONFIG_FILE
+    DEFAULT_PROTOCOL_CONFIG_FILE, DEFAULT_CONNECTION_CONFIG_FILE, DEFAULT_SKILL_CONFIG_FILE
 from aea.configurations.loader import ConfigLoader
 
 logger = logging.getLogger("aea")
@@ -62,6 +62,30 @@ class Context(object):
         """
         self.config[key] = value
         logger.debug('  config[%s] = %s' % (key, value))
+
+    def get_dependencies(self) -> List[str]:
+        """Aggregate the dependencies from every component.
+
+        :return a list of dependency version specification. e.g. ["gym >= 1.0.0"]
+        """
+
+        dependencies = []
+        for protocol_id in self.agent_config.protocols:
+            path = str(Path("protocols", protocol_id, DEFAULT_PROTOCOL_CONFIG_FILE))
+            protocol_config = self.protocol_loader.load(open(path))
+            dependencies.extend(protocol_config.dependencies)
+
+        for connection_id in self.agent_config.connections:
+            path = str(Path("connections", connection_id, DEFAULT_CONNECTION_CONFIG_FILE))
+            connection_config = self.connection_loader.load(open(path))
+            dependencies.extend(connection_config.dependencies)
+
+        for skill_id in self.agent_config.skills:
+            path = str(Path("skills", skill_id, DEFAULT_SKILL_CONFIG_FILE))
+            skill_config = self.skill_loader.load(open(path))
+            dependencies.extend(skill_config.dependencies)
+
+        return sorted(set(dependencies))
 
 
 pass_ctx = click.make_pass_decorator(Context)

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -18,6 +18,8 @@
 # ------------------------------------------------------------------------------
 
 """Implementation of the 'aea run' subcommand."""
+import subprocess
+
 import click
 import importlib.util
 import inspect
@@ -26,6 +28,8 @@ from pathlib import Path
 import re
 import sys
 from typing import cast
+
+import pip
 
 from aea.aea import AEA
 from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config, _try_to_load_protocols, AEAConfigException
@@ -97,6 +101,16 @@ def run(ctx: Context, connection_name: str):
         logger.error(str(e))
         exit(-1)
         return
+
+    logger.debug("Installing all the dependencies...")
+    for d in ctx.get_dependencies():
+        logger.debug("Installing {}...".format(d))
+        try:
+            subp = subprocess.Popen([sys.executable, "-m", "pip", "install", d])
+            subp.wait(30.0)
+        except Exception:
+            logger.error("An error occurred while installing {}. Stopping...".format(d))
+            exit(-1)
 
     mailbox = MailBox(connection)
     agent = AEA(agent_name, mailbox, private_key_pem_path=private_key_pem_path, directory=str(Path(".")))

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -18,21 +18,20 @@
 # ------------------------------------------------------------------------------
 
 """Implementation of the 'aea run' subcommand."""
-import subprocess
-
-import click
 import importlib.util
 import inspect
 import os
-from pathlib import Path
 import re
+import subprocess
 import sys
+from pathlib import Path
 from typing import cast
 
-import pip
+import click
 
 from aea.aea import AEA
-from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config, _try_to_load_protocols, AEAConfigException
+from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config, _try_to_load_protocols, \
+    AEAConfigException
 from aea.connections.base import Connection
 from aea.crypto.base import Crypto
 from aea.crypto.helpers import _try_validate_private_key_pem_path, _create_temporary_private_key_pem_path

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -111,6 +111,7 @@ class ConnectionConfig(Configuration):
                  url: str = "",
                  class_name: str = "",
                  supported_protocols: Optional[List[str]] = None,
+                 dependencies: Optional[List[str]] = None,
                  **config):
         """Initialize a connection configuration object."""
         self.name = name
@@ -120,6 +121,7 @@ class ConnectionConfig(Configuration):
         self.url = url
         self.class_name = class_name
         self.supported_protocols = supported_protocols if supported_protocols is not None else []
+        self.dependencies = dependencies if dependencies is not None else []
         self.config = config
 
     @property
@@ -133,13 +135,15 @@ class ConnectionConfig(Configuration):
             "url": self.url,
             "class_name": self.class_name,
             "supported_protocols": self.supported_protocols,
+            "dependencies": self.dependencies,
             "config": self.config
         }
 
     @classmethod
     def from_json(cls, obj: Dict):
         """Initialize from a JSON object."""
-        supported_protocols = cast(List[str], obj.get("supported_protocols"))
+        supported_protocols = cast(List[str], obj.get("supported_protocols", []))
+        dependencies = cast(List[str], obj.get("dependencies", []))
         return ConnectionConfig(
             name=cast(str, obj.get("name")),
             authors=cast(str, obj.get("authors")),
@@ -148,6 +152,7 @@ class ConnectionConfig(Configuration):
             url=cast(str, obj.get("url")),
             class_name=cast(str, obj.get("class_name")),
             supported_protocols=supported_protocols,
+            dependencies=dependencies,
             **cast(dict, obj.get("config"))
         )
 
@@ -160,13 +165,15 @@ class ProtocolConfig(Configuration):
                  authors: str = "",
                  version: str = "",
                  license: str = "",
-                 url: str = ""):
+                 url: str = "",
+                 dependencies: Optional[List[str]] = None):
         """Initialize a connection configuration object."""
         self.name = name
         self.authors = authors
         self.version = version
         self.license = license
         self.url = url
+        self.dependencies = dependencies
 
     @property
     def json(self) -> Dict:
@@ -176,18 +183,21 @@ class ProtocolConfig(Configuration):
             "authors": self.authors,
             "version": self.version,
             "license": self.license,
-            "url": self.url
+            "url": self.url,
+            "dependencies": self.dependencies
         }
 
     @classmethod
     def from_json(cls, obj: Dict):
         """Initialize from a JSON object."""
+        dependencies = cast(List[str], obj.get("dependencies", []))
         return ProtocolConfig(
             name=cast(str, obj.get("name")),
             authors=cast(str, obj.get("authors")),
             version=cast(str, obj.get("version")),
             license=cast(str, obj.get("license")),
-            url=cast(str, obj.get("url"))
+            url=cast(str, obj.get("url")),
+            dependencies=dependencies
         )
 
 
@@ -278,7 +288,8 @@ class SkillConfig(Configuration):
                  version: str = "",
                  license: str = "",
                  url: str = "",
-                 protocol: str = ""):
+                 protocol: str = "",
+                 dependencies: Optional[List[str]] = None):
         """Initialize a skill configuration."""
         self.name = name
         self.authors = authors
@@ -286,6 +297,7 @@ class SkillConfig(Configuration):
         self.license = license
         self.url = url
         self.protocol = protocol
+        self.dependencies = dependencies
         self.handler = HandlerConfig()
         self.behaviours = CRUDCollection[BehaviourConfig]()
         self.tasks = CRUDCollection[TaskConfig]()
@@ -300,6 +312,7 @@ class SkillConfig(Configuration):
             "license": self.license,
             "url": self.url,
             "protocol": self.protocol,
+            "dependencies": self.dependencies,
             "handler": self.handler.json,
             "behaviours": [{"behaviour": b.json} for _, b in self.behaviours.read_all()],
             "tasks": [{"task": t.json} for _, t in self.tasks.read_all()],
@@ -314,13 +327,15 @@ class SkillConfig(Configuration):
         license = cast(str, obj.get("license"))
         url = cast(str, obj.get("url"))
         protocol = cast(str, obj.get("protocol"))
+        dependencies = cast(List[str], obj.get("dependencies", []))
         skill_config = SkillConfig(
             name=name,
             authors=authors,
             version=version,
             license=license,
             url=url,
-            protocol=protocol
+            protocol=protocol,
+            dependencies=dependencies
         )
 
         for b in obj.get("behaviours"):  # type: ignore


### PR DESCRIPTION
## Proposed changes

- now every time `aea run` is executed, all the dependencies of the components are gathered together and installed via the current interpreter's pip module.
- `aea freeze` will instead print on stdout the list of gathered dependencies.

## Fixes

Fixes #128 and #152 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.