### PR TITLE
Reference a schema from another file.

### DIFF
--- a/aea/configurations/loader.py
+++ b/aea/configurations/loader.py
@@ -22,10 +22,12 @@
 import inspect
 import json
 import os
+from pathlib import Path
 from typing import TextIO, Type, TypeVar, Generic
 
+import jsonschema
 import yaml
-from jsonschema import validate
+from jsonschema import validate, Draft7Validator
 
 from aea.configurations.base import AgentConfig, SkillConfig, ConnectionConfig, ProtocolConfig
 
@@ -41,6 +43,8 @@ class ConfigLoader(Generic[T]):
     def __init__(self, schema_filename: str, configuration_type: Type[T]):
         """Initialize the parser for configuration files."""
         self.schema = json.load(open(os.path.join(_SCHEMAS_DIR, schema_filename)))
+        self.resolver = jsonschema.RefResolver("file://{}/".format(Path(_SCHEMAS_DIR).absolute()), self.schema)
+        self.validator = Draft7Validator(self.schema, resolver=self.resolver)
         self.configuration_type = configuration_type  # type: Type[T]
 
     def load(self, fp: TextIO) -> T:
@@ -52,7 +56,7 @@ class ConfigLoader(Generic[T]):
         :raises
         """
         configuration_file_json = yaml.safe_load(fp)
-        validate(instance=configuration_file_json, schema=self.schema)
+        self.validator.validate(instance=configuration_file_json)
         return self.configuration_type.from_json(configuration_file_json)
 
     def dump(self, configuration: T, fp: TextIO) -> None:
@@ -63,5 +67,5 @@ class ConfigLoader(Generic[T]):
         :return: None
         """
         result = configuration.json
-        validate(instance=result, schema=self.schema)
+        self.validator.validate(instance=result, schema=self.schema)
         yaml.safe_dump(result, fp)

--- a/aea/configurations/loader.py
+++ b/aea/configurations/loader.py
@@ -27,7 +27,7 @@ from typing import TextIO, Type, TypeVar, Generic
 
 import jsonschema
 import yaml
-from jsonschema import validate, Draft7Validator
+from jsonschema import Draft7Validator
 
 from aea.configurations.base import AgentConfig, SkillConfig, ConnectionConfig, ProtocolConfig
 

