### PR TITLE
Update Agent.stop method with new outbox.put_message semantics.

### DIFF
--- a/aea/agent.py
+++ b/aea/agent.py
@@ -175,13 +175,13 @@ class Agent(ABC):
 
         :return: None
         """
-        logger.debug("[{}]: Stopping message processing...".format(self.name))
         self.liveness._is_stopped = True
-        if self.multiplexer.connection_status.is_connected:
-            self.multiplexer.disconnect()
-
         logger.debug("[{}]: Calling teardown method...".format(self.name))
         self.teardown()
+
+        logger.debug("[{}]: Stopping message processing...".format(self.name))
+        if self.multiplexer.connection_status.is_connected:
+            self.multiplexer.disconnect()
 
     @abstractmethod
     def setup(self) -> None:


### PR DESCRIPTION
## Proposed changes

After the change from `MailBox` to `Multiplexer` (PR # #376 and #422 ), `OutBox.put`
and `OutBox.put_message` are blocking methods if the multiplexer is not running.
However, that casues issues when a skill in a teardown method of some Behaviour tries to use the connection to send the last messages, as it happened in #426.

To fix this problem, the `Agent.start` and `Agent.stop` should initialize and tear down resources in a mirrored way.
That is:
```
Agent.start():
    1) set connections up
    2) set skills up
    3) liveness to True
```

```
Agent.stop():
    3) liveness to False
    2) tear skills down
    1) tear connections down
```

That wasn't the case before this commit. Indeed, the `Agent.stop()` method was:

```
Agent.stop():
    3) liveness to False
    1) tear connections down
    2) tear skills down
```
But if the skills for some reason need the connection up in order to release the resources correctly, this approach might fail.
## Fixes

fixes #426 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that code coverage does not decrease.
- [X] I have checked that the documentation about the `aea cli` tool works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
