### PR TITLE
Add 'aea install [-r requirement]' subcommand

### DIFF
--- a/aea/cli/__main__.py
+++ b/aea/cli/__main__.py
@@ -22,10 +22,8 @@
 
 import os
 import shutil
-import subprocess
-import sys
 from pathlib import Path
-from typing import cast, Optional
+from typing import cast
 
 import click
 import click_log

--- a/aea/cli/__main__.py
+++ b/aea/cli/__main__.py
@@ -33,6 +33,7 @@ from jsonschema import ValidationError
 import aea
 from aea.cli.add import connection, add, skill
 from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config
+from aea.cli.install import install
 from aea.cli.remove import remove
 from aea.cli.run import run
 from aea.cli.scaffold import scaffold
@@ -122,6 +123,7 @@ def freeze(ctx: Context):
 cli.add_command(add)
 cli.add_command(scaffold)
 cli.add_command(remove)
+cli.add_command(install)
 cli.add_command(run)
 
 if __name__ == '__main__':

--- a/aea/cli/__main__.py
+++ b/aea/cli/__main__.py
@@ -130,11 +130,12 @@ def install(ctx: Context, requirement: Optional[str]):
     _try_to_load_agent_config(ctx)
 
     if requirement:
+        logger.debug("Installing the dependencies in '{}'...".format(requirement))
         dependencies = list(map(lambda x: x.strip(), open(requirement).readlines()))
     else:
+        logger.debug("Installing all the dependencies...")
         dependencies = ctx.get_dependencies()
 
-    logger.debug("Installing all the dependencies...")
     for d in dependencies:
         logger.debug("Installing {}...".format(d))
         try:

--- a/aea/cli/__main__.py
+++ b/aea/cli/__main__.py
@@ -121,31 +121,6 @@ def freeze(ctx: Context):
         print(d)
 
 
-@cli.command()
-@click.option('-r', '--requirement', type=str, required=False, default=None,
-              help="Install from the given requirements file.")
-@pass_ctx
-def install(ctx: Context, requirement: Optional[str]):
-    """Get the dependencies."""
-    _try_to_load_agent_config(ctx)
-
-    if requirement:
-        logger.debug("Installing the dependencies in '{}'...".format(requirement))
-        dependencies = list(map(lambda x: x.strip(), open(requirement).readlines()))
-    else:
-        logger.debug("Installing all the dependencies...")
-        dependencies = ctx.get_dependencies()
-
-    for d in dependencies:
-        logger.debug("Installing {}...".format(d))
-        try:
-            subp = subprocess.Popen([sys.executable, "-m", "pip", "install", d])
-            subp.wait(30.0)
-        except Exception:
-            logger.error("An error occurred while installing {}. Stopping...".format(d))
-            exit(-1)
-
-
 cli.add_command(add)
 cli.add_command(scaffold)
 cli.add_command(remove)

--- a/aea/cli/install.py
+++ b/aea/cli/install.py
@@ -33,7 +33,7 @@ from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config
               help="Install from the given requirements file.")
 @pass_ctx
 def install(ctx: Context, requirement: Optional[str]):
-    """Get the dependencies."""
+    """Install the dependencies."""
     _try_to_load_agent_config(ctx)
 
     if requirement:

--- a/aea/cli/install.py
+++ b/aea/cli/install.py
@@ -19,20 +19,13 @@
 
 """Implementation of the 'aea install' subcommand."""
 
-import os
-import shutil
 import subprocess
 import sys
-from pathlib import Path
-from typing import cast, Optional
+from typing import Optional
 
 import click
-from click import pass_context
-from jsonschema import ValidationError
 
-from aea import AEA_DIR
 from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config
-from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, DEFAULT_CONNECTION_CONFIG_FILE, DEFAULT_SKILL_CONFIG_FILE, DEFAULT_PROTOCOL_CONFIG_FILE
 
 
 @click.command()

