### PR TITLE
Make skill resources 'args' field optional in config file 'skill.yaml'

### DIFF
--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -223,7 +223,7 @@ class HandlerConfig(Configuration):
         class_name = cast(str, obj.get("class_name"))
         return HandlerConfig(
             class_name=class_name,
-            args=obj.get("args")
+            args=obj.get("args", {})
         )
 
 
@@ -249,7 +249,7 @@ class BehaviourConfig(Configuration):
         class_name = cast(str, obj.get("class_name"))
         return BehaviourConfig(
             class_name=class_name,
-            args=obj.get("args")
+            args=obj.get("args", {})
         )
 
 
@@ -275,7 +275,7 @@ class TaskConfig(Configuration):
         class_name = cast(str, obj.get("class_name"))
         return TaskConfig(
             class_name=class_name,
-            args=obj.get("args")
+            args=obj.get("args", {})
         )
 
 
@@ -314,7 +314,7 @@ class SkillConfig(Configuration):
                  version: str = "",
                  license: str = "",
                  url: str = "",
-                 protocols: str = "",
+                 protocols: List[str] = None,
                  dependencies: Optional[List[str]] = None):
         """Initialize a skill configuration."""
         self.name = name
@@ -322,7 +322,7 @@ class SkillConfig(Configuration):
         self.version = version
         self.license = license
         self.url = url
-        self.protocols = protocols
+        self.protocols = protocols if protocols is None else []
         self.dependencies = dependencies
         self.handlers = CRUDCollection[HandlerConfig]()
         self.behaviours = CRUDCollection[BehaviourConfig]()
@@ -354,7 +354,7 @@ class SkillConfig(Configuration):
         version = cast(str, obj.get("version"))
         license = cast(str, obj.get("license"))
         url = cast(str, obj.get("url"))
-        protocols = cast(str, obj.get("protocols"))
+        protocols = cast(List[str], obj.get("protocols", []))
         dependencies = cast(List[str], obj.get("dependencies", []))
         skill_config = SkillConfig(
             name=name,
@@ -366,19 +366,19 @@ class SkillConfig(Configuration):
             dependencies=dependencies
         )
 
-        for b in obj.get("behaviours"):  # type: ignore
+        for b in obj.get("behaviours", []):  # type: ignore
             behaviour_config = BehaviourConfig.from_json(b["behaviour"])
             skill_config.behaviours.create(behaviour_config.class_name, behaviour_config)
 
-        for t in obj.get("tasks"):  # type: ignore
+        for t in obj.get("tasks", []):  # type: ignore
             task_config = TaskConfig.from_json(t["task"])
             skill_config.tasks.create(task_config.class_name, task_config)
 
-        for h in obj.get("handlers"):  # type: ignore
+        for h in obj.get("handlers", []):  # type: ignore
             handler_config = HandlerConfig.from_json(h["handler"])
             skill_config.handlers.create(handler_config.class_name, handler_config)
 
-        for s in obj.get("shared_classes"):  # type: ignore
+        for s in obj.get("shared_classes", []):  # type: ignore
             shared_class_config = SharedClassConfig.from_json(s["shared_class"])
             skill_config.shared_classes.create(shared_class_config.class_name, shared_class_config)
 

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -322,7 +322,7 @@ class SkillConfig(Configuration):
         self.version = version
         self.license = license
         self.url = url
-        self.protocols = protocols if protocols is None else []
+        self.protocols = protocols if protocols is not None else []  # type: List[str]
         self.dependencies = dependencies
         self.handlers = CRUDCollection[HandlerConfig]()
         self.behaviours = CRUDCollection[BehaviourConfig]()