--- a/aea/configurations/loader.py
+++ b/aea/configurations/loader.py
@@ -67,5 +67,5 @@ class ConfigLoader(Generic[T]):
         :return: None
         """
         result = configuration.json
-        self.validator.validate(instance=result, schema=self.schema)
+        self.validator.validate(instance=result)
         yaml.safe_dump(result, fp)

--- a/aea/configurations/schemas/connection-config_schema.json
+++ b/aea/configurations/schemas/connection-config_schema.json
@@ -29,10 +29,7 @@
         "dependencies": {
             "type": "array",
             "uniqueItems": true,
-            "items": {
-                "type": "string",
-                "pattern": "([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])( *(~=|==|>=|<=|!=|<|>) *v?(?:(?:(?P<epoch>[0-9]+)!)?(?P<release>[0-9]+(?:\\.[0-9]+)*)(?P<pre>[-_\\.]?(?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))[-_\\.]?(?P<pre_n>[0-9]+)?)?(?P<post>(?:-(?P<post_n1>[0-9]+))|(?:[-_\\.]?(?P<post_l>post|rev|r)[-_\\.]?(?P<post_n2>[0-9]+)?))?(?P<dev>[-_\\.]?(?P<dev_l>dev)[-_\\.]?(?P<dev_n>[0-9]+)?)?)(?:\\+(?P<local>[a-z0-9]+(?:[-_\\.][a-z0-9]+)*))?)?$"
-            }
+            "items": { "$ref": "definitions.json#/definitions/requirement" }
         }
     }
 }

--- a/aea/configurations/schemas/definitions.json
+++ b/aea/configurations/schemas/definitions.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "requirement": {
+      "type": "string",
+      "pattern": "([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])( *(~=|==|>=|<=|!=|<|>) *v?(?:(?:(?P<epoch>[0-9]+)!)?(?P<release>[0-9]+(?:\\.[0-9]+)*)(?P<pre>[-_\\.]?(?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))[-_\\.]?(?P<pre_n>[0-9]+)?)?(?P<post>(?:-(?P<post_n1>[0-9]+))|(?:[-_\\.]?(?P<post_l>post|rev|r)[-_\\.]?(?P<post_n2>[0-9]+)?))?(?P<dev>[-_\\.]?(?P<dev_l>dev)[-_\\.]?(?P<dev_n>[0-9]+)?)?)(?:\\+(?P<local>[a-z0-9]+(?:[-_\\.][a-z0-9]+)*))?)?$"
+    }
+  }
+}

--- a/aea/configurations/schemas/protocol-config_schema.json
+++ b/aea/configurations/schemas/protocol-config_schema.json
@@ -19,10 +19,7 @@
         "dependencies": {
             "type": "array",
             "uniqueItems": true,
-            "items": {
-                "type": "string",
-                "pattern": "([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])( *(~=|==|>=|<=|!=|<|>) *v?(?:(?:(?P<epoch>[0-9]+)!)?(?P<release>[0-9]+(?:\\.[0-9]+)*)(?P<pre>[-_\\.]?(?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))[-_\\.]?(?P<pre_n>[0-9]+)?)?(?P<post>(?:-(?P<post_n1>[0-9]+))|(?:[-_\\.]?(?P<post_l>post|rev|r)[-_\\.]?(?P<post_n2>[0-9]+)?))?(?P<dev>[-_\\.]?(?P<dev_l>dev)[-_\\.]?(?P<dev_n>[0-9]+)?)?)(?:\\+(?P<local>[a-z0-9]+(?:[-_\\.][a-z0-9]+)*))?)?$"
-            }
+            "items": { "$ref": "definitions.json#/definitions/requirement" }
         }
     }
 }

--- a/aea/configurations/schemas/skill-config_schema.json
+++ b/aea/configurations/schemas/skill-config_schema.json
@@ -47,10 +47,7 @@
         "dependencies": {
             "type": "array",
             "uniqueItems": true,
-            "items": {
-                "type": "string",
-                "pattern": "([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])( *(~=|==|>=|<=|!=|<|>) *v?(?:(?:(?P<epoch>[0-9]+)!)?(?P<release>[0-9]+(?:\\.[0-9]+)*)(?P<pre>[-_\\.]?(?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))[-_\\.]?(?P<pre_n>[0-9]+)?)?(?P<post>(?:-(?P<post_n1>[0-9]+))|(?:[-_\\.]?(?P<post_l>post|rev|r)[-_\\.]?(?P<post_n2>[0-9]+)?))?(?P<dev>[-_\\.]?(?P<dev_l>dev)[-_\\.]?(?P<dev_n>[0-9]+)?)?)(?:\\+(?P<local>[a-z0-9]+(?:[-_\\.][a-z0-9]+)*))?)?$"
-            }
+            "items": { "$ref": "definitions.json#/definitions/requirement" }
         }
     },
     "definitions": {

--- a/tests/test_cli/test_schema.py
+++ b/tests/test_cli/test_schema.py
@@ -21,7 +21,9 @@
 import json
 import os
 import pprint
+from pathlib import Path
 
+import jsonschema
 import pytest
 import yaml
 from jsonschema import validate, Draft7Validator  # type: ignore
@@ -29,7 +31,7 @@ from jsonschema import validate, Draft7Validator  # type: ignore
 from aea.configurations.base import DEFAULT_PROTOCOL_CONFIG_FILE, DEFAULT_CONNECTION_CONFIG_FILE, \
     DEFAULT_SKILL_CONFIG_FILE
 from ..conftest import CUR_PATH, ROOT_DIR, AGENT_CONFIGURATION_SCHEMA, SKILL_CONFIGURATION_SCHEMA, \
-    CONNECTION_CONFIGURATION_SCHEMA, PROTOCOL_CONFIGURATION_SCHEMA
+    CONNECTION_CONFIGURATION_SCHEMA, PROTOCOL_CONFIGURATION_SCHEMA, CONFIGURATION_SCHEMA_DIR
 
 
 def test_agent_configuration_schema_is_valid_wrt_draft_07():
@@ -64,7 +66,9 @@ class TestProtocolsSchema:
     @classmethod
     def setup_class(cls):
         """Set up the test class."""
-        cls.protocol_config_schema = json.load(open(PROTOCOL_CONFIGURATION_SCHEMA))
+        cls.schema = json.load(open(PROTOCOL_CONFIGURATION_SCHEMA))
+        cls.resolver = jsonschema.RefResolver("file://{}/".format(Path(CONFIGURATION_SCHEMA_DIR).absolute()), cls.schema)
+        cls.validator = Draft7Validator(cls.schema, resolver=cls.resolver)
 
     @pytest.mark.parametrize("protocol_path",
                              [
@@ -78,7 +82,7 @@ class TestProtocolsSchema:
     def test_validate_protocol_config(self, protocol_path):
         """Test that the validation of the protocol configuration file in aea/protocols works correctly."""
         protocol_config_file = yaml.safe_load(open(os.path.join(protocol_path, DEFAULT_PROTOCOL_CONFIG_FILE)))
-        validate(instance=protocol_config_file, schema=self.protocol_config_schema)
+        self.validator.validate(instance=protocol_config_file)
 
 
 class TestConnectionsSchema:
@@ -87,7 +91,9 @@ class TestConnectionsSchema:
     @classmethod
     def setup_class(cls):
         """Set up the test class."""
-        cls.connection_config_schema = json.load(open(CONNECTION_CONFIGURATION_SCHEMA))
+        cls.schema = json.load(open(CONNECTION_CONFIGURATION_SCHEMA))
+        cls.resolver = jsonschema.RefResolver("file://{}/".format(Path(CONFIGURATION_SCHEMA_DIR).absolute()), cls.schema)
+        cls.validator = Draft7Validator(cls.schema, resolver=cls.resolver)
 
     @pytest.mark.parametrize("connection_path",
                              [
@@ -100,7 +106,7 @@ class TestConnectionsSchema:
     def test_validate_connection_config(self, connection_path):
         """Test that the validation of the protocol configuration file in aea/protocols works correctly."""
         connection_config_file = yaml.safe_load(open(os.path.join(connection_path, DEFAULT_CONNECTION_CONFIG_FILE)))
-        validate(instance=connection_config_file, schema=self.connection_config_schema)
+        self.validator.validate(instance=connection_config_file)
 
 
 class TestSkillsSchema:
@@ -109,7 +115,9 @@ class TestSkillsSchema:
     @classmethod
     def setup_class(cls):
         """Set up the test class."""
-        cls.skill_config_schema = json.load(open(SKILL_CONFIGURATION_SCHEMA))
+        cls.schema = json.load(open(SKILL_CONFIGURATION_SCHEMA))
+        cls.resolver = jsonschema.RefResolver("file://{}/".format(Path(CONFIGURATION_SCHEMA_DIR).absolute()), cls.schema)
+        cls.validator = Draft7Validator(cls.schema, resolver=cls.resolver)
 
     @pytest.mark.parametrize("skill_path",
                              [
@@ -122,4 +130,4 @@ class TestSkillsSchema:
     def test_validate_skill_config(self, skill_path):
         """Test that the validation of the protocol configuration file in aea/protocols works correctly."""
         skill_config_file = yaml.safe_load(open(os.path.join(skill_path, DEFAULT_SKILL_CONFIG_FILE)))
-        validate(instance=skill_config_file, schema=self.skill_config_schema)
+        self.validator.validate(instance=skill_config_file)


### PR DESCRIPTION
## Proposed changes

This PR helps in the handling of complex schemas.

Now it's possible to easily reference parts of schemas between files. The only condition is that the root of the URI is `aea/configurations/schemas/`.

E.g. look at the `"dependencies"` schema definitions:
```
"dependencies": {
            "type": "array",
            "uniqueItems": true,
            "items": { "$ref": "definitions.json#/definitions/requirement" }
        }
```
it is an array of `"requirement"` object. This schema is defined in `aea/configurations/schemas/definitions.json`.

## Fixes

Fixes #154 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.