### PR TITLE
Add is connected status to skill context

### DIFF
--- a/aea/aea.py
+++ b/aea/aea.py
@@ -72,6 +72,7 @@ class AEA(Agent):
                                      self.wallet.public_keys,
                                      self.wallet.addresses,
                                      ledger_apis,
+                                     self.mailbox.is_connected,
                                      self.outbox,
                                      self.decision_maker.message_in_queue,
                                      self.decision_maker.ownership_state,

--- a/aea/context/base.py
+++ b/aea/context/base.py
@@ -34,6 +34,7 @@ class AgentContext:
                  public_keys: Dict[str, str],
                  addresses: Dict[str, str],
                  ledger_apis: LedgerApis,
+                 is_connected: bool,
                  outbox: OutBox,
                  decision_maker_message_queue: Queue,
                  ownership_state: OwnershipState,
@@ -45,6 +46,7 @@ class AgentContext:
         :param agent_name: the agent's name
         :param public_keys: the public keys of the agent
         :param ledger_apis: the ledger apis
+        :param is_connected: the connection status
         :param outbox: the outbox
         :param decision_maker_message_queue: the (in) queue of the decision maker
         :param ownership_state: the ownership state of the agent
@@ -55,6 +57,7 @@ class AgentContext:
         self._public_keys = public_keys
         self._addresses = addresses
         self._ledger_apis = ledger_apis
+        self._is_connected = is_connected
         self._outbox = outbox
         self._decision_maker_message_queue = decision_maker_message_queue
         self._ownership_state = ownership_state
@@ -85,6 +88,11 @@ class AgentContext:
     def public_key(self) -> str:
         """Get the default public key."""
         return self._public_keys['default']
+
+    @property
+    def is_connected(self) -> bool:
+        """Get connection status."""
+        return self._is_connected
 
     @property
     def outbox(self) -> OutBox:

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -79,6 +79,11 @@ class SkillContext:
         return self._agent_context.address
 
     @property
+    def is_connected(self) -> bool:
+        """Get connection status."""
+        return self._agent_context.is_connected
+
+    @property
     def outbox(self) -> OutBox:
         """Get outbox."""
         return self._agent_context.outbox

--- a/tests/test_aea.py
+++ b/tests/test_aea.py
@@ -52,6 +52,7 @@ def test_initialise_AEA():
     ledger_apis = LedgerApis({})
     my_AEA = AEA("Agent0", mailbox1, wallet, ledger_apis, resources=Resources(str(Path(CUR_PATH, "aea"))))
     assert my_AEA.context == my_AEA._context, "Cannot access the Agent's Context"
+    assert not my_AEA.context.is_connected, "AEA should not be connected."
     my_AEA.setup()
     assert my_AEA.resources is not None,\
         "Resources must not be None after setup"


### PR DESCRIPTION
## Proposed changes

Thi PR exposes the connection status to the skill context.

## Fixes

It addresses #358.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

In the future - once we have the multiplexer - we can collect each connection's status in a `ConnectionStatuses` object. Then we can also add additional information, like `reconnection` counts etc.

#358 asks for the ledger api status to also be exposed. However, the entire ledger api is accessible via the context so no further work is required there.