### PR TITLE
Adds services updating on OEF to all skills

### DIFF
--- a/packages/skills/weather_station/behaviours.py
+++ b/packages/skills/weather_station/behaviours.py
@@ -19,11 +19,13 @@
 
 """This package contains a scaffold of a behaviour."""
 
+import datetime
 import logging
-from typing import cast, TYPE_CHECKING
+from typing import cast, Optional, TYPE_CHECKING
 
 from aea.skills.base import Behaviour
 from aea.protocols.oef.message import OEFMessage
+from aea.protocols.oef.models import Description
 from aea.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
 
 if TYPE_CHECKING:
@@ -41,8 +43,10 @@ class ServiceRegistrationBehaviour(Behaviour):
 
     def __init__(self, **kwargs):
         """Initialise the behaviour."""
+        self._services_interval = kwargs.pop('services_interval', 30)  # type: int
         super().__init__(**kwargs)
-        self._registered = False
+        self._last_update_time = datetime.datetime.now()  # type: datetime.datetime
+        self._registered_service_description = None  # type: Optional[Description]
 
     def setup(self) -> None:
         """
@@ -50,20 +54,7 @@ class ServiceRegistrationBehaviour(Behaviour):
 
         :return: None
         """
-        if not self._registered:
-            strategy = cast(Strategy, self.context.strategy)
-            desc = strategy.get_service_description()
-            oef_msg_id = strategy.get_next_oef_msg_id()
-            msg = OEFMessage(oef_type=OEFMessage.Type.REGISTER_SERVICE,
-                             id=oef_msg_id,
-                             service_description=desc,
-                             service_id=SERVICE_ID)
-            self.context.outbox.put_message(to=DEFAULT_OEF,
-                                            sender=self.context.agent_public_key,
-                                            protocol_id=OEFMessage.protocol_id,
-                                            message=OEFSerializer().encode(msg))
-            logger.info("[{}]: registering weather station services on OEF.".format(self.context.agent_name))
-            self._registered = True
+        self._register_service()
 
     def act(self) -> None:
         """
@@ -71,7 +62,9 @@ class ServiceRegistrationBehaviour(Behaviour):
 
         :return: None
         """
-        pass
+        if self._is_time_to_update_services():
+            self._unregister_service()
+            self._register_service()
 
     def teardown(self) -> None:
         """
@@ -79,17 +72,56 @@ class ServiceRegistrationBehaviour(Behaviour):
 
         :return: None
         """
-        if self._registered:
-            strategy = cast(Strategy, self.context.strategy)
-            desc = strategy.get_service_description()
-            oef_msg_id = strategy.get_next_oef_msg_id()
-            msg = OEFMessage(oef_type=OEFMessage.Type.UNREGISTER_SERVICE,
-                             id=oef_msg_id,
-                             service_description=desc,
-                             service_id=SERVICE_ID)
-            self.context.outbox.put_message(to=DEFAULT_OEF,
-                                            sender=self.context.agent_public_key,
-                                            protocol_id=OEFMessage.protocol_id,
-                                            message=OEFSerializer().encode(msg))
-            logger.info("[{}]: unregistering weather station services from OEF.".format(self.context.agent_name))
-            self._registered = False
+        self._unregister_service()
+
+    def _register_service(self) -> None:
+        """
+        Register to the OEF Service Directory.
+
+        :return: None
+        """
+        strategy = cast(Strategy, self.context.strategy)
+        desc = strategy.get_service_description()
+        self._registered_service_description = desc
+        oef_msg_id = strategy.get_next_oef_msg_id()
+        msg = OEFMessage(oef_type=OEFMessage.Type.REGISTER_SERVICE,
+                         id=oef_msg_id,
+                         service_description=desc,
+                         service_id=SERVICE_ID)
+        self.context.outbox.put_message(to=DEFAULT_OEF,
+                                        sender=self.context.agent_public_key,
+                                        protocol_id=OEFMessage.protocol_id,
+                                        message=OEFSerializer().encode(msg))
+        logger.info("[{}]: updating weather station services on OEF.".format(self.context.agent_name))
+
+    def _unregister_service(self) -> None:
+        """
+        Unregister service from OEF Service Directory.
+
+        :return: None
+        """
+        strategy = cast(Strategy, self.context.strategy)
+        oef_msg_id = strategy.get_next_oef_msg_id()
+        msg = OEFMessage(oef_type=OEFMessage.Type.UNREGISTER_SERVICE,
+                         id=oef_msg_id,
+                         service_description=self._registered_service_description,
+                         service_id=SERVICE_ID)
+        self.context.outbox.put_message(to=DEFAULT_OEF,
+                                        sender=self.context.agent_public_key,
+                                        protocol_id=OEFMessage.protocol_id,
+                                        message=OEFSerializer().encode(msg))
+        logger.info("[{}]: unregistering weather station services from OEF.".format(self.context.agent_name))
+        self._registered_service_description = None
+
+    def _is_time_to_update_services(self) -> bool:
+        """
+        Check if the agent should update the service directory.
+
+        :return: bool indicating the action
+        """
+        now = datetime.datetime.now()
+        diff = now - self._last_update_time
+        result = diff.total_seconds() > self._services_interval
+        if result:
+            self._last_update_time = now
+        return result

