### PR TITLE
Enforce good resource names at schema level

### DIFF
--- a/aea/cli_gui/__main__.py
+++ b/aea/cli_gui/__main__.py
@@ -23,4 +23,3 @@ import aea.cli_gui
 # If we're running in stand alone mode, run the application
 if __name__ == '__main__':
     aea.cli_gui.run()
-

--- a/aea/configurations/schemas/aea-config_schema.json
+++ b/aea/configurations/schemas/aea-config_schema.json
@@ -39,13 +39,13 @@
         "connections": {
             "type": "array",
             "uniqueItems": true,
-            "items": {"type": "string"}
+            "items": {"$ref": "definitions.json#/definitions/resource_name"}
         },
         "default_connection": {"type": "string"},
         "protocols": {
             "type": "array",
             "uniqueItems": true,
-            "items": {"type": "string"}
+            "items": {"$ref": "definitions.json#/definitions/resource_name"}
         },
         "skills": {
             "type": "array",

--- a/aea/configurations/schemas/connection-config_schema.json
+++ b/aea/configurations/schemas/connection-config_schema.json
@@ -14,7 +14,7 @@
         "config"
     ],
     "properties": {
-        "name": {"type": "string"},
+        "name": {"$ref": "definitions.json#/definitions/resource_name"},
         "authors": {"type": "string"},
         "version": {"type": "string"},
         "license": {"type": "string"},

--- a/aea/configurations/schemas/definitions.json
+++ b/aea/configurations/schemas/definitions.json
@@ -6,6 +6,10 @@
     "requirement": {
       "type": "string",
       "pattern": "([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])( *(~=|==|>=|<=|!=|<|>) *v?(?:(?:(?P<epoch>[0-9]+)!)?(?P<release>[0-9]+(?:\\.[0-9]+)*)(?P<pre>[-_\\.]?(?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))[-_\\.]?(?P<pre_n>[0-9]+)?)?(?P<post>(?:-(?P<post_n1>[0-9]+))|(?:[-_\\.]?(?P<post_l>post|rev|r)[-_\\.]?(?P<post_n2>[0-9]+)?))?(?P<dev>[-_\\.]?(?P<dev_l>dev)[-_\\.]?(?P<dev_n>[0-9]+)?)?)(?:\\+(?P<local>[a-z0-9]+(?:[-_\\.][a-z0-9]+)*))?)?$"
+    },
+    "resource_name": {
+      "type": "string",
+      "pattern": "[a-zA-Z_][a-zA-Z0-9_]*"
     }
   }
 }

