### PR TITLE
make tests pass with Python 3.6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,13 +37,13 @@ pipeline {
 
                 } // docs
 
-//                 stage('Unit Tests: Python 3.6') {
-//
-//                     steps {
-//                         sh 'tox -e py36 -- --no-integration-tests'
-//                     }
-//
-//                 }  // unit tests: python 3.6
+                stage('Unit Tests: Python 3.6') {
+
+                    steps {
+                        sh 'tox -e py36 -- --no-integration-tests --ci'
+                    }
+
+                }  // unit tests: python 3.6
 
                 stage('Unit Tests: Python 3.7') {
 

--- a/aea/registries/base.py
+++ b/aea/registries/base.py
@@ -146,7 +146,8 @@ class ProtocolRegistry(Registry):
             logger.warning("No protocol found.")
             return
 
-        protocols_packages = list(filter(lambda x: PACKAGE_NAME_REGEX.match(x), protocols_spec.loader.contents()))  # type: ignore
+        loader_contents = [path.name for path in Path(directory, "protocols").iterdir()]
+        protocols_packages = list(filter(lambda x: PACKAGE_NAME_REGEX.match(x), loader_contents))  # type: ignore
         logger.debug("Processing the following protocol package: {}".format(protocols_packages))
         for protocol_name in protocols_packages:
             try:

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -493,7 +493,8 @@ class Skill:
 
         skill_module = importlib.util.module_from_spec(skills_spec)
         sys.modules[skill_config.name + "_skill"] = skill_module
-        skills_packages = list(filter(lambda x: not x.startswith("__"), skills_spec.loader.contents()))  # type: ignore
+        loader_contents = [path.name for path in Path(directory).iterdir()]
+        skills_packages = list(filter(lambda x: not x.startswith("__"), loader_contents))  # type: ignore
         logger.debug("Processing the following skill package: {}".format(skills_packages))
 
         skill_context = SkillContext(agent_context)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ import inspect
 import logging
 import os
 import socket
+import sys
 import time
 from threading import Timer
 from typing import Optional
@@ -224,6 +225,8 @@ def _create_oef_docker_image(oef_addr_, oef_port_) -> Container:
 @pytest.fixture(scope="session")
 def network_node(oef_addr, oef_port, pytestconfig):
     """Network node initialization."""
+    if sys.version_info < (3, 7):
+        pytest.skip("Python version < 3.7 not supported by the OEF.")
     if pytestconfig.getoption("no_integration_tests"):
         pytest.skip('skipped: no OEF running')
         return

--- a/tests/test_cli/test_commands/test_gui.py
+++ b/tests/test_cli/test_commands/test_gui.py
@@ -47,7 +47,7 @@ class TestGui:
         cls.t = tempfile.mkdtemp()
         os.chdir(cls.t)
         cls.proc = subprocess.Popen(["aea", *CLI_LOG_OPTION, "gui"])
-        time.sleep(3.0)
+        time.sleep(5.0)
 
     def test_gui(self, pytestconfig):
         """Test that the gui process has been spawned correctly."""

--- a/tests/test_cli/test_commands/test_run.py
+++ b/tests/test_cli/test_commands/test_run.py
@@ -199,6 +199,10 @@ class TestRunFailsWhenExceptionOccursInSkill:
         assert result.exit_code == 0
 
         os.chdir(Path(cls.t, cls.agent_name))
+
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "local"])
+        assert result.exit_code == 0
+
         shutil.copytree(Path(CUR_PATH, "data", "exception_skill"), Path(cls.t, cls.agent_name, "skills", "exception"))
         config_path = Path(cls.t, cls.agent_name, DEFAULT_AEA_CONFIG_FILE)
         config = yaml.safe_load(open(config_path))
@@ -206,7 +210,7 @@ class TestRunFailsWhenExceptionOccursInSkill:
         yaml.safe_dump(config, open(config_path, "w"))
 
         try:
-            cli.main([*CLI_LOG_OPTION, "run"])
+            cli.main([*CLI_LOG_OPTION, "run", "--connection", "local"])
         except SystemExit as e:
             cls.exit_code = e.code
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # envlist = flake8, mypy, py37, py36, docs
-envlist = flake8, mypy, py37, docs
+envlist = flake8, mypy, py37, py36, docs
 skipsdist = True
 ignore_basepython_conflict = True
 


### PR DESCRIPTION
## Proposed changes

make tests pass with Python 3.6.

Tests that use `oef` SDK must be skipped because it seems there's a compatibility problem.

## Fixes

Fixes #139 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.