--- a/packages/skills/weather_station/skill.yaml
+++ b/packages/skills/weather_station/skill.yaml
@@ -6,7 +6,8 @@ url: ""
 behaviours:
   - behaviour:
       class_name: ServiceRegistrationBehaviour
-      args: {}
+      args:
+        services_interval: 60
 handlers:
   - handler:
       class_name: FIPAHandler

--- a/packages/skills/weather_station_ledger/behaviours.py
+++ b/packages/skills/weather_station_ledger/behaviours.py
@@ -19,13 +19,15 @@
 
 """This package contains a scaffold of a behaviour."""
 
+import datetime
 import logging
-from typing import cast, TYPE_CHECKING
+from typing import cast, Optional, TYPE_CHECKING
 
 from aea.crypto.ethereum import ETHEREUM
 from aea.crypto.fetchai import FETCHAI
 from aea.skills.base import Behaviour
 from aea.protocols.oef.message import OEFMessage
+from aea.protocols.oef.models import Description
 from aea.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
 
 if TYPE_CHECKING:
@@ -43,8 +45,10 @@ class ServiceRegistrationBehaviour(Behaviour):
 
     def __init__(self, **kwargs):
         """Initialise the behaviour."""
+        self._services_interval = kwargs.pop('services_interval', 30)  # type: int
         super().__init__(**kwargs)
-        self._registered = False
+        self._last_update_time = datetime.datetime.now()  # type: datetime.datetime
+        self._registered_service_description = None  # type: Optional[Description]
 
     def setup(self) -> None:
         """
@@ -66,20 +70,7 @@ class ServiceRegistrationBehaviour(Behaviour):
             else:
                 logger.warning("[{}]: you have no starting balance on ethereum ledger!".format(self.context.agent_name))
 
-        if not self._registered:
-            strategy = cast(Strategy, self.context.strategy)
-            desc = strategy.get_service_description()
-            oef_msg_id = strategy.get_next_oef_msg_id()
-            msg = OEFMessage(oef_type=OEFMessage.Type.REGISTER_SERVICE,
-                             id=oef_msg_id,
-                             service_description=desc,
-                             service_id=SERVICE_ID)
-            self.context.outbox.put_message(to=DEFAULT_OEF,
-                                            sender=self.context.agent_public_key,
-                                            protocol_id=OEFMessage.protocol_id,
-                                            message=OEFSerializer().encode(msg))
-            logger.info("[{}]: registering weather station services on OEF.".format(self.context.agent_name))
-            self._registered = True
+        self._register_service()
 
     def act(self) -> None:
         """