--- a/aea/configurations/schemas/protocol-config_schema.json
+++ b/aea/configurations/schemas/protocol-config_schema.json
@@ -11,7 +11,7 @@
         "url"
     ],
     "properties": {
-        "name": {"type": "string"},
+        "name": {"$ref": "definitions.json#/definitions/resource_name"},
         "authors": {"type": "string"},
         "version": {"type": "string"},
         "license": {"type": "string"},

--- a/aea/configurations/schemas/skill-config_schema.json
+++ b/aea/configurations/schemas/skill-config_schema.json
@@ -12,7 +12,7 @@
         "protocols"
     ],
     "properties": {
-        "name": {"type": "string"},
+        "name": {"$ref": "definitions.json#/definitions/resource_name"},
         "authors": {"type": "string"},
         "version": {"type": "string"},
         "license": {"type": "string"},

--- a/aea/connections/scaffold/connection.yaml
+++ b/aea/connections/scaffold/connection.yaml
@@ -1,4 +1,4 @@
-name: scaffold
+name: scaffold_connection
 authors: Fetch.AI Limited
 version: 0.1.0
 license: Apache 2.0

--- a/aea/protocols/scaffold/protocol.yaml
+++ b/aea/protocols/scaffold/protocol.yaml
@@ -1,4 +1,4 @@
-name: 'my_scaffold_protocol'
+name: 'scaffold_protocol'
 authors: Fetch.AI Limited
 version: 0.1.0
 license: Apache 2.0

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -487,26 +487,30 @@ class Skill:
 
         skill_context = SkillContext(agent_context)
 
-        if skill_config.handlers:
-            handlers_configurations = list(dict(skill_config.handlers.read_all()).values())
+        handlers_by_id = skill_config.handlers.read_all()
+        if len(handlers_by_id) > 0:
+            handlers_configurations = list(dict(handlers_by_id).values())
             handlers = Handler.parse_module(os.path.join(directory, "handlers.py"), handlers_configurations, skill_context)
         else:
             handlers = []
 
-        if skill_config.behaviours:
-            behaviours_configurations = list(dict(skill_config.behaviours.read_all()).values())
+        behaviours_by_id = skill_config.behaviours.read_all()
+        if len(behaviours_by_id) > 0:
+            behaviours_configurations = list(dict(behaviours_by_id).values())
             behaviours = Behaviour.parse_module(os.path.join(directory, "behaviours.py"), behaviours_configurations, skill_context)
         else:
             behaviours = []
 
-        if skill_config.tasks:
-            tasks_configurations = list(dict(skill_config.tasks.read_all()).values())
+        tasks_by_id = skill_config.tasks.read_all()
+        if len(tasks_by_id) > 0:
+            tasks_configurations = list(dict(tasks_by_id).values())
             tasks = Task.parse_module(os.path.join(directory, "tasks.py"), tasks_configurations, skill_context)
         else:
             tasks = []
 
-        if skill_config.shared_classes:
-            shared_classes_configurations = list(dict(skill_config.shared_classes.read_all()).values())
+        shared_classes_by_id = skill_config.shared_classes.read_all()
+        if len(shared_classes_by_id) > 0:
+            shared_classes_configurations = list(dict(shared_classes_by_id).values())
             shared_classes_instances = SharedClass.parse_module(directory, shared_classes_configurations, skill_context)
         else:
             shared_classes_instances = []

--- a/aea/skills/scaffold/skill.yaml
+++ b/aea/skills/scaffold/skill.yaml
@@ -1,4 +1,4 @@
-name: ''
+name: scaffold_skill
 authors: Fetch.AI Limited
 version: 0.1.0
 license: Apache 2.0

--- a/packages/protocols/tac/serialization.py
+++ b/packages/protocols/tac/serialization.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from packages.protocols.tac import tac_pb2
     from packages.protocols.tac.message import TACMessage
 else:
-    from tac_protocol import tac_pb2
+    import tac_protocol.tac_pb2 as tac_pb2
     from tac_protocol.message import TACMessage
 
 

--- a/packages/skills/tac/game.py
+++ b/packages/skills/tac/game.py
@@ -146,8 +146,9 @@ class GameConfiguration:
 class Game(SharedClass):
     """This class deals with the game."""
 
-    def __init__(self, expected_version_id: str, expected_controller_pbk: Optional[Address] = None):
+    def __init__(self, expected_version_id: str, expected_controller_pbk: Optional[Address] = None, **kwargs):
         """Instantiate the game class."""
+        super().__init__(**kwargs)
         self._expected_version_id = expected_version_id
         self._game_phase = GamePhase.PRE_GAME
         self._expected_controller_pbk = expected_controller_pbk

--- a/packages/skills/tac/handlers.py
+++ b/packages/skills/tac/handlers.py
@@ -50,6 +50,7 @@ class OEFHandler(Handler):
 
     def __init__(self, **kwargs):
         """Initialize the echo behaviour."""
+        super().__init__(**kwargs)
         self._rejoin = False
 
     def setup(self) -> None:

--- a/packages/skills/tac/search.py
+++ b/packages/skills/tac/search.py
@@ -27,8 +27,9 @@ from aea.skills.base import SharedClass
 class Search(SharedClass):
     """This class deals with the search state."""
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """Instantiate the search class."""
+        super().__init__(*args, **kwargs)
         self._id = 0
         self.ids_for_tac = set()  # type: Set[int]
 

--- a/packages/skills/tac/skill.yaml
+++ b/packages/skills/tac/skill.yaml
@@ -1,4 +1,4 @@
-name: ''
+name: tac
 authors: Fetch.AI Limited
 version: 0.1.0
 license: Apache 2.0

--- a/tests/test_cli/test_commands/test_create.py
+++ b/tests/test_cli/test_commands/test_create.py
@@ -32,13 +32,14 @@ import jsonschema
 import pytest
 import yaml
 from click.testing import CliRunner
+from jsonschema import Draft4Validator
 
 import aea
 import aea.cli.common
 from aea.cli import cli
 from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE
 from aea.configurations.loader import ConfigLoader
-from ...conftest import AGENT_CONFIGURATION_SCHEMA, ROOT_DIR
+from ...conftest import AGENT_CONFIGURATION_SCHEMA, ROOT_DIR, CONFIGURATION_SCHEMA_DIR
 
 
 class TestCreate:
@@ -47,6 +48,10 @@ class TestCreate:
     @classmethod
     def setup_class(cls):
         """Set the test up."""
+        cls.schema = json.load(open(AGENT_CONFIGURATION_SCHEMA))
+        cls.resolver = jsonschema.RefResolver("file://{}/".format(Path(CONFIGURATION_SCHEMA_DIR).absolute()), cls.schema)
+        cls.validator = Draft4Validator(cls.schema, resolver=cls.resolver)
+
         cls.runner = CliRunner()
         cls.agent_name = "myagent"
         cls.cwd = os.getcwd()
@@ -80,10 +85,8 @@ class TestCreate:
     def test_configuration_file_is_compliant_to_schema(self):
         """Check that the agent's configuration file is compliant with the schema."""
         agent_config_instance = self._load_config_file()
-        agent_config_schema = json.load(open(AGENT_CONFIGURATION_SCHEMA))
-
         try:
-            jsonschema.validate(instance=agent_config_instance, schema=agent_config_schema)
+            self.validator.validate(instance=agent_config_instance)
         except jsonschema.exceptions.ValidationError as e:
             pytest.fail("Configuration file is not compliant with the schema. Exception: {}".format(str(e)))
 

--- a/tests/test_cli/test_schema.py
+++ b/tests/test_cli/test_schema.py
@@ -20,7 +20,6 @@
 """This test module contains the tests for the JSON schemas of the configuration files."""
 import json
 import os
-import pprint
 from pathlib import Path
 
 import jsonschema
@@ -54,10 +53,9 @@ def test_connection_configuration_schema_is_valid_wrt_draft_07():
 
 def test_validate_agent_config():
     """Test that the validation of the agent configuration file works correctly."""
-    agent_config_schema = json.load(open(AGENT_CONFIGURATION_SCHEMA))
     agent_config_file = yaml.safe_load(open(os.path.join(CUR_PATH, "data", "aea-config.example.yaml")))
-    schema_dir = Path(ROOT_DIR, "aea", "configurations", "schemas").absolute()
-    resolver = jsonschema.RefResolver("file://{}/".format(schema_dir), agent_config_schema)
+    agent_config_schema = json.load(open(AGENT_CONFIGURATION_SCHEMA))
+    resolver = jsonschema.RefResolver("file://{}/".format(CONFIGURATION_SCHEMA_DIR), agent_config_schema)
     validate(instance=agent_config_file, schema=agent_config_schema, resolver=resolver)
 
 

--- a/tests/test_cli/test_schema.py
+++ b/tests/test_cli/test_schema.py
@@ -56,8 +56,9 @@ def test_validate_agent_config():
     """Test that the validation of the agent configuration file works correctly."""
     agent_config_schema = json.load(open(AGENT_CONFIGURATION_SCHEMA))
     agent_config_file = yaml.safe_load(open(os.path.join(CUR_PATH, "data", "aea-config.example.yaml")))
-    pprint.pprint(agent_config_file)
-    validate(instance=agent_config_file, schema=agent_config_schema)
+    schema_dir = Path(ROOT_DIR, "aea", "configurations", "schemas").absolute()
+    resolver = jsonschema.RefResolver("file://{}/".format(schema_dir), agent_config_schema)
+    validate(instance=agent_config_file, schema=agent_config_schema, resolver=resolver)
 
 
 class TestProtocolsSchema:


### PR DESCRIPTION
## Proposed changes

Fix an importing issue in the `tac` skill/protocol.

Also, fix a more general issue of the framework. In particular:
- enforce at schema level the resource names to be at least of length `1`
- enforce at schema level the resource names to be compatible as Python module names.

## Fixes

None.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None/