### PR TITLE
Save `aea` logs to file.

### DIFF
--- a/aea/cli/__main__.py
+++ b/aea/cli/__main__.py
@@ -22,7 +22,6 @@
 
 import os
 import shutil
-from logging import FileHandler
 from pathlib import Path
 from typing import cast
 
@@ -34,9 +33,9 @@ from jsonschema import ValidationError
 import aea
 from aea.cli.add import connection, add, skill
 from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config
+from aea.cli.list import list as _list
 from aea.cli.remove import remove
 from aea.cli.run import run
-from aea.cli.list import list as _list
 from aea.cli.scaffold import scaffold
 from aea.cli.search import search
 from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig
@@ -49,13 +48,9 @@ DEFAULT_SKILL = "error"
 @click.version_option('0.1.0')
 @click.pass_context
 @click_log.simple_verbosity_option(logger, default="INFO")
-@click.option('-l', '--logfile', 'log_file', type=click.Path(), required=False, default=None,
-              help="Save logs into a log file.")
-def cli(ctx, log_file: str) -> None:
+def cli(ctx) -> None:
     """Command-line tool for setting up an Autonomous Economic Agent."""
     ctx.obj = Context(cwd=".")
-    if log_file:
-        logger.addHandler(FileHandler(log_file))
 
 
 @cli.command()

--- a/aea/cli/__main__.py
+++ b/aea/cli/__main__.py
@@ -22,6 +22,7 @@
 
 import os
 import shutil
+from logging import FileHandler
 from pathlib import Path
 from typing import cast
 
@@ -48,9 +49,13 @@ DEFAULT_SKILL = "error"
 @click.version_option('0.1.0')
 @click.pass_context
 @click_log.simple_verbosity_option(logger, default="INFO")
-def cli(ctx) -> None:
+@click.option('-l', '--logfile', 'log_file', type=click.Path(), required=False, default=None,
+              help="Save logs into a log file.")
+def cli(ctx, log_file: str) -> None:
     """Command-line tool for setting up an Autonomous Economic Agent."""
     ctx.obj = Context(cwd=".")
+    if log_file:
+        logger.addHandler(FileHandler(log_file))
 
 
 @cli.command()

--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -21,6 +21,7 @@
 
 import importlib.util
 import logging
+import logging.config
 import os
 import sys
 from pathlib import Path
@@ -98,6 +99,7 @@ def _try_to_load_agent_config(ctx: Context):
         path = Path(DEFAULT_AEA_CONFIG_FILE)
         fp = open(str(path), mode="r", encoding="utf-8")
         ctx.agent_config = ctx.agent_loader.load(fp)
+        logging.config.dictConfig(ctx.agent_config.logging_config)
     except FileNotFoundError:
         logger.error("Agent configuration file '{}' not found in the current directory. "
                      "Aborting...".format(DEFAULT_AEA_CONFIG_FILE))

--- a/aea/cli/list.py
+++ b/aea/cli/list.py
@@ -17,7 +17,7 @@
 #
 # ------------------------------------------------------------------------------
 
-"""Implementation of the 'aea add' subcommand."""
+"""Implementation of the 'aea list' subcommand."""
 
 import click
 

--- a/aea/cli/search.py
+++ b/aea/cli/search.py
@@ -17,7 +17,7 @@
 #
 # ------------------------------------------------------------------------------
 
-"""Implementation of the 'aea add' subcommand."""
+"""Implementation of the 'aea search' subcommand."""
 from pathlib import Path
 
 import click

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -396,7 +396,8 @@ class AgentConfig(Configuration):
                  license: str = "",
                  url: str = "",
                  registry_path: str = "",
-                 private_key_pem_path: str = ""):
+                 private_key_pem_path: str = "",
+                 logging_config: Optional[Dict] = None):
         """Instantiate the agent configuration object."""
         self.agent_name = agent_name
         self.aea_version = aea_version
@@ -406,10 +407,15 @@ class AgentConfig(Configuration):
         self.url = url
         self.registry_path = registry_path
         self.private_key_pem_path = private_key_pem_path
+        self.logging_config = logging_config if logging_config is not None else {}
         self._default_connection = None  # type: Optional[str]
         self.connections = set()  # type: Set[str]
         self.protocols = set()  # type: Set[str]
         self.skills = set()  # type: Set[str]
