### PR TITLE
Load .env file and resolve variable names in .yaml files. 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -35,6 +35,7 @@ jsonschema = "<3.0.0"
 protobuf = "*"
 flask = "*"
 "connexion[swagger-ui]" = "*"
+python-dotenv = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8811658b3ed67cb3b47ff81db7e6414b6f79012dce4cdbf584a033106f59c6fd"
+            "sha256": "839ebf4293fbcbbe03172b8caca6c2909e540b76a6f8ec14f8452df5e0fe240c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -284,6 +284,14 @@
                 "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
             ],
             "version": "==2.19"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:debd928b49dbc2bf68040566f55cdb3252458036464806f4094487244e2a4093",
+                "sha256:f157d71d5fec9d4bd5f51c82746b6344dffa680ee85217c123f4a0c8117c4544"
+            ],
+            "index": "pypi",
+            "version": "==0.10.3"
         },
         "pyyaml": {
             "hashes": [

--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -29,6 +29,7 @@ from typing import Dict, List, cast
 import click
 import click_log
 import jsonschema  # type: ignore
+from dotenv import load_dotenv
 
 from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig, SkillConfig, ConnectionConfig, ProtocolConfig, \
     DEFAULT_PROTOCOL_CONFIG_FILE, DEFAULT_CONNECTION_CONFIG_FILE, DEFAULT_SKILL_CONFIG_FILE
@@ -126,6 +127,16 @@ def _try_to_load_protocols(ctx: Context):
         except FileNotFoundError:
             logger.error("Protocol {} not found in registry".format(protocol_name))
             exit(-1)
+
+
+def _load_env_file(env_file: str):
+    """
+    Load the content of the environment file into the process environment.
+
+    :param env_file: path to the env file.
+    :return: None.
+    """
+    load_dotenv(dotenv_path=Path(env_file), override=False)
 
 
 class AEAConfigException(Exception):

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -30,7 +30,7 @@ import click
 from click import pass_context
 
 from aea.aea import AEA
-from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config, _try_to_load_protocols, \
+from aea.cli.common import Context, logger, _try_to_load_agent_config, _try_to_load_protocols, \
     AEAConfigException, _load_env_file
 from aea.cli.install import install
 from aea.connections.base import Connection

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -31,7 +31,7 @@ import click
 
 from aea.aea import AEA
 from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config, _try_to_load_protocols, \
-    AEAConfigException
+    AEAConfigException, _load_env_file
 from aea.connections.base import Connection
 from aea.crypto.base import Crypto
 from aea.crypto.helpers import _try_validate_private_key_pem_path, _create_temporary_private_key_pem_path
@@ -86,6 +86,7 @@ def _setup_connection(connection_name: str, public_key: str, ctx: Context) -> Co
 def run(ctx: Context, connection_name: str, env_file: str):
     """Run the agent."""
     _try_to_load_agent_config(ctx)
+    _load_env_file(env_file)
     agent_name = cast(str, ctx.agent_config.agent_name)
     private_key_pem_path = cast(str, ctx.agent_config.private_key_pem_path)
     if private_key_pem_path == "":

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -80,8 +80,10 @@ def _setup_connection(connection_name: str, public_key: str, ctx: Context) -> Co
 @click.command()
 @click.option('--connection', 'connection_name', metavar="CONN_NAME", type=str, required=False, default=None,
               help="The connection name. Must be declared in the agent's configuration file.")
+@click.option('--env', 'env_file', type=str, required=False, default=".env",
+              help="Specify an environment file (default: .env)")
 @pass_ctx
-def run(ctx: Context, connection_name: str):
+def run(ctx: Context, connection_name: str, env_file: str):
     """Run the agent."""
     _try_to_load_agent_config(ctx)
     agent_name = cast(str, ctx.agent_config.agent_name)

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -80,7 +80,7 @@ def _setup_connection(connection_name: str, public_key: str, ctx: Context) -> Co
 @click.command()
 @click.option('--connection', 'connection_name', metavar="CONN_NAME", type=str, required=False, default=None,
               help="The connection name. Must be declared in the agent's configuration file.")
-@click.option('--env', 'env_file', type=str, required=False, default=".env",
+@click.option('--env', 'env_file', type=click.Path(), required=False, default=".env",
               help="Specify an environment file (default: .env)")
 @pass_ctx
 def run(ctx: Context, connection_name: str, env_file: str):

--- a/aea/configurations/loader.py
+++ b/aea/configurations/loader.py
@@ -77,7 +77,7 @@ def _config_loader():
     envvar_matcher = re.compile(r'\${([^}^{]+)\}')
 
     def envvar_constructor(loader, node):
-        """Extract the matched value, expand env variable, and replace the match"""
+        """Extract the matched value, expand env variable, and replace the match."""
         node_value = node.value
         match = envvar_matcher.match(node_value)
         env_var = match.group()[2:-1]
@@ -91,5 +91,6 @@ def _config_loader():
 
     yaml.add_implicit_resolver('!envvar', envvar_matcher, None, SafeLoader)
     yaml.add_constructor('!envvar', envvar_constructor, SafeLoader)
+
 
 _config_loader()

--- a/aea/configurations/loader.py
+++ b/aea/configurations/loader.py
@@ -22,12 +22,14 @@
 import inspect
 import json
 import os
+import re
 from pathlib import Path
 from typing import TextIO, Type, TypeVar, Generic
 
 import jsonschema
 import yaml
 from jsonschema import Draft4Validator
+from yaml import SafeLoader
 
 from aea.configurations.base import AgentConfig, SkillConfig, ConnectionConfig, ProtocolConfig
 
@@ -69,3 +71,25 @@ class ConfigLoader(Generic[T]):
         result = configuration.json
         self.validator.validate(instance=result)
         yaml.safe_dump(result, fp)
+
+
+def _config_loader():
+    envvar_matcher = re.compile(r'\${([^}^{]+)\}')
+
+    def envvar_constructor(loader, node):
+        """Extract the matched value, expand env variable, and replace the match"""
+        node_value = node.value
+        match = envvar_matcher.match(node_value)
+        env_var = match.group()[2:-1]
+
+        # check for defaults
+        var_name, default_value = env_var.split(":")
+        var_name = var_name.strip()
+        default_value = default_value.strip()
+        var_value = os.getenv(var_name, default_value)
+        return var_value + node_value[match.end():]
+
+    yaml.add_implicit_resolver('!envvar', envvar_matcher, None, SafeLoader)
+    yaml.add_constructor('!envvar', envvar_constructor, SafeLoader)
+
+_config_loader()

--- a/aea/connections/oef/connection.yaml
+++ b/aea/connections/oef/connection.yaml
@@ -6,8 +6,8 @@ url: ""
 class_name: OEFConnection
 supported_protocols: ["oef"]
 config:
-  addr: 127.0.0.1
-  port: 10000
+  addr: ${OEF_ADDR:127.0.0.1}
+  port: ${OEF_PORT:10000}
 dependencies:
   - colorlog
   - oef

--- a/mypy.ini
+++ b/mypy.ini
@@ -33,6 +33,9 @@ ignore_missing_imports = True
 [mypy-jsonschema]
 ignore_missing_imports = True
 
+[mypy-dotenv]
+ignore_missing_imports = True
+
 # Per-module options for examples dir:
 
 [mypy-numpy]

--- a/setup.py
+++ b/setup.py
@@ -52,20 +52,18 @@ def get_aea_extras() -> Dict[str, List[str]]:
 
 
 def get_all_extras() -> Dict:
-    extras = {
-        "cli": [
-            "click",
-            "click_log",
-            "PyYAML",
-            "jsonschema<3.0.0",
-            "protobuf"
-        ],
-        "cli_gui": [
+    cli_deps = [
             "click",
             "click_log",
             "PyYAML",
             "jsonschema<3.0.0",
             "protobuf",
+            "python-dotenv"
+        ]
+    extras = {
+        "cli": cli_deps,
+        "cli_gui": [
+            *cli_deps,
             "flask",
             "connexion[swagger-ui]"
         ],


### PR DESCRIPTION
## Proposed changes

This PR adds the following two features:
- makes the configuration loader to resolve environment variables by using the process environment. In particular, it allows for variables in the following format: `${VAR_NAME:default_value}`. E.g.: `${OEF_ADDR:127.0.0.1}`.
- let the user load an environment file when doing `aea run --env ENV_FILE_PATH`. By default, the `ENV_FILE_PATH` is `.env`.

### How to test

First of all, do `aea create myagent` and then `cd myagent`.
Notice that in `connection.yaml` the field `config` contains:
```
config:
  addr: ${OEF_ADDR:127.0.0.1}
  port: ${OEF_PORT:10000}
```

Then, assuming an OEF node is listening at `127.0.0.1:10000`, all the following approaches should work:
1. `aea -v DEBUG run`  gives the output:
```
...
do connected finished
on_connect_ok[139647330480928]  127.0.0.1:10000
```

2. `OEF_ADDR=localhost aea -v DEBUG run`  gives the output:
```
...
do connected finished
on_connect_ok[139647330480928]  localhost:10000
```
notice that `127.0.0.1` has been replaced with `localhost`

3. now create a `.env` file with this content:
```
OEF_ADDR=localhost
OEF_PORT=10000
```
running `aea -v DEBUG run` (or, equivalently, `aea -v DEBUG run --env .env`) gives:
```
...
do connected finished
on_connect_ok[139647330480928]  localhost:10000
```

4. If you try to replace the value of the port with 10001, you should get:
```
...
on_connect_fail[140448189927208]  localhost:10001  =>  [Errno 111] Connect call failed ('127.0.0.1', 10001)
```

## Fixes

Fixes #179 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Notice: the environment gets loaded only when `aea run` is executed, and *not* when the agent is built through the code.