### PR TITLE
Fix `connexion[swagger-ui]` direct url dependency 

### DIFF
--- a/aea/cli/__main__.py
+++ b/aea/cli/__main__.py
@@ -126,7 +126,20 @@ def freeze(ctx: Context):
 @pass_ctx
 def gui(ctx: Context):
     """Run the CLI GUI."""
-    import aea.cli_gui  # pragma: no cover
+    try:
+        import aea.cli_gui  # pragma: no cover
+    except ImportError:
+        msg = """Please install aea[cli_gui] extension to use this feature:
+    
+    pip install aea[cli_gui]
+            
+Also, run the following:
+
+    pip install git+https://github.com/neverpanic/connexion.git@2f0d92b#egg=connexion[swagger-ui]
+         
+"""
+        logger.error(msg)
+        exit(-1)
     logger.info("Running the GUI.....(press Ctrl+C to exit)")   # pragma: no cover
     aea.cli_gui.run()   # pragma: no cover
 

--- a/aea/cli/__main__.py
+++ b/aea/cli/__main__.py
@@ -126,9 +126,9 @@ def freeze(ctx: Context):
 @pass_ctx
 def gui(ctx: Context):
     """Run the CLI GUI."""
-    try:
+    try:  # pragma: no cover
         import aea.cli_gui  # pragma: no cover
-    except ImportError:
+    except ImportError:  # pragma: no cover
         msg = """Please install aea[cli_gui] extension to use this feature:
     
     pip install aea[cli_gui]
@@ -138,8 +138,8 @@ Also, run the following:
     pip install git+https://github.com/neverpanic/connexion.git@2f0d92b#egg=connexion[swagger-ui]
          
 """
-        logger.error(msg)
-        exit(-1)
+        logger.error(msg)  # pragma: no cover
+        exit(-1)  # pragma: no cover
     logger.info("Running the GUI.....(press Ctrl+C to exit)")   # pragma: no cover
     aea.cli_gui.run()   # pragma: no cover
 

--- a/docs/cli-gui.md
+++ b/docs/cli-gui.md
@@ -14,7 +14,7 @@ pip install aea[cli_gui]
 Additionally, install the following revision of the `connexion` package:
 
 ```bash
-pip install git+https://github.com/neverpanic/connexion.git@jsonschema-3#egg=connexion[swagger-ui] 
+pip install git+https://github.com/neverpanic/connexion.git@2f0d92b#egg=connexion[swagger-ui] 
 ```
 
 ## Starting the GUI

--- a/docs/cli-gui.md
+++ b/docs/cli-gui.md
@@ -6,6 +6,11 @@ These instructions will take you through building an agent, starting an OEF Node
 
 Ensure you have the framework installed and the CLI is working by following the [quick-start guide](quickstart.md). 
 
+Please install the extra dependency for the CLI GUI:
+```python
+pip install aea[cli_gui]
+```
+
 Additionally, install the following revision of the `connexion` package:
 
 ```bash

--- a/docs/cli-gui.md
+++ b/docs/cli-gui.md
@@ -6,6 +6,12 @@ These instructions will take you through building an agent, starting an OEF Node
 
 Ensure you have the framework installed and the CLI is working by following the [quick-start guide](quickstart.md). 
 
+Additionally, install the following revision of the `connexion` package:
+
+```bash
+pip install git+https://github.com/neverpanic/connexion.git@jsonschema-3#egg=connexion[swagger-ui] 
+```
+
 ## Starting the GUI
 Go to your working folder, where you want to create new agents. If you followed the quick start guide, this will be in the my_aea directory. Start the local web-server:
 ``` bash

--- a/setup.py
+++ b/setup.py
@@ -71,12 +71,12 @@ def get_all_extras() -> Dict:
         "PyYAML",
         "jsonschema",
         "python-dotenv",
+        "flask",
         *crypto_deps
     ]
 
     cli_gui = [
         "flask",
-        "connexion[swagger-ui] @ git+https://github.com/neverpanic/connexion.git@jsonschema-3#egg=connexion[swagger-ui]",
         *cli_deps
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ def get_all_extras() -> Dict:
         "PyYAML",
         "jsonschema",
         "python-dotenv",
-        "flask",
         *crypto_deps
     ]
 


### PR DESCRIPTION
## Proposed changes

This PR removes the extra dependency `connexion[swagger-ui]` from `setup.py` and ask the user to install the package manually.

## Fixes

None.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.