### PR TITLE
Fix Gym example and associated test.

### DIFF
--- a/examples/gym_ex/proxy/env.py
+++ b/examples/gym_ex/proxy/env.py
@@ -21,6 +21,7 @@
 """This contains the proxy gym environment."""
 
 import sys
+import time
 
 from aea.helpers.base import locate
 
@@ -106,6 +107,7 @@ class ProxyEnv(gym.Env):
 
         :return: None
         """
+        # TODO: adapt this line to the new APIs. We no longer have a mailbox.
         self._agent.mailbox._connection.channel.gym_env.render(mode)
 
     def reset(self) -> None:
@@ -140,7 +142,10 @@ class ProxyEnv(gym.Env):
 
         :return: None
         """
+        assert not self._agent_thread.is_alive(), "Agent already running."
         self._agent_thread.start()
+        while not self._agent.multiplexer.is_connected:
+            time.sleep(0.1)
 
     def _disconnect(self):
         """

--- a/examples/gym_ex/proxy/env.py
+++ b/examples/gym_ex/proxy/env.py
@@ -116,7 +116,8 @@ class ProxyEnv(gym.Env):
 
         :return: None
         """
-        self._connect()
+        if not self._agent.multiplexer.is_connected:
+            self._connect()
         gym_msg = GymMessage(performative=GymMessage.Performative.RESET)
         gym_bytes = GymSerializer().encode(gym_msg)
         envelope = Envelope(to=DEFAULT_GYM, sender=self._agent_public_key, protocol_id=GymMessage.protocol_id,

--- a/examples/gym_ex/rl/agent.py
+++ b/examples/gym_ex/rl/agent.py
@@ -172,13 +172,19 @@ class RLAgent:
         :return: None
         """
         action_counter = 0
+        episode_counter = 0
+        nb_steps_digits = len(str(nb_steps))
 
-        env.reset()
         while action_counter < nb_steps:
-            action = self._pick_an_action()
-            action_counter += 1
-            obs, reward, done, info = env.step(action)
-            self._update_model(obs, reward, done, info, action)
-            if action_counter % 10 == 0:
-                print("Action: step_id='{}' action='{}' reward='{}'".format(action_counter, action, reward))
+            env.reset()
+            done = False
+            episode_counter += 1
+            while not done and action_counter < nb_steps:
+                action = self._pick_an_action()
+                action_counter += 1
+                obs, reward, done, info = env.step(action)
+                self._update_model(obs, reward, done, info, action)
+                if action_counter % 10 == 0:
+                    print(("Step {:" + str(nb_steps_digits) + "}/{}, episode={}, action={:7}, reward={}")
+                          .format(action_counter, nb_steps, episode_counter, str(action), reward))
         env.close()

--- a/examples/gym_ex/rl/agent.py
+++ b/examples/gym_ex/rl/agent.py
@@ -172,6 +172,9 @@ class RLAgent:
         :return: None
         """
         action_counter = 0
+        # for the BanditEnv example, the episode will always be 1.
+        # In general that's not the case, but for completeness
+        # we implemented a training loop that supports learning across many episodes.
         episode_counter = 0
         nb_steps_digits = len(str(nb_steps))
 

--- a/examples/gym_ex/train.py
+++ b/examples/gym_ex/train.py
@@ -24,17 +24,27 @@ from gyms.env import BanditNArmedRandom
 from proxy.env import ProxyEnv
 from rl.agent import RLAgent
 
+import argparse
+
+DEFAULT_NB_GOODS = 10
+DEFAULT_NB_PRICES_PER_GOOD = 100
+DEFAULT_NB_STEPS = 4000
+
+parser = argparse.ArgumentParser("train", description="Train an RL agent.")
+parser.add_argument("--nb-steps", type=int, default=DEFAULT_NB_STEPS, help="The number of training steps.")
+parser.add_argument("--nb-goods", type=int, default=DEFAULT_NB_GOODS, help="The number of goods.")
+parser.add_argument("--nb-prices-per-good", type=int, default=DEFAULT_NB_PRICES_PER_GOOD, help="The number of prices per goods.")
+
+
 if __name__ == "__main__":
-    NB_GOODS = 10
-    NB_PRICES_PER_GOOD = 100
-    NB_STEPS = 4000
+    arguments = parser.parse_args()
 
     # Use any gym.Env compatible environment:
-    gym_env = BanditNArmedRandom(nb_bandits=NB_GOODS, nb_prices_per_bandit=NB_PRICES_PER_GOOD)
+    gym_env = BanditNArmedRandom(nb_bandits=arguments.nb_goods, nb_prices_per_bandit=arguments.nb_prices_per_good)
 
     # Pass the gym environment to a proxy environment:
     proxy_env = ProxyEnv(gym_env)
 
     # Use any RL agent compatible with the gym environment and call the fit method:
-    rl_agent = RLAgent(nb_goods=NB_GOODS)
-    rl_agent.fit(env=proxy_env, nb_steps=NB_STEPS)
+    rl_agent = RLAgent(nb_goods=arguments.nb_goods)
+    rl_agent.fit(env=proxy_env, nb_steps=arguments.nb_steps)

--- a/tests/test_examples/test_gym_ex.py
+++ b/tests/test_examples/test_gym_ex.py
@@ -20,11 +20,15 @@
 """The tests module contains the tests of the gym example."""
 
 import os
-import pytest
 import signal
 import subprocess
 import sys
 import time
+from pathlib import Path
+
+import pytest
+
+from ..conftest import CUR_PATH
 
 
 def test_gym_ex(pytestconfig):
@@ -35,15 +39,16 @@ def test_gym_ex(pytestconfig):
     # run the example
     process = subprocess.Popen([
         sys.executable,
-        '-m',
-        'examples/gym_ex/train.py'
+        str(Path(CUR_PATH, '..', 'examples/gym_ex/train.py').resolve()),
+        "--nb-steps",
+        "100"
     ],
         stdout=subprocess.PIPE,
         env=os.environ.copy())
 
-    time.sleep(30.0)
+    time.sleep(3.0)
     process.send_signal(signal.SIGINT)
-    process.wait(timeout=20)
+    process.wait(timeout=10)
 
     assert process.returncode == 0
 


### PR DESCRIPTION
## Proposed changes

After the recent change of API (from `MailBox` to `Multiplexer`), the Gym example stopped working. This was because the multiplexer requires that it is connected before using `OutBox.put`. However, in the Gym example, the interleaving of the main thread (that executes `RLAgent.fit`) and the agent thread caused that the outbox was used before the multiplexer was fully set up.

## Fixes



## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