--- a/aea/cli/install.py
+++ b/aea/cli/install.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Implementation of the 'aea install' subcommand."""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import cast, Optional
+
+import click
+from click import pass_context
+from jsonschema import ValidationError
+
+from aea import AEA_DIR
+from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config
+from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, DEFAULT_CONNECTION_CONFIG_FILE, DEFAULT_SKILL_CONFIG_FILE, DEFAULT_PROTOCOL_CONFIG_FILE
+
+
+@click.command()
+@click.option('-r', '--requirement', type=str, required=False, default=None,
+              help="Install from the given requirements file.")
+@pass_ctx
+def install(ctx: Context, requirement: Optional[str]):
+    """Get the dependencies."""
+    _try_to_load_agent_config(ctx)
+
+    if requirement:
+        logger.debug("Installing the dependencies in '{}'...".format(requirement))
+        dependencies = list(map(lambda x: x.strip(), open(requirement).readlines()))
+    else:
+        logger.debug("Installing all the dependencies...")
+        dependencies = ctx.get_dependencies()
+
+    for d in dependencies:
+        logger.debug("Installing {}...".format(d))
+        try:
+            subp = subprocess.Popen([sys.executable, "-m", "pip", "install", d])
+            subp.wait(30.0)
+        except Exception:
+            logger.error("An error occurred while installing {}. Stopping...".format(d))
+            exit(-1)

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -22,7 +22,6 @@ import importlib.util
 import inspect
 import os
 import re
-import subprocess
 import sys
 from pathlib import Path
 from typing import cast
@@ -31,7 +30,7 @@ import click
 from click import pass_context
 
 from aea.aea import AEA
-from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config, _try_to_load_protocols, \
+from aea.cli.common import Context, logger, _try_to_load_agent_config, _try_to_load_protocols, \
     AEAConfigException
 from aea.cli.install import install
 from aea.connections.base import Connection

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -28,10 +28,12 @@ from pathlib import Path
 from typing import cast
 
 import click
+from click import pass_context
 
 from aea.aea import AEA
 from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config, _try_to_load_protocols, \
     AEAConfigException
+from aea.cli.install import install
 from aea.connections.base import Connection
 from aea.crypto.base import Crypto
 from aea.crypto.helpers import _try_validate_private_key_pem_path, _create_temporary_private_key_pem_path
@@ -80,9 +82,12 @@ def _setup_connection(connection_name: str, public_key: str, ctx: Context) -> Co
 @click.command()
 @click.option('--connection', 'connection_name', metavar="CONN_NAME", type=str, required=False, default=None,
               help="The connection name. Must be declared in the agent's configuration file.")
-@pass_ctx
-def run(ctx: Context, connection_name: str):
+@click.option('--install-deps', 'install_deps', is_flag=True, required=False, default=False,
+              help="Install all the dependencies before running the agent.")
+@pass_context
+def run(click_context, connection_name: str, install_deps: bool):
     """Run the agent."""
+    ctx = cast(Context, click_context.obj)
     _try_to_load_agent_config(ctx)
     agent_name = cast(str, ctx.agent_config.agent_name)
     private_key_pem_path = cast(str, ctx.agent_config.private_key_pem_path)
@@ -100,6 +105,12 @@ def run(ctx: Context, connection_name: str):
         logger.error(str(e))
         exit(-1)
         return
+
+    if install_deps:
+        if Path("requirements.txt").exists():
+            click_context.invoke(install, requirement="requirements.txt")
+        else:
+            click_context.invoke(install)
 
     mailbox = MailBox(connection)
     agent = AEA(agent_name, mailbox, private_key_pem_path=private_key_pem_path, directory=str(Path(".")))

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -101,16 +101,6 @@ def run(ctx: Context, connection_name: str):
         exit(-1)
         return
 
-    logger.debug("Installing all the dependencies...")
-    for d in ctx.get_dependencies():
-        logger.debug("Installing {}...".format(d))
-        try:
-            subp = subprocess.Popen([sys.executable, "-m", "pip", "install", d])
-            subp.wait(30.0)
-        except Exception:
-            logger.error("An error occurred while installing {}. Stopping...".format(d))
-            exit(-1)
-
     mailbox = MailBox(connection)
     agent = AEA(agent_name, mailbox, private_key_pem_path=private_key_pem_path, directory=str(Path(".")))
     try:

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -7,6 +7,9 @@ Command  | Description
 `scaffold connection/protocol/skill [name]`  | Scaffold a new connection, protocol, or skill.
 `add connection/protocol/skill [name]`  | Add connection, protocol, or skill to agent.
 `remove connection/protocol/skill [name]` | Remove connection, protocol, or skill from agent.
+`install [-r <requirements_file>]` | Install the dependencies.
+`list protocols/connections/skills` |   List the installed resources.
+`search protocols/connections/skills` | Search for components in the registry.
 `run {using [connection, ...]}`  | Run the agent on the Fetch.AI network with default or specified connections.
 `-v DEBUG run` | Run with debugging.
 `delete [name]`  | Delete an aea project. See below for disabling a resource.


### PR DESCRIPTION
## Proposed changes

This PR adds the subcommand `aea install` to install dependencies explicitly.

Moreover, they are not installed by default when `aea run`.

## Fixes

Fixes #167 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Should we add a `aea run --install-deps` to force the installation when launching the agent?