--- a/aea/configurations/schemas/skill-config_schema.json
+++ b/aea/configurations/schemas/skill-config_schema.json
@@ -19,11 +19,13 @@
         "url": {"type": "string"},
         "protocols": {
             "type": "array",
+            "additionalProperties": false,
             "uniqueItems": true,
             "items": {"type": "string"}
         },
         "handlers": {
             "type": "array",
+            "additionalProperties": false,
             "uniqueItems": true,
             "items": {
               "type": "object",
@@ -38,6 +40,7 @@
             "uniqueItems": true,
             "items": {
               "type": "object",
+              "additionalProperties": false,
               "required": ["behaviour"],
               "properties": {
                 "behaviour": { "$ref": "#/definitions/behaviour" }
@@ -49,6 +52,7 @@
             "uniqueItems": true,
             "items": {
               "type": "object",
+              "additionalProperties": false,
               "required": ["task"],
               "properties": {
                 "task": { "$ref": "#/definitions/task" }
@@ -60,7 +64,6 @@
             "uniqueItems": true,
             "items": {
               "type": "object",
-              "required": ["shared_class"],
               "properties": {
                 "task": { "$ref": "#/definitions/shared_class" }
               }
@@ -75,7 +78,8 @@
     "definitions": {
         "behaviour": {
             "type": "object",
-            "required": ["class_name", "args"],
+            "additionalProperties": false,
+            "required": ["class_name"],
             "properties": {
                 "class_name": {"type": "string"},
                 "args": {"type": "object"}
@@ -83,7 +87,8 @@
         },
         "task": {
             "type": "object",
-            "required": ["class_name", "args"],
+            "additionalProperties": false,
+            "required": ["class_name"],
             "properties": {
                 "class_name": {"type": "string"},
                 "args": {"type": "object"}
@@ -91,7 +96,8 @@
         },
         "handler": {
             "type": "object",
-            "required": ["class_name", "args"],
+            "additionalProperties": false,
+            "required": ["class_name"],
             "properties": {
                 "class_name": {"type": "string"},
                 "args": {"type": "object"}
@@ -99,7 +105,8 @@
         },
         "shared_class": {
             "type": "object",
-            "required": ["class_name", "args"],
+            "additionalProperties": false,
+            "required": ["class_name"],
             "properties": {
                 "class_name": {"type": "string"},
                 "args": {"type": "object"}

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -482,14 +482,29 @@ class Skill:
 
         skill_context = SkillContext(agent_context)
 
-        handlers_configurations = list(dict(skill_config.handlers.read_all()).values())
-        handlers = Handler.parse_module(os.path.join(directory, "handlers.py"), handlers_configurations, skill_context)
-        behaviours_configurations = list(dict(skill_config.behaviours.read_all()).values())
-        behaviours = Behaviour.parse_module(os.path.join(directory, "behaviours.py"), behaviours_configurations, skill_context)
-        tasks_configurations = list(dict(skill_config.tasks.read_all()).values())
-        tasks = Task.parse_module(os.path.join(directory, "tasks.py"), tasks_configurations, skill_context)
-        shared_classes_configurations = list(dict(skill_config.shared_classes.read_all()).values())
-        shared_classes_instances = SharedClass.parse_module(directory, shared_classes_configurations, skill_context)
+        if skill_config.handlers:
+            handlers_configurations = list(dict(skill_config.handlers.read_all()).values())
+            handlers = Handler.parse_module(os.path.join(directory, "handlers.py"), handlers_configurations, skill_context)
+        else:
+            handlers = []
+
+        if skill_config.behaviours:
+            behaviours_configurations = list(dict(skill_config.behaviours.read_all()).values())
+            behaviours = Behaviour.parse_module(os.path.join(directory, "behaviours.py"), behaviours_configurations, skill_context)
+        else:
+            behaviours = []
+
+        if skill_config.tasks:
+            tasks_configurations = list(dict(skill_config.tasks.read_all()).values())
+            tasks = Task.parse_module(os.path.join(directory, "tasks.py"), tasks_configurations, skill_context)
+        else:
+            tasks = []
+
+        if skill_config.shared_classes:
+            shared_classes_configurations = list(dict(skill_config.shared_classes.read_all()).values())
+            shared_classes_instances = SharedClass.parse_module(directory, shared_classes_configurations, skill_context)
+        else:
+            shared_classes_instances = []
 
         skill = Skill(skill_config, skill_context, handlers, behaviours, tasks, shared_classes_instances)
         skill_context._skill = skill

--- a/tests/data/dummy_aea/skills/dummy/skill.yaml
+++ b/tests/data/dummy_aea/skills/dummy/skill.yaml
@@ -6,20 +6,11 @@ url: ""
 behaviours:
   - behaviour:
       class_name: DummyBehaviour
-      args:
-        behaviour_arg_1: 1
-        behaviour_arg_2: "2"
 handlers:
   - handler:
       class_name: DummyHandler
-      args:
-        handler_arg_1: 1
-        handler_arg_2: "2"
 tasks:
   - task:
       class_name: DummyTask
-      args:
-        task_arg_1: 1
-        task_arg_2: "2"
 shared_classes: []
 protocols: ["default"]

--- a/tests/test_cli/test_commands/test_create.py
+++ b/tests/test_cli/test_commands/test_create.py
@@ -122,7 +122,7 @@ class TestCreate:
         agent_config_instance = self._load_config_file()
         assert agent_config_instance["private_key_pem_path"] == ""
 
-    def test_protocols_field_is_empty_list(self):
+    def test_protocols_field_is_not_empty_list(self):
         """Check that the 'protocols' field is a list with the 'default' protocol."""
         agent_config_instance = self._load_config_file()
         assert agent_config_instance["protocols"] == ["default"]


### PR DESCRIPTION
## Proposed changes

This PR makes the fields `args` in  `handler`, `behaviour`, `task`, and `shared_classe` of `skill.yaml` optional.

## Fixes

Fixes #166 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.