### PR TITLE
Put log messages to stdout with default config.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,13 +28,12 @@ base58 = "*"
 docker = "*"
 click = "*"
 pyyaml = ">=4.2b1"
-click-log = "*"
 oef = {index = "test-pypi",version = "==0.6.10"}
 colorlog = "*"
 jsonschema = "*"
 protobuf = "*"
 flask = "*"
-connexion = {git = "https://github.com/neverpanic/connexion.git", editable = true, ref = "jsonschema-3"}
+connexion = {git = "https://github.com/neverpanic/connexion.git",editable = true,ref = "jsonschema-3"}
 watchdog = "*"
 python-dotenv = "*"
 fetchai-ledger-api = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f1e84c9d1a2d43fb29b340be13d1731f89700fe09e4afc06222ef2e60efa40a9"
+            "sha256": "eeff9998b99b29ddb9eafda38d9f37c6493fc54c6a63333cdb8945c31e7f30f9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -44,10 +44,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:ec20e7a4825331c1b5ebf261d111e16fa9612c1f7a5e1f884f12bd53a664dfd2",
-                "sha256:f913492e1663d3c36f502e5e9ba6cd13cf19d7fab50aa13239e420fef95e1396"
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
-            "version": "==19.2.0"
+            "version": "==19.3.0"
         },
         "base58": {
             "hashes": [
@@ -67,36 +67,34 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:041c81822e9f84b1d9c401182e174996f0bae9991f33725d059b771744290774",
-                "sha256:046ef9a22f5d3eed06334d01b1e836977eeef500d9b78e9ef693f9380ad0b83d",
-                "sha256:066bc4c7895c91812eff46f4b1c285220947d4aa46fa0a2651ff85f2afae9c90",
-                "sha256:066c7ff148ae33040c01058662d6752fd73fbc8e64787229ea8498c7d7f4041b",
-                "sha256:2444d0c61f03dcd26dbf7600cf64354376ee579acad77aef459e34efcb438c63",
-                "sha256:300832850b8f7967e278870c5d51e3819b9aad8f0a2c8dbe39ab11f119237f45",
-                "sha256:34c77afe85b6b9e967bd8154e3855e847b70ca42043db6ad17f26899a3df1b25",
-                "sha256:46de5fa00f7ac09f020729148ff632819649b3e05a007d286242c4882f7b1dc3",
-                "sha256:4aa8ee7ba27c472d429b980c51e714a24f47ca296d53f4d7868075b175866f4b",
-                "sha256:4d0004eb4351e35ed950c14c11e734182591465a33e960a4ab5e8d4f04d72647",
-                "sha256:4e3d3f31a1e202b0f5a35ba3bc4eb41e2fc2b11c1eff38b362de710bcffb5016",
-                "sha256:50bec6d35e6b1aaeb17f7c4e2b9374ebf95a8975d57863546fa83e8d31bdb8c4",
-                "sha256:55cad9a6df1e2a1d62063f79d0881a414a906a6962bc160ac968cc03ed3efcfb",
-                "sha256:5662ad4e4e84f1eaa8efce5da695c5d2e229c563f9d5ce5b0113f71321bcf753",
-                "sha256:59b4dc008f98fc6ee2bb4fd7fc786a8d70000d058c2bbe2698275bc53a8d3fa7",
-                "sha256:73e1ffefe05e4ccd7bcea61af76f36077b914f92b76f95ccf00b0c1b9186f3f9",
-                "sha256:a1f0fd46eba2d71ce1589f7e50a9e2ffaeb739fb2c11e8192aa2b45d5f6cc41f",
-                "sha256:a2e85dc204556657661051ff4bab75a84e968669765c8a2cd425918699c3d0e8",
-                "sha256:a5457d47dfff24882a21492e5815f891c0ca35fefae8aa742c6c263dac16ef1f",
-                "sha256:a8dccd61d52a8dae4a825cdbb7735da530179fea472903eb871a5513b5abbfdc",
-                "sha256:ae61af521ed676cf16ae94f30fe202781a38d7178b6b4ab622e4eec8cefaff42",
-                "sha256:b012a5edb48288f77a63dba0840c92d0504aa215612da4541b7b42d849bc83a3",
-                "sha256:d2c5cfa536227f57f97c92ac30c8109688ace8fa4ac086d19d0af47d134e2909",
-                "sha256:d42b5796e20aacc9d15e66befb7a345454eef794fdb0737d1af593447c6c8f45",
-                "sha256:dee54f5d30d775f525894d67b1495625dd9322945e7fee00731952e0368ff42d",
-                "sha256:e070535507bd6aa07124258171be2ee8dfc19119c28ca94c9dfb7efd23564512",
-                "sha256:e1ff2748c84d97b065cc95429814cdba39bcbd77c9c85c89344b317dc0d9cbff",
-                "sha256:ed851c75d1e0e043cbf5ca9a8e1b13c4c90f3fbd863dacb01c0808e2b5204201"
+                "sha256:1112d2fc92a867a6103bce6740a549e74b1d320cf28875609f6e93857eee4f2d",
+                "sha256:1b9ab50c74e075bd2ae489853c5f7f592160b379df53b7f72befcbe145475a36",
+                "sha256:24eff2997436b6156c2f30bed215c782b1d8fd8c6a704206053c79af95962e45",
+                "sha256:2eff642fbc9877a6449026ad66bf37c73bf4232505fb557168ba5c502f95999b",
+                "sha256:362e896cea1249ed5c2a81cf6477fabd9e1a5088aa7ea08358a4c6b0998294d2",
+                "sha256:40eddb3589f382cb950f2dcf1c39c9b8d7bd5af20665ce273815b0d24635008b",
+                "sha256:5ed40760976f6b8613d4a0db5e423673ca162d4ed6c9ed92d1f4e58a47ee01b5",
+                "sha256:6f19c9df4785305669335b934c852133faed913c0faa63056248168966f7a7d5",
+                "sha256:719537b4c5cd5218f0f47826dd705fb7a21d83824920088c4214794457113f3f",
+                "sha256:7b0e337a70e58f1a36fb483fd63880c9e74f1db5c532b4082bceac83df1523fa",
+                "sha256:853376efeeb8a4ae49a737d5d30f5db8cdf01d9319695719c4af126488df5a6a",
+                "sha256:85bbf77ffd12985d76a69d2feb449e35ecdcb4fc54a5f087d2bd54158ae5bb0c",
+                "sha256:8978115c6f0b0ce5880bc21c967c65058be8a15f1b81aa5fdbdcbea0e03952d1",
+                "sha256:8f7eec920bc83692231d7306b3e311586c2e340db2dc734c43c37fbf9c981d24",
+                "sha256:8fe230f612c18af1df6f348d02d682fe2c28ca0a6c3856c99599cdacae7cf226",
+                "sha256:b57e1c8bcdd7340e9c9d09613b5e7fdd0c600be142f04e2cc1cc8cb7c0b43529",
+                "sha256:ba956c9b44646bc1852db715b4a252e52a8f5a4009b57f1dac48ba3203a7bde1",
+                "sha256:ca42034c11eb447497ea0e7b855d87ccc2aebc1e253c22e7d276b8599c112a27",
+                "sha256:dc9b2003e9a62bbe0c84a04c61b0329e86fccd85134a78d7aca373bbbf788165",
+                "sha256:e77cd105b19b8cd721d101687fcf665fd1553eb7b57556a1ef0d453b6fc42faa",
+                "sha256:f56dff1bd81022f1c980754ec721fb8da56192b026f17f0f99b965da5ab4fbd2",
+                "sha256:fa4cc13c03ea1d0d37ce8528e0ecc988d2365e8ac64d8d86cafab4038cb4ce89",
+                "sha256:fa8cf1cb974a9f5911d2a0303f6adc40625c05578d8e7ff5d313e1e27850bd59",
+                "sha256:fb003019f06d5fc0aa4738492ad8df1fa343b8a37cbcf634018ad78575d185df",
+                "sha256:fd409b7778167c3bcc836484a8f49c0e0b93d3e745d975749f83aa5d18a5822f",
+                "sha256:fe5d65a3ee38122003245a82303d11ac05ff36531a8f5ce4bc7d4bbc012797e1"
             ],
-            "version": "==1.12.3"
+            "version": "==1.13.0"
         },
         "chardet": {
             "hashes": [
@@ -112,14 +110,6 @@
             ],
             "index": "pypi",
             "version": "==7.0"
-        },
-        "click-log": {
-            "hashes": [
-                "sha256:16fd1ca3fc6b16c98cea63acf1ab474ea8e676849dc669d86afafb0ed7003124",
-                "sha256:eee14dc37cdf3072158570f00406572f9e03e414accdccfccd4c538df9ae322c"
-            ],
-            "index": "pypi",
-            "version": "==0.3.2"
         },
         "clickclick": {
             "hashes": [
@@ -647,10 +637,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:ec20e7a4825331c1b5ebf261d111e16fa9612c1f7a5e1f884f12bd53a664dfd2",
-                "sha256:f913492e1663d3c36f502e5e9ba6cd13cf19d7fab50aa13239e420fef95e1396"
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
-            "version": "==19.2.0"
+            "version": "==19.3.0"
         },
         "certifi": {
             "hashes": [

--- a/aea/cli/__main__.py
+++ b/aea/cli/__main__.py
@@ -26,7 +26,6 @@ from pathlib import Path
 from typing import cast
 
 import click
-import click_log
 from click import pass_context
 from jsonschema import ValidationError
 
@@ -35,6 +34,7 @@ from aea.cli.add import connection, add, skill
 from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config, DEFAULT_REGISTRY_PATH
 from aea.cli.install import install
 from aea.cli.list import list as _list
+from aea.cli.loggers import simple_verbosity_option
 from aea.cli.remove import remove
 from aea.cli.run import run
 from aea.cli.scaffold import scaffold
@@ -49,7 +49,7 @@ DEFAULT_SKILL = "error"
 @click.group()
 @click.version_option('0.1.0')
 @click.pass_context
-@click_log.simple_verbosity_option(logger, default="INFO")
+@simple_verbosity_option(logger, default="INFO")
 def cli(ctx) -> None:
     """Command-line tool for setting up an Autonomous Economic Agent."""
     ctx.obj = Context(cwd=".")

--- a/aea/cli/__main__.py
+++ b/aea/cli/__main__.py
@@ -40,7 +40,6 @@ from aea.cli.run import run
 from aea.cli.scaffold import scaffold
 from aea.cli.search import search
 from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig
-import aea.cli_gui
 
 DEFAULT_CONNECTION = "oef"
 DEFAULT_SKILL = "error"
@@ -48,8 +47,8 @@ DEFAULT_SKILL = "error"
 
 @click.group()
 @click.version_option('0.1.0')
-@click.pass_context
 @simple_verbosity_option(logger, default="INFO")
+@click.pass_context
 def cli(ctx) -> None:
     """Command-line tool for setting up an Autonomous Economic Agent."""
     ctx.obj = Context(cwd=".")
@@ -127,6 +126,7 @@ def freeze(ctx: Context):
 @pass_ctx
 def gui(ctx: Context):
     """Run the CLI GUI."""
+    import aea.cli_gui
     logger.info("Running the GUI.....(press Ctrl+C to exit)")
     aea.cli_gui.run()
 

--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -28,16 +28,16 @@ from pathlib import Path
 from typing import Dict, List, cast
 
 import click
-import click_log
 import jsonschema  # type: ignore
 from dotenv import load_dotenv
 
+from aea.cli.loggers import default_logging_config
 from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig, SkillConfig, ConnectionConfig, ProtocolConfig, \
     DEFAULT_PROTOCOL_CONFIG_FILE, DEFAULT_CONNECTION_CONFIG_FILE, DEFAULT_SKILL_CONFIG_FILE
 from aea.configurations.loader import ConfigLoader
 
 logger = logging.getLogger("aea")
-logger = click_log.basic_config(logger=logger)
+logger = default_logging_config(logger)
 
 DEFAULT_REGISTRY_PATH = "../packages"
 

--- a/aea/cli/loggers.py
+++ b/aea/cli/loggers.py
@@ -23,8 +23,10 @@ import sys
 
 import click
 
+OFF = 100
+logging.addLevelName(OFF, "OFF")
 
-LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+LOG_LEVELS = ["NOTSET", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "OFF"]
 
 
 class ColorFormatter(logging.Formatter):
@@ -70,12 +72,8 @@ def simple_verbosity_option(logger=None, *names, **kwargs):
 
     def decorator(f):
         def _set_level(ctx, param, value):
-            x = getattr(logging, value.upper(), None)
-            if x is None:
-                raise click.BadParameter(
-                    'Must be CRITICAL, ERROR, WARNING, INFO or DEBUG, not {}'
-                )
-            logger.setLevel(x)
+            level = logging.getLevelName(value)
+            logger.setLevel(level)
 
         return click.option(*names, callback=_set_level, **kwargs)(f)
     return decorator

--- a/aea/cli/loggers.py
+++ b/aea/cli/loggers.py
@@ -24,6 +24,9 @@ import sys
 import click
 
 
+LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+
+
 class ColorFormatter(logging.Formatter):
     """The default formatter for cli output."""
 
@@ -59,9 +62,10 @@ def simple_verbosity_option(logger=None, *names, **kwargs):
         names = ['--verbosity', '-v']
 
     kwargs.setdefault('default', 'INFO')
+    kwargs.setdefault('type', click.Choice(LOG_LEVELS, case_sensitive=False))
     kwargs.setdefault('metavar', 'LVL')
     kwargs.setdefault('expose_value', False)
-    kwargs.setdefault('help', 'Either CRITICAL, ERROR, WARNING, INFO or DEBUG')
+    kwargs.setdefault('help', 'One of {}'.format(", ".join(LOG_LEVELS)))
     kwargs.setdefault('is_eager', True)
 
     def decorator(f):

--- a/aea/cli/loggers.py
+++ b/aea/cli/loggers.py
@@ -55,7 +55,7 @@ class ColorFormatter(logging.Formatter):
 
 
 def simple_verbosity_option(logger=None, *names, **kwargs):
-    """A decorator that adds a `--verbosity, -v` option to the decoratedcommand.
+    """Add a decorator that adds a `--verbosity, -v` option to the decorated command.
 
     Name can be configured through `*names`. Keyword arguments are passed to
     the underlying `click.option` decorator.

--- a/aea/cli/loggers.py
+++ b/aea/cli/loggers.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Helpers for the logging module."""
+import logging
+import sys
+
+import click
+
+
+class ColorFormatter(logging.Formatter):
+    """The default formatter for cli output."""
+
+    colors = {
+        'error': dict(fg='red'),
+        'exception': dict(fg='red'),
+        'critical': dict(fg='red'),
+        'debug': dict(fg='blue'),
+        'info': dict(fg='green'),
+        'warning': dict(fg='yellow')
+    }
+
+    def format(self, record):
+        if not record.exc_info:
+            level = record.levelname.lower()
+            msg = record.getMessage()
+            if level in self.colors:
+                prefix = click.style('{}: '.format(level),
+                                     **self.colors[level])
+                msg = '\n'.join(prefix + x for x in msg.splitlines())
+            return msg
+        return logging.Formatter.format(self, record)
+
+
+def simple_verbosity_option(logger=None, *names, **kwargs):
+    """
+    A decorator that adds a `--verbosity, -v` option to the decorated
+    command.
+
+    Name can be configured through ``*names``. Keyword arguments are passed to
+    the underlying ``click.option`` decorator.
+    """
+    if not names:
+        names = ['--verbosity', '-v']
+
+    kwargs.setdefault('default', 'INFO')
+    kwargs.setdefault('metavar', 'LVL')
+    kwargs.setdefault('expose_value', False)
+    kwargs.setdefault('help', 'Either CRITICAL, ERROR, WARNING, INFO or DEBUG')
+    kwargs.setdefault('is_eager', True)
+
+    def decorator(f):
+        def _set_level(ctx, param, value):
+            x = getattr(logging, value.upper(), None)
+            if x is None:
+                raise click.BadParameter(
+                    'Must be CRITICAL, ERROR, WARNING, INFO or DEBUG, not {}'
+                )
+            logger.setLevel(x)
+
+        return click.option(*names, callback=_set_level, **kwargs)(f)
+    return decorator
+
+
+def default_logging_config(logger):
+    """Set up the default handler and formatter on the given logger."""
+    default_handler = logging.StreamHandler(stream=sys.stdout)
+    default_handler.formatter = ColorFormatter()
+    logger.handlers = [default_handler]
+    logger.propagate = True
+    return logger

--- a/aea/cli/loggers.py
+++ b/aea/cli/loggers.py
@@ -37,6 +37,7 @@ class ColorFormatter(logging.Formatter):
     }
 
     def format(self, record):
+        """Format the log message."""
         if not record.exc_info:
             level = record.levelname.lower()
             msg = record.getMessage()
@@ -49,12 +50,10 @@ class ColorFormatter(logging.Formatter):
 
 
 def simple_verbosity_option(logger=None, *names, **kwargs):
-    """
-    A decorator that adds a `--verbosity, -v` option to the decorated
-    command.
+    """A decorator that adds a `--verbosity, -v` option to the decoratedcommand.
 
-    Name can be configured through ``*names``. Keyword arguments are passed to
-    the underlying ``click.option`` decorator.
+    Name can be configured through `*names`. Keyword arguments are passed to
+    the underlying `click.option` decorator.
     """
     if not names:
         names = ['--verbosity', '-v']

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ def get_all_extras() -> Dict:
 
     cli_deps = [
         "click",
-        "click_log",
         "PyYAML",
         "jsonschema",
         "python-dotenv",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 
 CUR_PATH = os.path.dirname(inspect.getfile(inspect.currentframe()))  # type: ignore
 ROOT_DIR = os.path.join(CUR_PATH, "..")
+CLI_LOG_OPTION = ["-v", "OFF"]
 
 CONFIGURATION_SCHEMA_DIR = os.path.join(ROOT_DIR, "aea", "configurations", "schemas")
 AGENT_CONFIGURATION_SCHEMA = os.path.join(CONFIGURATION_SCHEMA_DIR, "aea-config_schema.json")

--- a/tests/test_aea.py
+++ b/tests/test_aea.py
@@ -138,7 +138,7 @@ def test_handle():
     try:
         t.start()
         agent.mailbox.inbox._queue.put(envelope)
-        env = agent.mailbox.outbox._queue.get(block=True, timeout=5.0)
+        env = agent.mailbox.outbox._queue.get(block=True, timeout=10.0)
         assert env.protocol_id == "default", \
             "The envelope is not the expected protocol (Unsupported protocol)"
 

--- a/tests/test_cli/test_commands/test_add/test_connection.py
+++ b/tests/test_cli/test_commands/test_add/test_connection.py
@@ -31,6 +31,7 @@ import aea
 import aea.cli.common
 import aea.configurations.base
 from aea.cli import cli
+from tests.conftest import CLI_LOG_OPTION
 
 
 class TestAddConnectionFailsWhenConnectionAlreadyExists:
@@ -48,14 +49,14 @@ class TestAddConnectionFailsWhenConnectionAlreadyExists:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
         # add connection first time
-        result = cls.runner.invoke(cli, ["add", "connection", cls.connection_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", cls.connection_name])
         assert result.exit_code == 0
         # add connection again
-        cls.result = cls.runner.invoke(cli, ["add", "connection", cls.connection_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", cls.connection_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
@@ -94,10 +95,10 @@ class TestAddConnectionFailsWhenConnectionNotInRegistry:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
-        cls.result = cls.runner.invoke(cli, ["add", "connection", cls.connection_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", cls.connection_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
@@ -136,7 +137,7 @@ class TestAddConnectionFailsWhenConfigFileIsNotCompliant:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
 
         # change the serialization of the AgentConfig class so to make the parsing to fail.
@@ -145,7 +146,7 @@ class TestAddConnectionFailsWhenConfigFileIsNotCompliant:
         cls.patch.__enter__()
 
         os.chdir(cls.agent_name)
-        cls.result = cls.runner.invoke(cli, ["add", "connection", cls.connection_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", cls.connection_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
@@ -184,12 +185,12 @@ class TestAddConnectionFailsWhenDirectoryAlreadyExists:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
 
         os.chdir(cls.agent_name)
         Path("connections", cls.connection_name).mkdir(parents=True, exist_ok=True)
-        cls.result = cls.runner.invoke(cli, ["add", "connection", cls.connection_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", cls.connection_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""

--- a/tests/test_cli/test_commands/test_add/test_protocol.py
+++ b/tests/test_cli/test_commands/test_add/test_protocol.py
@@ -31,6 +31,7 @@ import aea
 import aea.cli.common
 import aea.configurations.base
 from aea.cli import cli
+from tests.conftest import CLI_LOG_OPTION
 
 
 class TestAddProtocolFailsWhenProtocolAlreadyExists:
@@ -48,12 +49,12 @@ class TestAddProtocolFailsWhenProtocolAlreadyExists:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
-        result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "protocol", cls.protocol_name])
         assert result.exit_code == 0
-        cls.result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "protocol", cls.protocol_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
@@ -92,10 +93,10 @@ class TestAddProtocolFailsWhenProtocolNotInRegistry:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
-        cls.result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "protocol", cls.protocol_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
@@ -134,7 +135,7 @@ class TestAddProtocolFailsWhenConfigFileIsNotCompliant:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
 
         # change the serialization of the ProtocolConfig class so to make the parsing to fail.
@@ -143,7 +144,7 @@ class TestAddProtocolFailsWhenConfigFileIsNotCompliant:
         cls.patch.__enter__()
 
         os.chdir(cls.agent_name)
-        cls.result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "protocol", cls.protocol_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
@@ -182,12 +183,12 @@ class TestAddProtocolFailsWhenDirectoryAlreadyExists:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
 
         os.chdir(cls.agent_name)
         Path("protocols", cls.protocol_name).mkdir(parents=True, exist_ok=True)
-        cls.result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "protocol", cls.protocol_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""

--- a/tests/test_cli/test_commands/test_add/test_skill.py
+++ b/tests/test_cli/test_commands/test_add/test_skill.py
@@ -32,7 +32,7 @@ import aea
 import aea.cli.common
 from aea.cli import cli
 from aea.configurations.base import AgentConfig, DEFAULT_AEA_CONFIG_FILE
-from ....conftest import ROOT_DIR
+from ....conftest import ROOT_DIR, CLI_LOG_OPTION
 
 
 class TestAddSkillFailsWhenSkillAlreadyExists:
@@ -50,7 +50,7 @@ class TestAddSkillFailsWhenSkillAlreadyExists:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         # this also by default adds the oef connection and error skill
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
@@ -61,7 +61,7 @@ class TestAddSkillFailsWhenSkillAlreadyExists:
         yaml.safe_dump(config.json, open(DEFAULT_AEA_CONFIG_FILE, "w"))
 
         # add the error skill again
-        cls.result = cls.runner.invoke(cli, ["add", "skill", cls.skill_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", cls.skill_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
@@ -100,10 +100,10 @@ class TestAddSkillFailsWhenSkillNotInRegistry:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
-        cls.result = cls.runner.invoke(cli, ["add", "skill", cls.skill_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", cls.skill_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
@@ -142,7 +142,7 @@ class TestAddSkillFailsWhenConfigFileIsNotCompliant:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
 
@@ -156,7 +156,7 @@ class TestAddSkillFailsWhenConfigFileIsNotCompliant:
                                                side_effect=ValidationError("test error message"))
         cls.patch.__enter__()
 
-        cls.result = cls.runner.invoke(cli, ["add", "skill", cls.skill_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", cls.skill_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
@@ -195,7 +195,7 @@ class TestAddSkillFailsWhenDirectoryAlreadyExists:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
 
@@ -205,7 +205,7 @@ class TestAddSkillFailsWhenDirectoryAlreadyExists:
         yaml.safe_dump(config.json, open(DEFAULT_AEA_CONFIG_FILE, "w"))
 
         Path("skills", cls.skill_name).mkdir(parents=True, exist_ok=True)
-        cls.result = cls.runner.invoke(cli, ["add", "skill", cls.skill_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", cls.skill_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""

--- a/tests/test_cli/test_commands/test_create.py
+++ b/tests/test_cli/test_commands/test_create.py
@@ -39,7 +39,7 @@ import aea.cli.common
 from aea.cli import cli
 from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE
 from aea.configurations.loader import ConfigLoader
-from ...conftest import AGENT_CONFIGURATION_SCHEMA, ROOT_DIR, CONFIGURATION_SCHEMA_DIR
+from ...conftest import AGENT_CONFIGURATION_SCHEMA, ROOT_DIR, CONFIGURATION_SCHEMA_DIR, CLI_LOG_OPTION
 
 
 class TestCreate:
@@ -57,7 +57,7 @@ class TestCreate:
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
         os.chdir(cls.t)
-        cls.result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
 
     def _load_config_file(self) -> Dict:
         """Load a config file."""
@@ -191,7 +191,7 @@ class TestCreateFailsWhenDirectoryAlreadyExists:
 
         # create a directory with the agent name -> make 'aea create fail.
         os.mkdir(cls.agent_name)
-        cls.result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the error code is equal to -1."""
@@ -233,7 +233,7 @@ class TestCreateFailsWhenConfigFileIsNotCompliant:
         cls.t = tempfile.mkdtemp()
         os.chdir(cls.t)
 
-        cls.result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the error code is equal to -1."""
@@ -271,7 +271,7 @@ class TestCreateFailsWhenExceptionOccurs:
         cls.t = tempfile.mkdtemp()
         os.chdir(cls.t)
 
-        cls.result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the error code is equal to -1."""

--- a/tests/test_cli/test_commands/test_delete.py
+++ b/tests/test_cli/test_commands/test_delete.py
@@ -29,6 +29,7 @@ from click.testing import CliRunner
 import aea
 import aea.cli.common
 from aea.cli import cli
+from tests.conftest import CLI_LOG_OPTION
 
 
 class TestDelete:
@@ -43,8 +44,8 @@ class TestDelete:
         cls.t = tempfile.mkdtemp()
         os.chdir(cls.t)
 
-        cls.runner.invoke(cli, ["create", cls.agent_name])
-        cls.result = cls.runner.invoke(cli, ["delete", cls.agent_name])
+        cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "delete", cls.agent_name])
 
     def test_exit_code_equal_to_zero(self):
         """Assert that the exit code is equal to zero (i.e. success)."""
@@ -81,7 +82,7 @@ class TestDeleteFailsWhenDirectoryDoesNotExist:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         # agent's directory does not exist -> command will fail.
-        cls.result = cls.runner.invoke(cli, ["delete", cls.agent_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "delete", cls.agent_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the error code is equal to -1."""

--- a/tests/test_cli/test_commands/test_remove/test_connection.py
+++ b/tests/test_cli/test_commands/test_remove/test_connection.py
@@ -32,6 +32,7 @@ import aea.cli.common
 import aea.configurations.base
 from aea.cli import cli
 from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE
+from tests.conftest import CLI_LOG_OPTION
 
 
 class TestRemoveConnection:
@@ -49,12 +50,12 @@ class TestRemoveConnection:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
-        result = cls.runner.invoke(cli, ["add", "connection", cls.connection_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", cls.connection_name])
         assert result.exit_code == 0
-        cls.result = cls.runner.invoke(cli, ["remove", "connection", cls.connection_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "remove", "connection", cls.connection_name])
 
     def test_exit_code_equal_to_zero(self):
         """Test that the exit code is equal to minus 1."""
@@ -94,11 +95,11 @@ class TestRemoveConnectionFailsWhenConnectionDoesNotExist:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
 
-        cls.result = cls.runner.invoke(cli, ["remove", "connection", cls.connection_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "remove", "connection", cls.connection_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
@@ -137,16 +138,16 @@ class TestRemoveConnectionFailsWhenExceptionOccurs:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
-        result = cls.runner.invoke(cli, ["add", "connection", cls.connection_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", cls.connection_name])
         assert result.exit_code == 0
 
         cls.patch = unittest.mock.patch("shutil.rmtree", side_effect=BaseException("an exception"))
         cls.patch.__enter__()
 
-        cls.result = cls.runner.invoke(cli, ["remove", "connection", cls.connection_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "remove", "connection", cls.connection_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""

--- a/tests/test_cli/test_commands/test_remove/test_protocol.py
+++ b/tests/test_cli/test_commands/test_remove/test_protocol.py
@@ -32,6 +32,7 @@ import aea.cli.common
 import aea.configurations.base
 from aea.cli import cli
 from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE
+from tests.conftest import CLI_LOG_OPTION
 
 
 class TestRemoveProtocol:
@@ -49,12 +50,12 @@ class TestRemoveProtocol:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
-        result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "protocol", cls.protocol_name])
         assert result.exit_code == 0
-        cls.result = cls.runner.invoke(cli, ["remove", "protocol", cls.protocol_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "remove", "protocol", cls.protocol_name])
 
     def test_exit_code_equal_to_zero(self):
         """Test that the exit code is equal to minus 1."""
@@ -94,11 +95,11 @@ class TestRemoveProtocolFailsWhenProtocolDoesNotExist:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
 
-        cls.result = cls.runner.invoke(cli, ["remove", "protocol", cls.protocol_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "remove", "protocol", cls.protocol_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
@@ -137,16 +138,16 @@ class TestRemoveProtocolFailsWhenExceptionOccurs:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
-        result = cls.runner.invoke(cli, ["add", "protocol", cls.protocol_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "protocol", cls.protocol_name])
         assert result.exit_code == 0
 
         cls.patch = unittest.mock.patch("shutil.rmtree", side_effect=BaseException("an exception"))
         cls.patch.__enter__()
 
-        cls.result = cls.runner.invoke(cli, ["remove", "protocol", cls.protocol_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "remove", "protocol", cls.protocol_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""

--- a/tests/test_cli/test_commands/test_remove/test_skill.py
+++ b/tests/test_cli/test_commands/test_remove/test_skill.py
@@ -32,7 +32,7 @@ import aea.cli.common
 import aea.configurations.base
 from aea.cli import cli
 from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig
-from ....conftest import ROOT_DIR
+from ....conftest import ROOT_DIR, CLI_LOG_OPTION
 
 
 class TestRemoveSkill:
@@ -50,7 +50,7 @@ class TestRemoveSkill:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
 
@@ -59,9 +59,9 @@ class TestRemoveSkill:
         config.registry_path = os.path.join(ROOT_DIR, "packages")
         yaml.safe_dump(config.json, open(DEFAULT_AEA_CONFIG_FILE, "w"))
 
-        result = cls.runner.invoke(cli, ["add", "skill", cls.skill_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", cls.skill_name])
         assert result.exit_code == 0
-        cls.result = cls.runner.invoke(cli, ["remove", "skill", cls.skill_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "remove", "skill", cls.skill_name])
 
     def test_exit_code_equal_to_zero(self):
         """Test that the exit code is equal to minus 1."""
@@ -101,11 +101,11 @@ class TestRemoveSkillFailsWhenSkillIsNotSupported:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
 
-        cls.result = cls.runner.invoke(cli, ["remove", "skill", cls.skill_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "remove", "skill", cls.skill_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""
@@ -144,7 +144,7 @@ class TestRemoveSkillFailsWhenExceptionOccurs:
         cls.mocked_logger_error = cls.patch.__enter__()
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(cli, ["create", cls.agent_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name])
         assert result.exit_code == 0
         os.chdir(cls.agent_name)
 
@@ -153,13 +153,13 @@ class TestRemoveSkillFailsWhenExceptionOccurs:
         config.registry_path = os.path.join(ROOT_DIR, "packages")
         yaml.safe_dump(config.json, open(DEFAULT_AEA_CONFIG_FILE, "w"))
 
-        result = cls.runner.invoke(cli, ["add", "skill", cls.skill_name])
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", cls.skill_name])
         assert result.exit_code == 0
 
         cls.patch = unittest.mock.patch("shutil.rmtree", side_effect=BaseException("an exception"))
         cls.patch.__enter__()
 
-        cls.result = cls.runner.invoke(cli, ["remove", "skill", cls.skill_name])
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "remove", "skill", cls.skill_name])
 
     def test_exit_code_equal_to_minus_1(self):
         """Test that the exit code is equal to minus 1."""


### PR DESCRIPTION

## Proposed changes

Put log messages to stdout with default config.

this change implied removing the 'click_log' dependency and
reimplementing part of the functionalities that the package provided.

## Fixes

fixes #236 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None