@@ -87,7 +78,9 @@ class ServiceRegistrationBehaviour(Behaviour):
 
         :return: None
         """
-        pass
+        if self._is_time_to_update_services():
+            self._unregister_service()
+            self._register_service()
 
     def teardown(self) -> None:
         """
@@ -103,17 +96,56 @@ class ServiceRegistrationBehaviour(Behaviour):
             balance = self.context.ledger_apis.token_balance(ETHEREUM, cast(str, self.context.agent_addresses.get(ETHEREUM)))
             logger.info("[{}]: ending balance on ethereum ledger={}.".format(self.context.agent_name, balance))
 
-        if self._registered:
-            strategy = cast(Strategy, self.context.strategy)
-            desc = strategy.get_service_description()
-            oef_msg_id = strategy.get_next_oef_msg_id()
-            msg = OEFMessage(oef_type=OEFMessage.Type.UNREGISTER_SERVICE,
-                             id=oef_msg_id,
-                             service_description=desc,
-                             service_id=SERVICE_ID)
-            self.context.outbox.put_message(to=DEFAULT_OEF,
-                                            sender=self.context.agent_public_key,
-                                            protocol_id=OEFMessage.protocol_id,
-                                            message=OEFSerializer().encode(msg))
-            logger.info("[{}]: unregistering weather station services from OEF.".format(self.context.agent_name))
-            self._registered = False
+        self._unregister_service()
+
+    def _register_service(self) -> None:
+        """
+        Register to the OEF Service Directory.
+
+        :return: None
+        """
+        strategy = cast(Strategy, self.context.strategy)
+        desc = strategy.get_service_description()
+        self._registered_service_description = desc
+        oef_msg_id = strategy.get_next_oef_msg_id()
+        msg = OEFMessage(oef_type=OEFMessage.Type.REGISTER_SERVICE,
+                         id=oef_msg_id,
+                         service_description=desc,
+                         service_id=SERVICE_ID)
+        self.context.outbox.put_message(to=DEFAULT_OEF,
+                                        sender=self.context.agent_public_key,
+                                        protocol_id=OEFMessage.protocol_id,
+                                        message=OEFSerializer().encode(msg))
+        logger.info("[{}]: updating weather station services on OEF.".format(self.context.agent_name))
+
+    def _unregister_service(self) -> None:
+        """
+        Unregister service from OEF Service Directory.
+
+        :return: None
+        """
+        strategy = cast(Strategy, self.context.strategy)
+        oef_msg_id = strategy.get_next_oef_msg_id()
+        msg = OEFMessage(oef_type=OEFMessage.Type.UNREGISTER_SERVICE,
+                         id=oef_msg_id,
+                         service_description=self._registered_service_description,
+                         service_id=SERVICE_ID)
+        self.context.outbox.put_message(to=DEFAULT_OEF,
+                                        sender=self.context.agent_public_key,
+                                        protocol_id=OEFMessage.protocol_id,
+                                        message=OEFSerializer().encode(msg))
+        logger.info("[{}]: unregistering weather station services from OEF.".format(self.context.agent_name))
+        self._registered_service_description = None
+
+    def _is_time_to_update_services(self) -> bool:
+        """
+        Check if the agent should update the service directory.
+
+        :return: bool indicating the action
+        """
+        now = datetime.datetime.now()
+        diff = now - self._last_update_time
+        result = diff.total_seconds() > self._services_interval
+        if result:
+            self._last_update_time = now
+        return result

--- a/packages/skills/weather_station_ledger/skill.yaml
+++ b/packages/skills/weather_station_ledger/skill.yaml
@@ -6,7 +6,8 @@ url: ""
 behaviours:
   - behaviour:
       class_name: ServiceRegistrationBehaviour
-      args: {}
+      args:
+        services_interval: 60
 handlers:
   - handler:
       class_name: FIPAHandler


### PR DESCRIPTION
## Proposed changes

The OEF operates a transient registry (and is error prone). This PR addresses the fact and changes the registration behaviour in the remaining skills such that the agent's services are occasionally update (deregistered/reregistered) on the OEF.

## Fixes

It addresses #391 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

-