+
+        if self.logging_config == {}:
+            self.logging_config["version"] = 1
+            self.logging_config["disable_existing_loggers"] = False
 
     @property
     def default_connection(self) -> str:
@@ -439,6 +445,7 @@ class AgentConfig(Configuration):
             "url": self.url,
             "registry_path": self.registry_path,
             "private_key_pem_path": self.private_key_pem_path,
+            "logging_config": self.logging_config,
             "default_connection": self.default_connection,
             "connections": sorted(self.connections),
             "protocols": sorted(self.protocols),
@@ -457,6 +464,7 @@ class AgentConfig(Configuration):
             url=cast(str, obj.get("url")),
             registry_path=cast(str, obj.get("registry_path")),
             private_key_pem_path=cast(str, obj.get("private_key_pem_path")),
+            logging_config=cast(Dict, obj.get("logging_config", {})),
         )
 
         agent_config.connections = set(cast(List[str], obj.get("connections")))

--- a/aea/configurations/schemas/aea-config_schema.json
+++ b/aea/configurations/schemas/aea-config_schema.json
@@ -3,7 +3,19 @@
     "description": "Schema for the agent configuration file.",
     "additionalProperties": false,
     "type": "object",
-    "required": ["aea_version", "agent_name", "authors", "version", "license", "url", "private_key_pem_path", "connections", "default_connection", "protocols", "skills"],
+    "required": [
+        "aea_version",
+        "agent_name",
+        "authors",
+        "version",
+        "license",
+        "url",
+        "private_key_pem_path",
+        "connections",
+        "default_connection",
+        "protocols",
+        "skills"
+    ],
     "properties": {
         "aea_version": {"type": "string"},
         "agent_name": {"type": "string"},
@@ -28,6 +40,9 @@
             "type": "array",
             "uniqueItems": true,
             "items": {"type": "string"}
+        },
+        "logging_config": {
+            "type": "object"
         }
     }
 }

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,81 @@
+## Logging
+
+The framework supports flexible logging capabilities by 
+relying on the standard [Python logging library](https://docs.python.org/3/library/logging.html).
+
+In this tutorial, you'll see how you can configure 
+logging for your agent.
+
+
+First of all, create your agent:
+
+
+``` bash
+aea create my_agent
+cd my_agent
+```
+
+
+The `aea-config.yaml` file should look like:
+```yaml
+aea_version: 0.1.6
+agent_name: my_agent
+authors: ''
+connections:
+- oef
+default_connection: oef
+license: ''
+private_key_pem_path: ''
+protocols:
+- default
+registry_path: ../packages
+skills:
+- error
+url: ''
+version: v1
+logging_config:
+  disable_existing_loggers: false
+  version: 1
+```
+
+By updating the `logging_config` section, you can configure 
+the loggers of your application.
+
+The format of this section is specified in the 
+[`logging.config`](https://docs.python.org/3/library/logging.config.html)
+module.
+At [this section](https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema) 
+you'll find the definition of the configuration dictionary schema.
+
+An example of `logging_config` value is reported below:
+
+```yaml
+logging_config:
+  version: 1
+  disable_existing_loggers: false
+  formatters:
+    standard:
+      format: '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
+  handlers:
+    logfile:
+      class: logging.FileHandler
+      formatter: standard
+      level: DEBUG
+      filename: logconfig.log
+    console:
+      class: logging.StreamHandler
+      formatter: standard
+      level: DEBUG
+  loggers:
+    aea:
+      handlers:
+      - logfile
+      - console
+      level: DEBUG
+      propagate: true
+```
+
+This configuration wiill set up a logger with name `aea`,
+print both on console (see `console` handler) and on file
+(see `logfile` handler) with format specified by the 
+`standard` formatter.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
       - "Protocol": 'protocol.md'
       - "Connection": 'connection.md'
       - "Scaffolding": 'scaffolding.md'
+      - "Logging": 'logging.md'
       - CLI:
          - "CLI tool": 'cli-how-to.md'
          - "Commands": 'cli-commands.md'


### PR DESCRIPTION
## Proposed changes

This PR adds an option to `aea` command: `-l/--logfile log_file_path` It will save the logs of every subcommand of `aea` to the specified file.

## Fixes

Fixes #178 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.