### PR TITLE
make 'cli_gui' depend on 'cli' and not the other way around.

### DIFF
--- a/aea/cli/__main__.py
+++ b/aea/cli/__main__.py
@@ -40,7 +40,6 @@ from aea.cli.run import run
 from aea.cli.scaffold import scaffold
 from aea.cli.search import search
 from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig
-import aea.cli_gui
 
 DEFAULT_CONNECTION = "oef"
 DEFAULT_SKILL = "error"
@@ -127,6 +126,7 @@ def freeze(ctx: Context):
 @pass_ctx
 def gui(ctx: Context):
     """Run the CLI GUI."""
+    import aea.cli_gui
     logger.info("Running the GUI.....(press Ctrl+C to exit)")
     aea.cli_gui.run()
 

--- a/setup.py
+++ b/setup.py
@@ -66,19 +66,19 @@ def get_all_extras() -> Dict:
         *ethereum_deps
     ]
 
-    cli_gui = [
-        "flask",
-        "connexion[swagger-ui]==2018.0.dev1"
-    ]
-
     cli_deps = [
         "click",
         "click_log",
         "PyYAML",
         "jsonschema",
         "python-dotenv",
-        *cli_gui,
         *crypto_deps
+    ]
+
+    cli_gui = [
+        "flask",
+        "connexion[swagger-ui] @ git+https://github.com/neverpanic/connexion.git@jsonschema-3#egg=connexion[swagger-ui]",
+        *cli_deps
     ]
 
     extras = {
@@ -129,9 +129,6 @@ setup(
         *all_extras.get("crypto", []),
         *all_extras.get("cli", []),
         *all_extras.get("oef_connection", []),
-    ],
-    dependency_links=[
-        'git+https://github.com/neverpanic/connexion.git@jsonschema-3#egg=connexion[swagger-ui]',
     ],
     tests_require=["tox"],
     extras_require=all_extras,


### PR DESCRIPTION
## Proposed changes

make 'cli_gui' extra depend on 'cli' and not the other way around.

In this way, we have `cli_gui` as an extra (installable through `pip install aea[cli_gui]`).
This will let us to include `"connexion[swagger-ui] @ git+https://github.com/neverpanic/connexion.git@jsonschema-3#egg=connexion[swagger-ui]"` as an (extra) direct dependency and hence allow the release to PyPI.

## Fixes

None.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.