### PR TITLE
100% coverage on decision maker

### DIFF
--- a/tests/test_decision_maker/test_base.py
+++ b/tests/test_decision_maker/test_base.py
@@ -344,6 +344,13 @@ class TestDecisionMaker:
                 self.decision_maker.handle(tx_message)
                 assert not self.decision_maker.message_out_queue.empty()
 
+        with mock.patch.object(self.decision_maker.ledger_apis, "token_balance", return_value=1000000):
+            with mock.patch.object(self.decision_maker.ledger_apis, "transfer", return_value="This is a test digest"):
+                with mock.patch("aea.decision_maker.base.GoalPursuitReadiness.Status") as mocked_status:
+                    mocked_status.READY.value = False
+                    self.decision_maker.handle(tx_message)
+                    assert not self.decision_maker.goal_pursuit_readiness.is_ready
+
         tx_message = TransactionMessage(performative=TransactionMessage.Performative.PROPOSE,
                                         skill_id="default",
                                         transaction_id="transaction0",


### PR DESCRIPTION
## Proposed changes

Just added a couple of lines in order to test a logger.warning that we had in the decision_maker.

## Fixes

Nothing

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules