### PR TITLE
Support new fipa performatives in oef connection, fixes #250

### DIFF
--- a/aea/connections/oef/connection.py
+++ b/aea/connections/oef/connection.py
@@ -452,6 +452,10 @@ class OEFChannel(OEFAgent, Channel):
             self.send_accept(id, dialogue_id, destination, target)
         elif performative == FIPAMessage.Performative.DECLINE:
             self.send_decline(id, dialogue_id, destination, target)
+        elif performative == FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS or \
+                performative == FIPAMessage.Performative.ACCEPT_W_ADDRESS or \
+                performative == FIPAMessage.Performative.INFORM:
+            self.send_default_message(envelope)
         else:
             raise ValueError("OEF FIPA message not recognized.")  # pragma: no cover
 

--- a/tests/test_connections/test_oef/test_communication.py
+++ b/tests/test_connections/test_oef/test_communication.py
@@ -381,7 +381,7 @@ class TestFIPA:
         assert returned_accept_w_address == accept_w_address
 
     def test_inform(self):
-        """Test that an accept with address can be sent correctly."""
+        """Test that an inform can be sent correctly."""
         payload = {'foo': 'bar'}
         json_data = json.dumps(payload)
         inform = FIPAMessage(message_id=0,

--- a/tests/test_connections/test_oef/test_communication.py
+++ b/tests/test_connections/test_oef/test_communication.py
@@ -18,6 +18,7 @@
 # ------------------------------------------------------------------------------
 
 """This test module contains the tests for the OEF communication using an OEF."""
+import json
 import logging
 import time
 from queue import Queue
@@ -348,6 +349,53 @@ class TestFIPA:
         envelope = self.mailbox2.inbox.get(block=True, timeout=2.0)
         expected_decline = FIPASerializer().decode(envelope.message)
         assert expected_decline == decline
+
+    def test_match_accept_w_address(self):
+        """Test that a match accept with address can be sent correctly."""
+        match_accept_w_address = FIPAMessage(message_id=0,
+                                             dialogue_id=0,
+                                             target=0,
+                                             performative=FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS,
+                                             address='my_address')
+        self.mailbox1.outbox.put_message(to=self.crypto2.public_key,
+                                         sender=self.crypto1.public_key,
+                                         protocol_id=FIPAMessage.protocol_id,
+                                         message=FIPASerializer().encode(match_accept_w_address))
+        envelope = self.mailbox2.inbox.get(block=True, timeout=2.0)
+        returned_match_accept_w_address = FIPASerializer().decode(envelope.message)
+        assert returned_match_accept_w_address == match_accept_w_address
+
+    def test_accept_w_address(self):
+        """Test that an accept with address can be sent correctly."""
+        accept_w_address = FIPAMessage(message_id=0,
+                                       dialogue_id=0,
+                                       target=0,
+                                       performative=FIPAMessage.Performative.ACCEPT_W_ADDRESS,
+                                       address='my_address')
+        self.mailbox1.outbox.put_message(to=self.crypto2.public_key,
+                                         sender=self.crypto1.public_key,
+                                         protocol_id=FIPAMessage.protocol_id,
+                                         message=FIPASerializer().encode(accept_w_address))
+        envelope = self.mailbox2.inbox.get(block=True, timeout=2.0)
+        returned_accept_w_address = FIPASerializer().decode(envelope.message)
+        assert returned_accept_w_address == accept_w_address
+
+    def test_inform(self):
+        """Test that an accept with address can be sent correctly."""
+        payload = {'foo': 'bar'}
+        json_data = json.dumps(payload)
+        inform = FIPAMessage(message_id=0,
+                             dialogue_id=0,
+                             target=0,
+                             performative=FIPAMessage.Performative.INFORM,
+                             data=json_data.encode("utf-8"))
+        self.mailbox1.outbox.put_message(to=self.crypto2.public_key,
+                                         sender=self.crypto1.public_key,
+                                         protocol_id=FIPAMessage.protocol_id,
+                                         message=FIPASerializer().encode(inform))
+        envelope = self.mailbox2.inbox.get(block=True, timeout=2.0)
+        returned_inform = FIPASerializer().decode(envelope.message)
+        assert returned_inform == inform
 
     def test_serialisation_fipa(self):
         """Tests a Value Error flag for wrong CFP query."""


### PR DESCRIPTION
## Proposed changes

Supports the new FIPA performatives `ACCEPT_W_ADDRESS`, `MATCH_ACCEPT_W_ADDRESS`, `INFORM` in oef connection.

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

-