### PR TITLE
Fix Echo skill test

### DIFF
--- a/aea/cli/core.py
+++ b/aea/cli/core.py
@@ -125,7 +125,7 @@ def delete(ctx: Context, agent_name):
     finally:
         os.chdir(cwd)
 
-    logger.info("Deleting agent project directory '/{}'...".format(path))
+    logger.info("Deleting agent project directory '{}'...".format(path))
 
     # delete the agent's directory
     try:

--- a/aea/cli/scaffold.py
+++ b/aea/cli/scaffold.py
@@ -29,7 +29,7 @@ from jsonschema import ValidationError
 
 from aea import AEA_DIR
 from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config
-from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE  # noqa: F401
+from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, DEFAULT_CONNECTION_CONFIG_FILE, DEFAULT_PROTOCOL_CONFIG_FILE, DEFAULT_SKILL_CONFIG_FILE  # noqa: F401
 
 
 @click.group()

--- a/aea/cli/scaffold.py
+++ b/aea/cli/scaffold.py
@@ -29,7 +29,7 @@ from jsonschema import ValidationError
 
 from aea import AEA_DIR
 from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config
-from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, DEFAULT_CONNECTION_CONFIG_FILE, DEFAULT_PROTOCOL_CONFIG_FILE, DEFAULT_SKILL_CONFIG_FILE  # noqa: F401
+from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE  # noqa: F401
 
 
 @click.group()

--- a/aea/connections/stub/connection.py
+++ b/aea/connections/stub/connection.py
@@ -122,8 +122,8 @@ class StubConnection(Connection):
         if not input_file_path.exists():
             input_file_path.touch()
 
-        self.input_file = open(input_file_path, "rb+", buffering=1)
-        self.output_file = open(output_file_path, "wb+", buffering=1)
+        self.input_file = open(input_file_path, "rb+")
+        self.output_file = open(output_file_path, "wb+")
 
         self.in_queue = None  # type: Optional[asyncio.Queue]
 

--- a/packages/skills/gym/rl_agent.py
+++ b/packages/skills/gym/rl_agent.py
@@ -20,10 +20,11 @@
 """This contains the rl agent class."""
 
 import logging
-import numpy as np
 import random
 import sys
 from typing import Any, Dict, TYPE_CHECKING
+
+import numpy as np
 
 if TYPE_CHECKING or "pytest" in sys.modules:
     from packages.skills.gym.helpers import RLAgent, ProxyEnv

--- a/packages/skills/gym/tasks.py
+++ b/packages/skills/gym/tasks.py
@@ -29,7 +29,7 @@ from aea.skills.base import Task
 
 if TYPE_CHECKING or "pytest" in sys.modules:
     from packages.skills.gym.helpers import ProxyEnv
-    from packages.skills.gym.rl_agent import MyRLAgent, NB_STEPS, NB_GOODS
+    from packages.skills.gym.rl_agent import MyRLAgent, DEFAULT_NB_STEPS, NB_GOODS
 else:
     from gym_skill.helpers import ProxyEnv
     from gym_skill.rl_agent import MyRLAgent, DEFAULT_NB_STEPS, NB_GOODS

--- a/tests/test_packages/test_skills/test_echo.py
+++ b/tests/test_packages/test_skills/test_echo.py
@@ -30,15 +30,13 @@ from pathlib import Path
 
 import yaml
 
-from aea.configurations.base import SkillConfig, DEFAULT_AEA_CONFIG_FILE, AgentConfig
+from aea.cli import cli
+from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig
 from aea.mail.base import Envelope
 from aea.protocols.default.message import DefaultMessage
 from aea.protocols.default.serialization import DefaultSerializer
-from ...common.click_testing import CliRunner
-
-from aea.cli import cli
-
 from tests.conftest import CLI_LOG_OPTION
+from ...common.click_testing import CliRunner
 
 
 class TestEchoSkill:

--- a/tests/test_packages/test_skills/test_echo.py
+++ b/tests/test_packages/test_skills/test_echo.py
@@ -35,7 +35,7 @@ from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig
 from aea.mail.base import Envelope
 from aea.protocols.default.message import DefaultMessage
 from aea.protocols.default.serialization import DefaultSerializer
-from tests.conftest import CLI_LOG_OPTION
+from ...conftest import CLI_LOG_OPTION, ROOT_DIR
 from ...common.click_testing import CliRunner
 
 
@@ -54,8 +54,8 @@ class TestEchoSkill:
     def test_echo(self, pytestconfig):
         """Run the echo skill sequence."""
         # add packages folder
-        packages_src = os.path.join(self.cwd, 'packages')
-        packages_dst = os.path.join(os.getcwd(), 'packages')
+        packages_src = os.path.join(ROOT_DIR, 'packages')
+        packages_dst = os.path.join(self.t, 'packages')
         shutil.copytree(packages_src, packages_dst)
 
         # create agent
@@ -73,7 +73,8 @@ class TestEchoSkill:
         # disable logging
         aea_config_path = Path(self.t, self.agent_name, DEFAULT_AEA_CONFIG_FILE)
         aea_config = AgentConfig.from_json(yaml.safe_load(open(aea_config_path)))
