### PR TITLE
add pipeline timeout to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,10 @@ pipeline {
 
     }
 
+    options {
+        timeout(time: 2, unit: 'HOURS')
+    }
+
     stages {
 
         stage('Unit Tests & Code Style Check') {


### PR DESCRIPTION
## Proposed changes

Proposing to add a pipeline timeout of 2 hours to ensure that Jenkins job will abort after a finite amount of time and not block execution slots.

## Fixes

* 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

*