-        aea_config.logging_config = {"disable_existing_loggers": False, "version": 1}
+        aea_config.logging_config = {"disable_existing_loggers": False, "version": 1,
+                                     "loggers": {"aea.echo_skill": {"level": "CRITICAL"}}}
         yaml.safe_dump(aea_config.json, open(aea_config_path, "w"))
 
         # run the agent

--- a/tests/test_packages/test_skills/test_echo.py
+++ b/tests/test_packages/test_skills/test_echo.py
@@ -28,6 +28,9 @@ import tempfile
 import time
 from pathlib import Path
 
+import yaml
+
+from aea.configurations.base import SkillConfig, DEFAULT_AEA_CONFIG_FILE, AgentConfig
 from aea.mail.base import Envelope
 from aea.protocols.default.message import DefaultMessage
 from aea.protocols.default.serialization import DefaultSerializer
@@ -68,6 +71,12 @@ class TestEchoSkill:
         assert result.exit_code == 0
         result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "stub"], standalone_mode=False)
         assert result.exit_code == 0
+
+        # disable logging
+        aea_config_path = Path(self.t, self.agent_name, DEFAULT_AEA_CONFIG_FILE)
+        aea_config = AgentConfig.from_json(yaml.safe_load(open(aea_config_path)))
+        aea_config.logging_config = {"disable_existing_loggers": False, "version": 1}
+        yaml.safe_dump(aea_config.json, open(aea_config_path, "w"))
 
         # run the agent
         process = subprocess.Popen([

--- a/tests/test_packages/test_skills/test_echo.py
+++ b/tests/test_packages/test_skills/test_echo.py
@@ -119,8 +119,10 @@ class TestEchoSkill:
         assert expected_envelope.protocol_id == actual_envelope.protocol_id
         assert expected_envelope.message == actual_envelope.message
 
+        time.sleep(0.5)
         process.send_signal(signal.SIGINT)
-        process.wait(timeout=5)
+        time.sleep(0.5)
+        process.wait(timeout=20)
 
         assert process.returncode == 0
 

--- a/tests/test_packages/test_skills/test_echo.py
+++ b/tests/test_packages/test_skills/test_echo.py
@@ -81,6 +81,7 @@ class TestEchoSkill:
 
         time.sleep(10.0)
         process.send_signal(signal.SIGINT)
+        time.sleep(2.0)
         process.wait(timeout=20)
 
         assert process.returncode == 0

--- a/tests/test_packages/test_skills/test_gym.py
+++ b/tests/test_packages/test_skills/test_gym.py
@@ -93,7 +93,7 @@ class TestGymSkill:
         ledger_apis = LedgerApis({})
         json_connection_configuration = yaml.safe_load(open(Path(self.t, self.agent_name, "connections", "gym", "connection.yaml")))
         connection = GymConnection.from_config(wallet.public_keys['default'],
-                                                ConnectionConfig.from_json(json_connection_configuration))
+                                               ConnectionConfig.from_json(json_connection_configuration))
         gym_agent = AEA(self.agent_name, [connection], wallet, ledger_apis, resources=Resources(str(Path(self.t, self.agent_name))))
         t = Thread(target=gym_agent.start)
         t.start()

--- a/tests/test_packages/test_skills/test_gym.py
+++ b/tests/test_packages/test_skills/test_gym.py
@@ -18,7 +18,6 @@
 # ------------------------------------------------------------------------------
 
 """This test module contains the integration test for the gym skill."""
-import json
 import os
 import shutil
 import signal
@@ -30,12 +29,10 @@ from pathlib import Path
 
 import yaml
 
-from aea.configurations.base import SkillConfig
-from ...common.click_testing import CliRunner
-
 from aea.cli import cli
-
+from aea.configurations.base import SkillConfig
 from tests.conftest import CLI_LOG_OPTION
+from ...common.click_testing import CliRunner
 
 
 class TestGymSkill:

--- a/tests/test_packages/test_skills/test_gym.py
+++ b/tests/test_packages/test_skills/test_gym.py
@@ -99,7 +99,7 @@ class TestGymSkill:
 
         time.sleep(5.0)
         process.send_signal(signal.SIGINT)
-        process.wait(timeout=5)
+        process.wait(timeout=20)
 
         assert process.returncode == 0
 

--- a/tests/test_packages/test_skills/test_gym.py
+++ b/tests/test_packages/test_skills/test_gym.py
@@ -31,7 +31,7 @@ import yaml
 
 from aea.cli import cli
 from aea.configurations.base import SkillConfig
-from tests.conftest import CLI_LOG_OPTION
+from ...conftest import CLI_LOG_OPTION, ROOT_DIR
 from ...common.click_testing import CliRunner
 
 
@@ -50,7 +50,7 @@ class TestGymSkill:
     def test_gym(self, pytestconfig):
         """Run the gym skill sequence."""
         # add packages folder
-        packages_src = os.path.join(self.cwd, 'packages')
+        packages_src = os.path.join(ROOT_DIR, 'packages')
         packages_dst = os.path.join(os.getcwd(), 'packages')
         shutil.copytree(packages_src, packages_dst)
 


### PR DESCRIPTION
## Proposed changes

This PR tries to fix the Echo skill test:
- test that the skill sends back what receives
- disable logging that causes problems when tearing the agent down. 

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
