### PR TITLE
Refactor the fipa protocol to include inform component

### DIFF
--- a/aea/decision_maker/messages/transaction.py
+++ b/aea/decision_maker/messages/transaction.py
@@ -41,6 +41,7 @@ class TransactionMessage(Message):
         """Transaction performative."""
 
         PROPOSE = "propose"
+        SIGN = "sign"
         ACCEPT = "accept"
         REJECT = "reject"
 

--- a/aea/protocols/fipa/fipa.proto
+++ b/aea/protocols/fipa/fipa.proto
@@ -20,24 +20,18 @@ message FIPAMessage{
 
     message MatchAccept{}
 
-    message Accept_W_Address{
-        string address = 1;
-    }
-
-    message MatchAccept_W_Address{
-        string address = 1;
-    }
     message Decline{}
+
     message Inform{
         bytes bytes = 1;
     }
 
-    message AcceptWAddress{
-        string address = 1;
+    message AcceptWInform{
+        bytes bytes = 1;
     }
 
-    message MatchAcceptWAddress{
-        string address = 1;
+    message MatchAcceptWInform{
+        bytes bytes = 1;
     }
 
     int32 message_id = 1;
@@ -51,7 +45,7 @@ message FIPAMessage{
         MatchAccept match_accept = 8;
         Decline decline = 9;
         Inform inform = 10;
-        AcceptWAddress accept_w_address = 11;
-        MatchAcceptWAddress match_accept_w_address = 12;
+        AcceptWInform accept_w_inform = 11;
+        MatchAcceptWInform match_accept_w_inform = 12;
     }
 }

--- a/aea/protocols/fipa/fipa_pb2.py
+++ b/aea/protocols/fipa/fipa_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='fetch.aea.fipa',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\nfipa.proto\x12\x0e\x66\x65tch.aea.fipa\"\xe6\x07\n\x0b\x46IPAMessage\x12\x12\n\nmessage_id\x18\x01 \x01(\x05\x12\"\n\x1a\x64ialogue_starter_reference\x18\x02 \x01(\t\x12$\n\x1c\x64ialogue_responder_reference\x18\x03 \x01(\t\x12\x0e\n\x06target\x18\x04 \x01(\x05\x12.\n\x03\x63\x66p\x18\x05 \x01(\x0b\x32\x1f.fetch.aea.fipa.FIPAMessage.CFPH\x00\x12\x36\n\x07propose\x18\x06 \x01(\x0b\x32#.fetch.aea.fipa.FIPAMessage.ProposeH\x00\x12\x34\n\x06\x61\x63\x63\x65pt\x18\x07 \x01(\x0b\x32\".fetch.aea.fipa.FIPAMessage.AcceptH\x00\x12?\n\x0cmatch_accept\x18\x08 \x01(\x0b\x32\'.fetch.aea.fipa.FIPAMessage.MatchAcceptH\x00\x12\x36\n\x07\x64\x65\x63line\x18\t \x01(\x0b\x32#.fetch.aea.fipa.FIPAMessage.DeclineH\x00\x12\x34\n\x06inform\x18\n \x01(\x0b\x32\".fetch.aea.fipa.FIPAMessage.InformH\x00\x12\x46\n\x10\x61\x63\x63\x65pt_w_address\x18\x0b \x01(\x0b\x32*.fetch.aea.fipa.FIPAMessage.AcceptWAddressH\x00\x12Q\n\x16match_accept_w_address\x18\x0c \x01(\x0b\x32/.fetch.aea.fipa.FIPAMessage.MatchAcceptWAddressH\x00\x1a}\n\x03\x43\x46P\x12\x0f\n\x05\x62ytes\x18\x01 \x01(\x0cH\x00\x12:\n\x07nothing\x18\x02 \x01(\x0b\x32\'.fetch.aea.fipa.FIPAMessage.CFP.NothingH\x00\x12\x15\n\x0bquery_bytes\x18\x03 \x01(\x0cH\x00\x1a\t\n\x07NothingB\x07\n\x05query\x1a\x1b\n\x07Propose\x12\x10\n\x08proposal\x18\x01 \x03(\x0c\x1a\x08\n\x06\x41\x63\x63\x65pt\x1a\r\n\x0bMatchAccept\x1a#\n\x10\x41\x63\x63\x65pt_W_Address\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x1a(\n\x15MatchAccept_W_Address\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x1a\t\n\x07\x44\x65\x63line\x1a\x17\n\x06Inform\x12\r\n\x05\x62ytes\x18\x01 \x01(\x0c\x1a!\n\x0e\x41\x63\x63\x65ptWAddress\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x1a&\n\x13MatchAcceptWAddress\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\tB\x0e\n\x0cperformativeb\x06proto3')
+  serialized_pb=_b('\n\nfipa.proto\x12\x0e\x66\x65tch.aea.fipa\"\x8d\x07\n\x0b\x46IPAMessage\x12\x12\n\nmessage_id\x18\x01 \x01(\x05\x12\"\n\x1a\x64ialogue_starter_reference\x18\x02 \x01(\t\x12$\n\x1c\x64ialogue_responder_reference\x18\x03 \x01(\t\x12\x0e\n\x06target\x18\x04 \x01(\x05\x12.\n\x03\x63\x66p\x18\x05 \x01(\x0b\x32\x1f.fetch.aea.fipa.FIPAMessage.CFPH\x00\x12\x36\n\x07propose\x18\x06 \x01(\x0b\x32#.fetch.aea.fipa.FIPAMessage.ProposeH\x00\x12\x34\n\x06\x61\x63\x63\x65pt\x18\x07 \x01(\x0b\x32\".fetch.aea.fipa.FIPAMessage.AcceptH\x00\x12?\n\x0cmatch_accept\x18\x08 \x01(\x0b\x32\'.fetch.aea.fipa.FIPAMessage.MatchAcceptH\x00\x12\x36\n\x07\x64\x65\x63line\x18\t \x01(\x0b\x32#.fetch.aea.fipa.FIPAMessage.DeclineH\x00\x12\x34\n\x06inform\x18\n \x01(\x0b\x32\".fetch.aea.fipa.FIPAMessage.InformH\x00\x12\x44\n\x0f\x61\x63\x63\x65pt_w_inform\x18\x0b \x01(\x0b\x32).fetch.aea.fipa.FIPAMessage.AcceptWInformH\x00\x12O\n\x15match_accept_w_inform\x18\x0c \x01(\x0b\x32..fetch.aea.fipa.FIPAMessage.MatchAcceptWInformH\x00\x1a}\n\x03\x43\x46P\x12\x0f\n\x05\x62ytes\x18\x01 \x01(\x0cH\x00\x12:\n\x07nothing\x18\x02 \x01(\x0b\x32\'.fetch.aea.fipa.FIPAMessage.CFP.NothingH\x00\x12\x15\n\x0bquery_bytes\x18\x03 \x01(\x0cH\x00\x1a\t\n\x07NothingB\x07\n\x05query\x1a\x1b\n\x07Propose\x12\x10\n\x08proposal\x18\x01 \x03(\x0c\x1a\x08\n\x06\x41\x63\x63\x65pt\x1a\r\n\x0bMatchAccept\x1a\t\n\x07\x44\x65\x63line\x1a\x17\n\x06Inform\x12\r\n\x05\x62ytes\x18\x01 \x01(\x0c\x1a\x1e\n\rAcceptWInform\x12\r\n\x05\x62ytes\x18\x01 \x01(\x0c\x1a#\n\x12MatchAcceptWInform\x12\r\n\x05\x62ytes\x18\x01 \x01(\x0c\x42\x0e\n\x0cperformativeb\x06proto3')
 )
 
 
@@ -45,8 +45,8 @@ _FIPAMESSAGE_CFP_NOTHING = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=751,
-  serialized_end=760,
+  serialized_start=747,
+  serialized_end=756,
 )
 
 _FIPAMESSAGE_CFP = _descriptor.Descriptor(
@@ -92,8 +92,8 @@ _FIPAMESSAGE_CFP = _descriptor.Descriptor(
       name='query', full_name='fetch.aea.fipa.FIPAMessage.CFP.query',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=644,
-  serialized_end=769,
+  serialized_start=640,
+  serialized_end=765,
 )
 
 _FIPAMESSAGE_PROPOSE = _descriptor.Descriptor(
@@ -122,8 +122,8 @@ _FIPAMESSAGE_PROPOSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=771,
-  serialized_end=798,
+  serialized_start=767,
+  serialized_end=794,
 )
 
 _FIPAMESSAGE_ACCEPT = _descriptor.Descriptor(
@@ -145,8 +145,8 @@ _FIPAMESSAGE_ACCEPT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=800,
-  serialized_end=808,
+  serialized_start=796,
+  serialized_end=804,
 )
 
 _FIPAMESSAGE_MATCHACCEPT = _descriptor.Descriptor(
@@ -168,68 +168,8 @@ _FIPAMESSAGE_MATCHACCEPT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=810,
-  serialized_end=823,
-)
-
-_FIPAMESSAGE_ACCEPT_W_ADDRESS = _descriptor.Descriptor(
-  name='Accept_W_Address',
-  full_name='fetch.aea.fipa.FIPAMessage.Accept_W_Address',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='address', full_name='fetch.aea.fipa.FIPAMessage.Accept_W_Address.address', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=825,
-  serialized_end=860,
-)
-
-_FIPAMESSAGE_MATCHACCEPT_W_ADDRESS = _descriptor.Descriptor(
-  name='MatchAccept_W_Address',
-  full_name='fetch.aea.fipa.FIPAMessage.MatchAccept_W_Address',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='address', full_name='fetch.aea.fipa.FIPAMessage.MatchAccept_W_Address.address', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=862,
-  serialized_end=902,
+  serialized_start=806,
+  serialized_end=819,
 )
 
 _FIPAMESSAGE_DECLINE = _descriptor.Descriptor(
@@ -251,8 +191,8 @@ _FIPAMESSAGE_DECLINE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=904,
-  serialized_end=913,
+  serialized_start=821,
+  serialized_end=830,
 )
 
 _FIPAMESSAGE_INFORM = _descriptor.Descriptor(
@@ -281,21 +221,21 @@ _FIPAMESSAGE_INFORM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=915,
-  serialized_end=938,
+  serialized_start=832,
+  serialized_end=855,
 )
 
-_FIPAMESSAGE_ACCEPTWADDRESS = _descriptor.Descriptor(
-  name='AcceptWAddress',
-  full_name='fetch.aea.fipa.FIPAMessage.AcceptWAddress',
+_FIPAMESSAGE_ACCEPTWINFORM = _descriptor.Descriptor(
+  name='AcceptWInform',
+  full_name='fetch.aea.fipa.FIPAMessage.AcceptWInform',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='address', full_name='fetch.aea.fipa.FIPAMessage.AcceptWAddress.address', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
+      name='bytes', full_name='fetch.aea.fipa.FIPAMessage.AcceptWInform.bytes', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
@@ -311,21 +251,21 @@ _FIPAMESSAGE_ACCEPTWADDRESS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=940,
-  serialized_end=973,
+  serialized_start=857,
+  serialized_end=887,
 )
 
-_FIPAMESSAGE_MATCHACCEPTWADDRESS = _descriptor.Descriptor(
-  name='MatchAcceptWAddress',
-  full_name='fetch.aea.fipa.FIPAMessage.MatchAcceptWAddress',
+_FIPAMESSAGE_MATCHACCEPTWINFORM = _descriptor.Descriptor(
+  name='MatchAcceptWInform',
+  full_name='fetch.aea.fipa.FIPAMessage.MatchAcceptWInform',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='address', full_name='fetch.aea.fipa.FIPAMessage.MatchAcceptWAddress.address', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
+      name='bytes', full_name='fetch.aea.fipa.FIPAMessage.MatchAcceptWInform.bytes', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
@@ -341,8 +281,8 @@ _FIPAMESSAGE_MATCHACCEPTWADDRESS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=975,
-  serialized_end=1013,
+  serialized_start=889,
+  serialized_end=924,
 )
 
 _FIPAMESSAGE = _descriptor.Descriptor(
@@ -423,14 +363,14 @@ _FIPAMESSAGE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='accept_w_address', full_name='fetch.aea.fipa.FIPAMessage.accept_w_address', index=10,
+      name='accept_w_inform', full_name='fetch.aea.fipa.FIPAMessage.accept_w_inform', index=10,
       number=11, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='match_accept_w_address', full_name='fetch.aea.fipa.FIPAMessage.match_accept_w_address', index=11,
+      name='match_accept_w_inform', full_name='fetch.aea.fipa.FIPAMessage.match_accept_w_inform', index=11,
       number=12, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -439,7 +379,7 @@ _FIPAMESSAGE = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_FIPAMESSAGE_CFP, _FIPAMESSAGE_PROPOSE, _FIPAMESSAGE_ACCEPT, _FIPAMESSAGE_MATCHACCEPT, _FIPAMESSAGE_ACCEPT_W_ADDRESS, _FIPAMESSAGE_MATCHACCEPT_W_ADDRESS, _FIPAMESSAGE_DECLINE, _FIPAMESSAGE_INFORM, _FIPAMESSAGE_ACCEPTWADDRESS, _FIPAMESSAGE_MATCHACCEPTWADDRESS, ],
+  nested_types=[_FIPAMESSAGE_CFP, _FIPAMESSAGE_PROPOSE, _FIPAMESSAGE_ACCEPT, _FIPAMESSAGE_MATCHACCEPT, _FIPAMESSAGE_DECLINE, _FIPAMESSAGE_INFORM, _FIPAMESSAGE_ACCEPTWINFORM, _FIPAMESSAGE_MATCHACCEPTWINFORM, ],
   enum_types=[
   ],
   serialized_options=None,
@@ -452,7 +392,7 @@ _FIPAMESSAGE = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=31,
-  serialized_end=1029,
+  serialized_end=940,
 )
 
 _FIPAMESSAGE_CFP_NOTHING.containing_type = _FIPAMESSAGE_CFP
@@ -470,20 +410,18 @@ _FIPAMESSAGE_CFP.fields_by_name['query_bytes'].containing_oneof = _FIPAMESSAGE_C
 _FIPAMESSAGE_PROPOSE.containing_type = _FIPAMESSAGE
 _FIPAMESSAGE_ACCEPT.containing_type = _FIPAMESSAGE
 _FIPAMESSAGE_MATCHACCEPT.containing_type = _FIPAMESSAGE
-_FIPAMESSAGE_ACCEPT_W_ADDRESS.containing_type = _FIPAMESSAGE
-_FIPAMESSAGE_MATCHACCEPT_W_ADDRESS.containing_type = _FIPAMESSAGE
 _FIPAMESSAGE_DECLINE.containing_type = _FIPAMESSAGE
 _FIPAMESSAGE_INFORM.containing_type = _FIPAMESSAGE
-_FIPAMESSAGE_ACCEPTWADDRESS.containing_type = _FIPAMESSAGE
-_FIPAMESSAGE_MATCHACCEPTWADDRESS.containing_type = _FIPAMESSAGE
+_FIPAMESSAGE_ACCEPTWINFORM.containing_type = _FIPAMESSAGE
+_FIPAMESSAGE_MATCHACCEPTWINFORM.containing_type = _FIPAMESSAGE
 _FIPAMESSAGE.fields_by_name['cfp'].message_type = _FIPAMESSAGE_CFP
 _FIPAMESSAGE.fields_by_name['propose'].message_type = _FIPAMESSAGE_PROPOSE
 _FIPAMESSAGE.fields_by_name['accept'].message_type = _FIPAMESSAGE_ACCEPT
 _FIPAMESSAGE.fields_by_name['match_accept'].message_type = _FIPAMESSAGE_MATCHACCEPT
 _FIPAMESSAGE.fields_by_name['decline'].message_type = _FIPAMESSAGE_DECLINE
 _FIPAMESSAGE.fields_by_name['inform'].message_type = _FIPAMESSAGE_INFORM
-_FIPAMESSAGE.fields_by_name['accept_w_address'].message_type = _FIPAMESSAGE_ACCEPTWADDRESS
-_FIPAMESSAGE.fields_by_name['match_accept_w_address'].message_type = _FIPAMESSAGE_MATCHACCEPTWADDRESS
+_FIPAMESSAGE.fields_by_name['accept_w_inform'].message_type = _FIPAMESSAGE_ACCEPTWINFORM
+_FIPAMESSAGE.fields_by_name['match_accept_w_inform'].message_type = _FIPAMESSAGE_MATCHACCEPTWINFORM
 _FIPAMESSAGE.oneofs_by_name['performative'].fields.append(
   _FIPAMESSAGE.fields_by_name['cfp'])
 _FIPAMESSAGE.fields_by_name['cfp'].containing_oneof = _FIPAMESSAGE.oneofs_by_name['performative']
@@ -503,11 +441,11 @@ _FIPAMESSAGE.oneofs_by_name['performative'].fields.append(
   _FIPAMESSAGE.fields_by_name['inform'])
 _FIPAMESSAGE.fields_by_name['inform'].containing_oneof = _FIPAMESSAGE.oneofs_by_name['performative']
 _FIPAMESSAGE.oneofs_by_name['performative'].fields.append(
-  _FIPAMESSAGE.fields_by_name['accept_w_address'])
-_FIPAMESSAGE.fields_by_name['accept_w_address'].containing_oneof = _FIPAMESSAGE.oneofs_by_name['performative']
+  _FIPAMESSAGE.fields_by_name['accept_w_inform'])
+_FIPAMESSAGE.fields_by_name['accept_w_inform'].containing_oneof = _FIPAMESSAGE.oneofs_by_name['performative']
 _FIPAMESSAGE.oneofs_by_name['performative'].fields.append(
-  _FIPAMESSAGE.fields_by_name['match_accept_w_address'])
-_FIPAMESSAGE.fields_by_name['match_accept_w_address'].containing_oneof = _FIPAMESSAGE.oneofs_by_name['performative']
+  _FIPAMESSAGE.fields_by_name['match_accept_w_inform'])
+_FIPAMESSAGE.fields_by_name['match_accept_w_inform'].containing_oneof = _FIPAMESSAGE.oneofs_by_name['performative']
 DESCRIPTOR.message_types_by_name['FIPAMessage'] = _FIPAMESSAGE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -548,20 +486,6 @@ FIPAMessage = _reflection.GeneratedProtocolMessageType('FIPAMessage', (_message.
     ))
   ,
 
-  Accept_W_Address = _reflection.GeneratedProtocolMessageType('Accept_W_Address', (_message.Message,), dict(
-    DESCRIPTOR = _FIPAMESSAGE_ACCEPT_W_ADDRESS,
-    __module__ = 'fipa_pb2'
-    # @@protoc_insertion_point(class_scope:fetch.aea.fipa.FIPAMessage.Accept_W_Address)
-    ))
-  ,
-
-  MatchAccept_W_Address = _reflection.GeneratedProtocolMessageType('MatchAccept_W_Address', (_message.Message,), dict(
-    DESCRIPTOR = _FIPAMESSAGE_MATCHACCEPT_W_ADDRESS,
-    __module__ = 'fipa_pb2'
-    # @@protoc_insertion_point(class_scope:fetch.aea.fipa.FIPAMessage.MatchAccept_W_Address)
-    ))
-  ,
-
   Decline = _reflection.GeneratedProtocolMessageType('Decline', (_message.Message,), dict(
     DESCRIPTOR = _FIPAMESSAGE_DECLINE,
     __module__ = 'fipa_pb2'
@@ -576,17 +500,17 @@ FIPAMessage = _reflection.GeneratedProtocolMessageType('FIPAMessage', (_message.
     ))
   ,
 
-  AcceptWAddress = _reflection.GeneratedProtocolMessageType('AcceptWAddress', (_message.Message,), dict(
-    DESCRIPTOR = _FIPAMESSAGE_ACCEPTWADDRESS,
+  AcceptWInform = _reflection.GeneratedProtocolMessageType('AcceptWInform', (_message.Message,), dict(
+    DESCRIPTOR = _FIPAMESSAGE_ACCEPTWINFORM,
     __module__ = 'fipa_pb2'
-    # @@protoc_insertion_point(class_scope:fetch.aea.fipa.FIPAMessage.AcceptWAddress)
+    # @@protoc_insertion_point(class_scope:fetch.aea.fipa.FIPAMessage.AcceptWInform)
     ))
   ,
 
-  MatchAcceptWAddress = _reflection.GeneratedProtocolMessageType('MatchAcceptWAddress', (_message.Message,), dict(
-    DESCRIPTOR = _FIPAMESSAGE_MATCHACCEPTWADDRESS,
+  MatchAcceptWInform = _reflection.GeneratedProtocolMessageType('MatchAcceptWInform', (_message.Message,), dict(
+    DESCRIPTOR = _FIPAMESSAGE_MATCHACCEPTWINFORM,
     __module__ = 'fipa_pb2'
-    # @@protoc_insertion_point(class_scope:fetch.aea.fipa.FIPAMessage.MatchAcceptWAddress)
+    # @@protoc_insertion_point(class_scope:fetch.aea.fipa.FIPAMessage.MatchAcceptWInform)
     ))
   ,
   DESCRIPTOR = _FIPAMESSAGE,
@@ -599,12 +523,10 @@ _sym_db.RegisterMessage(FIPAMessage.CFP.Nothing)
 _sym_db.RegisterMessage(FIPAMessage.Propose)
 _sym_db.RegisterMessage(FIPAMessage.Accept)
 _sym_db.RegisterMessage(FIPAMessage.MatchAccept)
-_sym_db.RegisterMessage(FIPAMessage.Accept_W_Address)
-_sym_db.RegisterMessage(FIPAMessage.MatchAccept_W_Address)
 _sym_db.RegisterMessage(FIPAMessage.Decline)
 _sym_db.RegisterMessage(FIPAMessage.Inform)
-_sym_db.RegisterMessage(FIPAMessage.AcceptWAddress)
-_sym_db.RegisterMessage(FIPAMessage.MatchAcceptWAddress)
+_sym_db.RegisterMessage(FIPAMessage.AcceptWInform)
+_sym_db.RegisterMessage(FIPAMessage.MatchAcceptWInform)
 
 
 # @@protoc_insertion_point(module_scope)

--- a/aea/protocols/fipa/message.py
+++ b/aea/protocols/fipa/message.py
@@ -43,8 +43,8 @@ class FIPAMessage(Message):
         MATCH_ACCEPT = "match_accept"
         DECLINE = "decline"
         INFORM = "inform"
-        ACCEPT_W_ADDRESS = "accept_w_address"
-        MATCH_ACCEPT_W_ADDRESS = "match_accept_w_address"
+        ACCEPT_W_INFORM = "accept_w_inform"
+        MATCH_ACCEPT_W_INFORM = "match_accept_w_inform"
 
         def __str__(self):
             """Get string representation."""
@@ -97,13 +97,11 @@ class FIPAMessage(Message):
                     or performative == FIPAMessage.Performative.MATCH_ACCEPT \
                     or performative == FIPAMessage.Performative.DECLINE:
                 assert len(self.body) == 4
-            elif performative == FIPAMessage.Performative.ACCEPT_W_ADDRESS\
-                    or performative == FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS:
-                assert self.is_set("address")
-                assert len(self.body) == 5
-            elif performative == FIPAMessage.Performative.INFORM:
-                assert self.is_set("json_data")
-                json_data = self.get("json_data")
+            elif performative == FIPAMessage.Performative.ACCEPT_W_INFORM\
+                    or performative == FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM\
+                    or performative == FIPAMessage.Performative.INFORM:
+                assert self.is_set("info")
+                json_data = self.get("info")
                 assert isinstance(json_data, dict)
                 assert len(self.body) == 5
             else:
@@ -119,9 +117,9 @@ VALID_PREVIOUS_PERFORMATIVES = {
     FIPAMessage.Performative.CFP: [None],
     FIPAMessage.Performative.PROPOSE: [FIPAMessage.Performative.CFP],
     FIPAMessage.Performative.ACCEPT: [FIPAMessage.Performative.PROPOSE],
-    FIPAMessage.Performative.ACCEPT_W_ADDRESS: [FIPAMessage.Performative.PROPOSE],
-    FIPAMessage.Performative.MATCH_ACCEPT: [FIPAMessage.Performative.ACCEPT, FIPAMessage.Performative.ACCEPT_W_ADDRESS],
-    FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS: [FIPAMessage.Performative.ACCEPT, FIPAMessage.Performative.ACCEPT_W_ADDRESS],
-    FIPAMessage.Performative.INFORM: [FIPAMessage.Performative.MATCH_ACCEPT, FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS, FIPAMessage.Performative.INFORM],
-    FIPAMessage.Performative.DECLINE: [FIPAMessage.Performative.CFP, FIPAMessage.Performative.PROPOSE, FIPAMessage.Performative.ACCEPT, FIPAMessage.Performative.ACCEPT_W_ADDRESS]
+    FIPAMessage.Performative.ACCEPT_W_INFORM: [FIPAMessage.Performative.PROPOSE],
+    FIPAMessage.Performative.MATCH_ACCEPT: [FIPAMessage.Performative.ACCEPT, FIPAMessage.Performative.ACCEPT_W_INFORM],
+    FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM: [FIPAMessage.Performative.ACCEPT, FIPAMessage.Performative.ACCEPT_W_INFORM],
+    FIPAMessage.Performative.INFORM: [FIPAMessage.Performative.MATCH_ACCEPT, FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM, FIPAMessage.Performative.INFORM],
+    FIPAMessage.Performative.DECLINE: [FIPAMessage.Performative.CFP, FIPAMessage.Performative.PROPOSE, FIPAMessage.Performative.ACCEPT, FIPAMessage.Performative.ACCEPT_W_INFORM]
 }  # type: Dict[FIPAMessage.Performative, List[Union[None, FIPAMessage.Performative]]]

--- a/aea/protocols/fipa/serialization.py
+++ b/aea/protocols/fipa/serialization.py
@@ -69,24 +69,24 @@ class FIPASerializer(Serializer):
         elif performative_id == FIPAMessage.Performative.MATCH_ACCEPT:
             performative = fipa_pb2.FIPAMessage.MatchAccept()  # type: ignore
             fipa_msg.match_accept.CopyFrom(performative)
-        elif performative_id == FIPAMessage.Performative.ACCEPT_W_ADDRESS:
-            performative = fipa_pb2.FIPAMessage.AcceptWAddress()  # type: ignore
-            address = msg.get("address")
-            if type(address) == str:
-                performative.address = address
-            fipa_msg.accept_w_address.CopyFrom(performative)
-        elif performative_id == FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS:
-            performative = fipa_pb2.FIPAMessage.MatchAcceptWAddress()  # type: ignore
-            address = msg.get("address")
-            if type(address) == str:
-                performative.address = address
-            fipa_msg.match_accept_w_address.CopyFrom(performative)
+        elif performative_id == FIPAMessage.Performative.ACCEPT_W_INFORM:
+            performative = fipa_pb2.FIPAMessage.AcceptWInform()  # type: ignore
+            data = msg.get("info")
+            data_bytes = json.dumps(data).encode("utf-8")
+            performative.bytes = data_bytes
+            fipa_msg.accept_w_inform.CopyFrom(performative)
+        elif performative_id == FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM:
+            performative = fipa_pb2.FIPAMessage.MatchAcceptWInform()  # type: ignore
+            data = msg.get("info")
+            data_bytes = json.dumps(data).encode("utf-8")
+            performative.bytes = data_bytes
+            fipa_msg.match_accept_w_inform.CopyFrom(performative)
         elif performative_id == FIPAMessage.Performative.DECLINE:
             performative = fipa_pb2.FIPAMessage.Decline()  # type: ignore
             fipa_msg.decline.CopyFrom(performative)
         elif performative_id == FIPAMessage.Performative.INFORM:
             performative = fipa_pb2.FIPAMessage.Inform()  # type: ignore
-            data = msg.get("json_data")
+            data = msg.get("info")
             data_bytes = json.dumps(data).encode("utf-8")
             performative.bytes = data_bytes
             fipa_msg.inform.CopyFrom(performative)
@@ -128,17 +128,17 @@ class FIPASerializer(Serializer):
             pass
         elif performative_id == FIPAMessage.Performative.MATCH_ACCEPT:
             pass
-        elif performative_id == FIPAMessage.Performative.ACCEPT_W_ADDRESS:
-            address = fipa_pb.accept_w_address.address
-            performative_content['address'] = address
-        elif performative_id == FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS:
-            address = fipa_pb.match_accept_w_address.address
-            performative_content['address'] = address
+        elif performative_id == FIPAMessage.Performative.ACCEPT_W_INFORM:
+            info = json.loads(fipa_pb.accept_w_inform.bytes)
+            performative_content['info'] = info
+        elif performative_id == FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM:
+            info = json.loads(fipa_pb.match_accept_w_inform.bytes)
+            performative_content['info'] = info
         elif performative_id == FIPAMessage.Performative.DECLINE:
             pass
         elif performative_id == FIPAMessage.Performative.INFORM:
-            data = json.loads(fipa_pb.inform.bytes)
-            performative_content["json_data"] = data
+            info = json.loads(fipa_pb.inform.bytes)
+            performative_content["info"] = info
         else:
             raise ValueError("Performative not valid: {}.".format(performative))
 

--- a/docs/tac-skills.md
+++ b/docs/tac-skills.md
@@ -124,10 +124,9 @@ This diagram shows the communication between the two agents and the controller. 
         Buyer_Agent->>Seller_Agent: call_for_proposal
         Seller_Agent->>Buyer_Agent: proposal
         Buyer_Agent->>Seller_Agent: accept
-        Buyer_Agent->>Controller: request_transaction
         Seller_Agent->>Buyer_Agent: match_accept
-        Seller_Agent->>Controller: request_transaction
-        Controller->>Controller: transfer_funds
+        Seller_Agent->>Controller: transaction
+        Controller->>Controller: transaction_execution
         Controller->>Seller_Agent: confirm_transaction
         Controller->>Buyer_Agent: confirm_transaction
         

--- a/packages/skills/carpark_client/handlers.py
+++ b/packages/skills/carpark_client/handlers.py
@@ -93,7 +93,7 @@ class FIPAHandler(Handler):
             self._handle_propose(fipa_msg, sender, message_id, dialogue)
         elif msg_performative == FIPAMessage.Performative.DECLINE:
             self._handle_decline(fipa_msg, sender, message_id, dialogue)
-        elif msg_performative == FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS:
+        elif msg_performative == FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM:
             self._handle_match_accept(fipa_msg, sender, message_id, dialogue)
         elif msg_performative == FIPAMessage.Performative.INFORM:
             self._handle_inform(fipa_msg, sender, message_id, dialogue)
@@ -194,8 +194,9 @@ class FIPAHandler(Handler):
         :param dialogue: the dialogue object
         :return: None
         """
-        logger.info("[{}]: received MATCH_ACCEPT_W_ADDRESS from sender={}".format(self.context.agent_name, sender[-5:]))
-        address = cast(str, msg.get("address"))
+        logger.info("[{}]: received MATCH_ACCEPT_W_INFORM from sender={}".format(self.context.agent_name, sender[-5:]))
+        info = cast(Dict, msg.get("info"))
+        address = cast(str, info.get("address"))
         proposal = cast(Description, dialogue.proposal)
         tx_msg = TransactionMessage(performative=TransactionMessage.Performative.PROPOSE,
                                     skill_ids=["carpark_client"],
@@ -223,7 +224,7 @@ class FIPAHandler(Handler):
         :return: None
         """
         logger.info("[{}]: received INFORM from sender={}".format(self.context.agent_name, sender[-5:]))
-        json_data = cast(dict, msg.get("json_data"))
+        json_data = cast(dict, msg.get("info"))
         if 'message_type' in json_data and json_data['message_type'] == 'car_park_data':
             logger.info("[{}]: received the following carpark data={}".format(self.context.agent_name,
                                                                               pprint.pformat(json_data)))
@@ -340,7 +341,7 @@ class MyTransactionHandler(Handler):
                                      dialogue_reference=dialogue.dialogue_label.dialogue_reference,
                                      target=new_target_id,
                                      performative=FIPAMessage.Performative.INFORM,
-                                     json_data=json_data)
+                                     info=json_data)
             dialogue.outgoing_extend(inform_msg)
             self.context.outbox.put_message(to=counterparty_pbk,
                                             sender=self.context.agent_public_key,

--- a/packages/skills/carpark_detection/handlers.py
+++ b/packages/skills/carpark_detection/handlers.py
@@ -192,7 +192,7 @@ class FIPAHandler(Handler):
         """
         Handle the ACCEPT.
 
-        Respond with a MATCH_ACCEPT_W_ADDRESS which contains the address to send the funds to.
+        Respond with a MATCH_ACCEPT_W_INFORM which contains the address to send the funds to.
 
         :param msg: the message
         :param sender: the sender
@@ -204,13 +204,13 @@ class FIPAHandler(Handler):
         new_target = message_id
         logger.info("[{}]: received ACCEPT from sender={}".format(self.context.agent_name,
                                                                   sender[-5:]))
-        logger.info("[{}]: sending MATCH_ACCEPT_W_ADDRESS to sender={}".format(self.context.agent_name,
-                                                                               sender[-5:]))
+        logger.info("[{}]: sending MATCH_ACCEPT_W_INFORM to sender={}".format(self.context.agent_name,
+                                                                              sender[-5:]))
         match_accept_msg = FIPAMessage(message_id=new_message_id,
                                        dialogue_reference=dialogue.dialogue_label.dialogue_reference,
                                        target=new_target,
-                                       performative=FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS,
-                                       address=self.context.agent_addresses['fetchai'])
+                                       performative=FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM,
+                                       info={"address": self.context.agent_addresses['fetchai']})
         dialogue.outgoing_extend(match_accept_msg)
         self.context.outbox.put_message(to=sender,
                                         sender=self.context.agent_public_key,
@@ -237,7 +237,7 @@ class FIPAHandler(Handler):
         logger.info("[{}]: received INFORM from sender={}".format(self.context.agent_name,
                                                                   sender[-5:]))
 
-        json_data = cast(dict, msg.get("json_data"))
+        json_data = cast(dict, msg.get("info"))
         if "transaction_digest" in json_data.keys():
             tx_digest = json_data['transaction_digest']
             logger.info("[{}]: checking whether transaction={} has been received ...".format(self.context.agent_name,
@@ -262,7 +262,7 @@ class FIPAHandler(Handler):
                                          dialogue_reference=dialogue.dialogue_label.dialogue_reference,
                                          target=new_target,
                                          performative=FIPAMessage.Performative.INFORM,
-                                         json_data=dialogue.carpark_data)
+                                         info=dialogue.carpark_data)
                 dialogue.outgoing_extend(inform_msg)
                 # import pdb; pdb.set_trace()
                 self.context.outbox.put_message(to=sender,

--- a/packages/skills/weather_client/handlers.py
+++ b/packages/skills/weather_client/handlers.py
@@ -83,7 +83,7 @@ class FIPAHandler(Handler):
             self._handle_propose(fipa_msg, sender, message_id, dialogue)
         elif msg_performative == FIPAMessage.Performative.DECLINE:
             self._handle_decline(fipa_msg, sender, message_id, dialogue)
-        elif msg_performative == FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS:
+        elif msg_performative == FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM:
             self._handle_match_accept(fipa_msg, sender, message_id, dialogue)
         elif msg_performative == FIPAMessage.Performative.INFORM:
             self._handle_inform(fipa_msg, sender, message_id, dialogue)
@@ -191,7 +191,7 @@ class FIPAHandler(Handler):
                                  dialogue_reference=dialogue.dialogue_label.dialogue_reference,
                                  target=new_target_id,
                                  performative=FIPAMessage.Performative.INFORM,
-                                 json_data={"Done": "Sending payment via bank transfer"})
+                                 info={"Done": "Sending payment via bank transfer"})
         dialogue.outgoing_extend(inform_msg)
         self.context.outbox.put_message(to=counterparty_pbk,
                                         sender=self.context.agent_public_key,
@@ -212,7 +212,7 @@ class FIPAHandler(Handler):
         :return: None
         """
         logger.info("[{}]: received INFORM from sender={}".format(self.context.agent_name, sender[-5:]))
-        json_data = cast(dict, msg.get("json_data"))
+        json_data = cast(dict, msg.get("info"))
         if 'weather_data' in json_data.keys():
             weather_data = json_data['weather_data']
             logger.info("[{}]: received the following weather data={}".format(self.context.agent_name,

--- a/packages/skills/weather_client_ledger/handlers.py
+++ b/packages/skills/weather_client_ledger/handlers.py
@@ -85,7 +85,7 @@ class FIPAHandler(Handler):
             self._handle_propose(fipa_msg, sender, message_id, dialogue)
         elif msg_performative == FIPAMessage.Performative.DECLINE:
             self._handle_decline(fipa_msg, sender, message_id, dialogue)
-        elif msg_performative == FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS:
+        elif msg_performative == FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM:
             self._handle_match_accept(fipa_msg, sender, message_id, dialogue)
         elif msg_performative == FIPAMessage.Performative.INFORM:
             self._handle_inform(fipa_msg, sender, message_id, dialogue)
@@ -194,8 +194,9 @@ class FIPAHandler(Handler):
         :param dialogue: the dialogue object
         :return: None
         """
-        logger.info("[{}]: received MATCH_ACCEPT_W_ADDRESS from sender={}".format(self.context.agent_name, sender[-5:]))
-        address = cast(str, msg.get("address"))
+        logger.info("[{}]: received MATCH_ACCEPT_W_INFORM from sender={}".format(self.context.agent_name, sender[-5:]))
+        info = cast(dict, msg.get("info"))
+        address = cast(str, info.get("address"))
         strategy = cast(Strategy, self.context.strategy)
         proposal = cast(Description, dialogue.proposal)
         ledger_id = cast(str, proposal.values.get("ledger_id"))
@@ -226,7 +227,7 @@ class FIPAHandler(Handler):
         :return: None
         """
         logger.info("[{}]: received INFORM from sender={}".format(self.context.agent_name, sender[-5:]))
-        json_data = cast(dict, msg.get("json_data"))
+        json_data = cast(dict, msg.get("info"))
         if 'weather_data' in json_data.keys():
             weather_data = json_data['weather_data']
             logger.info("[{}]: received the following weather data={}".format(self.context.agent_name,
@@ -337,7 +338,7 @@ class MyTransactionHandler(Handler):
                                      dialogue_reference=dialogue.dialogue_label.dialogue_reference,
                                      target=new_target_id,
                                      performative=FIPAMessage.Performative.INFORM,
-                                     json_data=json_data)
+                                     info=json_data)
             dialogue.outgoing_extend(inform_msg)
             self.context.outbox.put_message(to=counterparty_pbk,
                                             sender=self.context.agent_public_key,

--- a/packages/skills/weather_station/handlers.py
+++ b/packages/skills/weather_station/handlers.py
@@ -186,7 +186,7 @@ class FIPAHandler(Handler):
         """
         Handle the ACCEPT.
 
-        Respond with a MATCH_ACCEPT_W_ADDRESS which contains the address to send the funds to.
+        Respond with a MATCH_ACCEPT_W_INFORM which contains the address to send the funds to.
 
         :param msg: the message
         :param sender: the sender
@@ -198,15 +198,15 @@ class FIPAHandler(Handler):
         new_target = message_id
         logger.info("[{}]: received ACCEPT from sender={}".format(self.context.agent_name,
                                                                   sender[-5:]))
-        logger.info("[{}]: sending MATCH_ACCEPT_W_ADDRESS to sender={}".format(self.context.agent_name,
-                                                                               sender[-5:]))
+        logger.info("[{}]: sending MATCH_ACCEPT_W_INFORM to sender={}".format(self.context.agent_name,
+                                                                              sender[-5:]))
         # proposal = cast(Description, dialogue.proposal)
         # identifier = cast(str, proposal.values.get("ledger_id"))
         match_accept_msg = FIPAMessage(message_id=new_message_id,
                                        dialogue_reference=dialogue.dialogue_label.dialogue_reference,
                                        target=new_target,
-                                       performative=FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS,
-                                       address="no_address")
+                                       performative=FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM,
+                                       info={"address": "no_address"})
         dialogue.outgoing_extend(match_accept_msg)
         self.context.outbox.put_message(to=sender,
                                         sender=self.context.agent_public_key,
@@ -232,13 +232,13 @@ class FIPAHandler(Handler):
         logger.info("[{}]: received INFORM from sender={}".format(self.context.agent_name,
                                                                   sender[-5:]))
 
-        json_data = cast(dict, msg.get("json_data"))
+        json_data = cast(dict, msg.get("info"))
         if "Done" in json_data:
             inform_msg = FIPAMessage(message_id=new_message_id,
                                      dialogue_reference=dialogue.dialogue_label.dialogue_reference,
                                      target=new_target,
                                      performative=FIPAMessage.Performative.INFORM,
-                                     json_data=dialogue.weather_data)
+                                     info=dialogue.weather_data)
             dialogue.outgoing_extend(inform_msg)
             # import pdb; pdb.set_trace()
             self.context.outbox.put_message(to=sender,

--- a/packages/skills/weather_station_ledger/handlers.py
+++ b/packages/skills/weather_station_ledger/handlers.py
@@ -185,7 +185,7 @@ class FIPAHandler(Handler):
         """
         Handle the ACCEPT.
 
-        Respond with a MATCH_ACCEPT_W_ADDRESS which contains the address to send the funds to.
+        Respond with a MATCH_ACCEPT_W_INFORM which contains the address to send the funds to.
 
         :param msg: the message
         :param sender: the sender
@@ -197,15 +197,15 @@ class FIPAHandler(Handler):
         new_target = message_id
         logger.info("[{}]: received ACCEPT from sender={}".format(self.context.agent_name,
                                                                   sender[-5:]))
-        logger.info("[{}]: sending MATCH_ACCEPT_W_ADDRESS to sender={}".format(self.context.agent_name,
-                                                                               sender[-5:]))
+        logger.info("[{}]: sending MATCH_ACCEPT_W_INFORM to sender={}".format(self.context.agent_name,
+                                                                              sender[-5:]))
         proposal = cast(Description, dialogue.proposal)
         identifier = cast(str, proposal.values.get("ledger_id"))
         match_accept_msg = FIPAMessage(message_id=new_message_id,
                                        dialogue_reference=dialogue.dialogue_label.dialogue_reference,
                                        target=new_target,
-                                       performative=FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS,
-                                       address=self.context.agent_addresses[identifier])
+                                       performative=FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM,
+                                       info={"address": self.context.agent_addresses[identifier]})
         dialogue.outgoing_extend(match_accept_msg)
         self.context.outbox.put_message(to=sender,
                                         sender=self.context.agent_public_key,
@@ -230,7 +230,7 @@ class FIPAHandler(Handler):
         logger.info("[{}]: received INFORM from sender={}".format(self.context.agent_name,
                                                                   sender[-5:]))
 
-        json_data = cast(dict, msg.get("json_data"))
+        json_data = cast(dict, msg.get("info"))
         if "transaction_digest" in json_data.keys():
             tx_digest = json_data['transaction_digest']
             logger.info("[{}]: checking whether transaction={} has been received ...".format(self.context.agent_name,
@@ -250,7 +250,7 @@ class FIPAHandler(Handler):
                                          dialogue_reference=dialogue.dialogue_label.dialogue_reference,
                                          target=new_target,
                                          performative=FIPAMessage.Performative.INFORM,
-                                         json_data=dialogue.weather_data)
+                                         info=dialogue.weather_data)
                 dialogue.outgoing_extend(inform_msg)
                 # import pdb; pdb.set_trace()
                 self.context.outbox.put_message(to=sender,

--- a/tests/data/dummy_aea/protocols/fipa/fipa.proto
+++ b/tests/data/dummy_aea/protocols/fipa/fipa.proto
@@ -20,24 +20,18 @@ message FIPAMessage{
 
     message MatchAccept{}
 
-    message Accept_W_Address{
-        string address = 1;
-    }
-
-    message MatchAccept_W_Address{
-        string address = 1;
-    }
     message Decline{}
+
     message Inform{
         bytes bytes = 1;
     }
 
-    message AcceptWAddress{
-        string address = 1;
+    message AcceptWInform{
+        bytes bytes = 1;
     }
 
-    message MatchAcceptWAddress{
-        string address = 1;
+    message MatchAcceptWInform{
+        bytes bytes = 1;
     }
 
     int32 message_id = 1;
@@ -51,7 +45,7 @@ message FIPAMessage{
         MatchAccept match_accept = 8;
         Decline decline = 9;
         Inform inform = 10;
-        AcceptWAddress accept_w_address = 11;
-        MatchAcceptWAddress match_accept_w_address = 12;
+        AcceptWInform accept_w_inform = 11;
+        MatchAcceptWInform match_accept_w_inform = 12;
     }
 }

--- a/tests/data/dummy_aea/protocols/fipa/fipa_pb2.py
+++ b/tests/data/dummy_aea/protocols/fipa/fipa_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='fetch.aea.fipa',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\nfipa.proto\x12\x0e\x66\x65tch.aea.fipa\"\xe6\x07\n\x0b\x46IPAMessage\x12\x12\n\nmessage_id\x18\x01 \x01(\x05\x12\"\n\x1a\x64ialogue_starter_reference\x18\x02 \x01(\t\x12$\n\x1c\x64ialogue_responder_reference\x18\x03 \x01(\t\x12\x0e\n\x06target\x18\x04 \x01(\x05\x12.\n\x03\x63\x66p\x18\x05 \x01(\x0b\x32\x1f.fetch.aea.fipa.FIPAMessage.CFPH\x00\x12\x36\n\x07propose\x18\x06 \x01(\x0b\x32#.fetch.aea.fipa.FIPAMessage.ProposeH\x00\x12\x34\n\x06\x61\x63\x63\x65pt\x18\x07 \x01(\x0b\x32\".fetch.aea.fipa.FIPAMessage.AcceptH\x00\x12?\n\x0cmatch_accept\x18\x08 \x01(\x0b\x32\'.fetch.aea.fipa.FIPAMessage.MatchAcceptH\x00\x12\x36\n\x07\x64\x65\x63line\x18\t \x01(\x0b\x32#.fetch.aea.fipa.FIPAMessage.DeclineH\x00\x12\x34\n\x06inform\x18\n \x01(\x0b\x32\".fetch.aea.fipa.FIPAMessage.InformH\x00\x12\x46\n\x10\x61\x63\x63\x65pt_w_address\x18\x0b \x01(\x0b\x32*.fetch.aea.fipa.FIPAMessage.AcceptWAddressH\x00\x12Q\n\x16match_accept_w_address\x18\x0c \x01(\x0b\x32/.fetch.aea.fipa.FIPAMessage.MatchAcceptWAddressH\x00\x1a}\n\x03\x43\x46P\x12\x0f\n\x05\x62ytes\x18\x01 \x01(\x0cH\x00\x12:\n\x07nothing\x18\x02 \x01(\x0b\x32\'.fetch.aea.fipa.FIPAMessage.CFP.NothingH\x00\x12\x15\n\x0bquery_bytes\x18\x03 \x01(\x0cH\x00\x1a\t\n\x07NothingB\x07\n\x05query\x1a\x1b\n\x07Propose\x12\x10\n\x08proposal\x18\x01 \x03(\x0c\x1a\x08\n\x06\x41\x63\x63\x65pt\x1a\r\n\x0bMatchAccept\x1a#\n\x10\x41\x63\x63\x65pt_W_Address\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x1a(\n\x15MatchAccept_W_Address\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x1a\t\n\x07\x44\x65\x63line\x1a\x17\n\x06Inform\x12\r\n\x05\x62ytes\x18\x01 \x01(\x0c\x1a!\n\x0e\x41\x63\x63\x65ptWAddress\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x1a&\n\x13MatchAcceptWAddress\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\tB\x0e\n\x0cperformativeb\x06proto3')
+  serialized_pb=_b('\n\nfipa.proto\x12\x0e\x66\x65tch.aea.fipa\"\x8d\x07\n\x0b\x46IPAMessage\x12\x12\n\nmessage_id\x18\x01 \x01(\x05\x12\"\n\x1a\x64ialogue_starter_reference\x18\x02 \x01(\t\x12$\n\x1c\x64ialogue_responder_reference\x18\x03 \x01(\t\x12\x0e\n\x06target\x18\x04 \x01(\x05\x12.\n\x03\x63\x66p\x18\x05 \x01(\x0b\x32\x1f.fetch.aea.fipa.FIPAMessage.CFPH\x00\x12\x36\n\x07propose\x18\x06 \x01(\x0b\x32#.fetch.aea.fipa.FIPAMessage.ProposeH\x00\x12\x34\n\x06\x61\x63\x63\x65pt\x18\x07 \x01(\x0b\x32\".fetch.aea.fipa.FIPAMessage.AcceptH\x00\x12?\n\x0cmatch_accept\x18\x08 \x01(\x0b\x32\'.fetch.aea.fipa.FIPAMessage.MatchAcceptH\x00\x12\x36\n\x07\x64\x65\x63line\x18\t \x01(\x0b\x32#.fetch.aea.fipa.FIPAMessage.DeclineH\x00\x12\x34\n\x06inform\x18\n \x01(\x0b\x32\".fetch.aea.fipa.FIPAMessage.InformH\x00\x12\x44\n\x0f\x61\x63\x63\x65pt_w_inform\x18\x0b \x01(\x0b\x32).fetch.aea.fipa.FIPAMessage.AcceptWInformH\x00\x12O\n\x15match_accept_w_inform\x18\x0c \x01(\x0b\x32..fetch.aea.fipa.FIPAMessage.MatchAcceptWInformH\x00\x1a}\n\x03\x43\x46P\x12\x0f\n\x05\x62ytes\x18\x01 \x01(\x0cH\x00\x12:\n\x07nothing\x18\x02 \x01(\x0b\x32\'.fetch.aea.fipa.FIPAMessage.CFP.NothingH\x00\x12\x15\n\x0bquery_bytes\x18\x03 \x01(\x0cH\x00\x1a\t\n\x07NothingB\x07\n\x05query\x1a\x1b\n\x07Propose\x12\x10\n\x08proposal\x18\x01 \x03(\x0c\x1a\x08\n\x06\x41\x63\x63\x65pt\x1a\r\n\x0bMatchAccept\x1a\t\n\x07\x44\x65\x63line\x1a\x17\n\x06Inform\x12\r\n\x05\x62ytes\x18\x01 \x01(\x0c\x1a\x1e\n\rAcceptWInform\x12\r\n\x05\x62ytes\x18\x01 \x01(\x0c\x1a#\n\x12MatchAcceptWInform\x12\r\n\x05\x62ytes\x18\x01 \x01(\x0c\x42\x0e\n\x0cperformativeb\x06proto3')
 )
 
 
@@ -45,8 +45,8 @@ _FIPAMESSAGE_CFP_NOTHING = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=751,
-  serialized_end=760,
+  serialized_start=747,
+  serialized_end=756,
 )
 
 _FIPAMESSAGE_CFP = _descriptor.Descriptor(
@@ -92,8 +92,8 @@ _FIPAMESSAGE_CFP = _descriptor.Descriptor(
       name='query', full_name='fetch.aea.fipa.FIPAMessage.CFP.query',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=644,
-  serialized_end=769,
+  serialized_start=640,
+  serialized_end=765,
 )
 
 _FIPAMESSAGE_PROPOSE = _descriptor.Descriptor(
@@ -122,8 +122,8 @@ _FIPAMESSAGE_PROPOSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=771,
-  serialized_end=798,
+  serialized_start=767,
+  serialized_end=794,
 )
 
 _FIPAMESSAGE_ACCEPT = _descriptor.Descriptor(
@@ -145,8 +145,8 @@ _FIPAMESSAGE_ACCEPT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=800,
-  serialized_end=808,
+  serialized_start=796,
+  serialized_end=804,
 )
 
 _FIPAMESSAGE_MATCHACCEPT = _descriptor.Descriptor(
@@ -168,68 +168,8 @@ _FIPAMESSAGE_MATCHACCEPT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=810,
-  serialized_end=823,
-)
-
-_FIPAMESSAGE_ACCEPT_W_ADDRESS = _descriptor.Descriptor(
-  name='Accept_W_Address',
-  full_name='fetch.aea.fipa.FIPAMessage.Accept_W_Address',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='address', full_name='fetch.aea.fipa.FIPAMessage.Accept_W_Address.address', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=825,
-  serialized_end=860,
-)
-
-_FIPAMESSAGE_MATCHACCEPT_W_ADDRESS = _descriptor.Descriptor(
-  name='MatchAccept_W_Address',
-  full_name='fetch.aea.fipa.FIPAMessage.MatchAccept_W_Address',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='address', full_name='fetch.aea.fipa.FIPAMessage.MatchAccept_W_Address.address', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=862,
-  serialized_end=902,
+  serialized_start=806,
+  serialized_end=819,
 )
 
 _FIPAMESSAGE_DECLINE = _descriptor.Descriptor(
@@ -251,8 +191,8 @@ _FIPAMESSAGE_DECLINE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=904,
-  serialized_end=913,
+  serialized_start=821,
+  serialized_end=830,
 )
 
 _FIPAMESSAGE_INFORM = _descriptor.Descriptor(
@@ -281,21 +221,21 @@ _FIPAMESSAGE_INFORM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=915,
-  serialized_end=938,
+  serialized_start=832,
+  serialized_end=855,
 )
 
-_FIPAMESSAGE_ACCEPTWADDRESS = _descriptor.Descriptor(
-  name='AcceptWAddress',
-  full_name='fetch.aea.fipa.FIPAMessage.AcceptWAddress',
+_FIPAMESSAGE_ACCEPTWINFORM = _descriptor.Descriptor(
+  name='AcceptWInform',
+  full_name='fetch.aea.fipa.FIPAMessage.AcceptWInform',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='address', full_name='fetch.aea.fipa.FIPAMessage.AcceptWAddress.address', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
+      name='bytes', full_name='fetch.aea.fipa.FIPAMessage.AcceptWInform.bytes', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
@@ -311,21 +251,21 @@ _FIPAMESSAGE_ACCEPTWADDRESS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=940,
-  serialized_end=973,
+  serialized_start=857,
+  serialized_end=887,
 )
 
-_FIPAMESSAGE_MATCHACCEPTWADDRESS = _descriptor.Descriptor(
-  name='MatchAcceptWAddress',
-  full_name='fetch.aea.fipa.FIPAMessage.MatchAcceptWAddress',
+_FIPAMESSAGE_MATCHACCEPTWINFORM = _descriptor.Descriptor(
+  name='MatchAcceptWInform',
+  full_name='fetch.aea.fipa.FIPAMessage.MatchAcceptWInform',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='address', full_name='fetch.aea.fipa.FIPAMessage.MatchAcceptWAddress.address', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
+      name='bytes', full_name='fetch.aea.fipa.FIPAMessage.MatchAcceptWInform.bytes', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
@@ -341,8 +281,8 @@ _FIPAMESSAGE_MATCHACCEPTWADDRESS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=975,
-  serialized_end=1013,
+  serialized_start=889,
+  serialized_end=924,
 )
 
 _FIPAMESSAGE = _descriptor.Descriptor(
@@ -423,14 +363,14 @@ _FIPAMESSAGE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='accept_w_address', full_name='fetch.aea.fipa.FIPAMessage.accept_w_address', index=10,
+      name='accept_w_inform', full_name='fetch.aea.fipa.FIPAMessage.accept_w_inform', index=10,
       number=11, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='match_accept_w_address', full_name='fetch.aea.fipa.FIPAMessage.match_accept_w_address', index=11,
+      name='match_accept_w_inform', full_name='fetch.aea.fipa.FIPAMessage.match_accept_w_inform', index=11,
       number=12, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -439,7 +379,7 @@ _FIPAMESSAGE = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_FIPAMESSAGE_CFP, _FIPAMESSAGE_PROPOSE, _FIPAMESSAGE_ACCEPT, _FIPAMESSAGE_MATCHACCEPT, _FIPAMESSAGE_ACCEPT_W_ADDRESS, _FIPAMESSAGE_MATCHACCEPT_W_ADDRESS, _FIPAMESSAGE_DECLINE, _FIPAMESSAGE_INFORM, _FIPAMESSAGE_ACCEPTWADDRESS, _FIPAMESSAGE_MATCHACCEPTWADDRESS, ],
+  nested_types=[_FIPAMESSAGE_CFP, _FIPAMESSAGE_PROPOSE, _FIPAMESSAGE_ACCEPT, _FIPAMESSAGE_MATCHACCEPT, _FIPAMESSAGE_DECLINE, _FIPAMESSAGE_INFORM, _FIPAMESSAGE_ACCEPTWINFORM, _FIPAMESSAGE_MATCHACCEPTWINFORM, ],
   enum_types=[
   ],
   serialized_options=None,
@@ -452,7 +392,7 @@ _FIPAMESSAGE = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=31,
-  serialized_end=1029,
+  serialized_end=940,
 )
 
 _FIPAMESSAGE_CFP_NOTHING.containing_type = _FIPAMESSAGE_CFP
@@ -470,20 +410,18 @@ _FIPAMESSAGE_CFP.fields_by_name['query_bytes'].containing_oneof = _FIPAMESSAGE_C
 _FIPAMESSAGE_PROPOSE.containing_type = _FIPAMESSAGE
 _FIPAMESSAGE_ACCEPT.containing_type = _FIPAMESSAGE
 _FIPAMESSAGE_MATCHACCEPT.containing_type = _FIPAMESSAGE
-_FIPAMESSAGE_ACCEPT_W_ADDRESS.containing_type = _FIPAMESSAGE
-_FIPAMESSAGE_MATCHACCEPT_W_ADDRESS.containing_type = _FIPAMESSAGE
 _FIPAMESSAGE_DECLINE.containing_type = _FIPAMESSAGE
 _FIPAMESSAGE_INFORM.containing_type = _FIPAMESSAGE
-_FIPAMESSAGE_ACCEPTWADDRESS.containing_type = _FIPAMESSAGE
-_FIPAMESSAGE_MATCHACCEPTWADDRESS.containing_type = _FIPAMESSAGE
+_FIPAMESSAGE_ACCEPTWINFORM.containing_type = _FIPAMESSAGE
+_FIPAMESSAGE_MATCHACCEPTWINFORM.containing_type = _FIPAMESSAGE
 _FIPAMESSAGE.fields_by_name['cfp'].message_type = _FIPAMESSAGE_CFP
 _FIPAMESSAGE.fields_by_name['propose'].message_type = _FIPAMESSAGE_PROPOSE
 _FIPAMESSAGE.fields_by_name['accept'].message_type = _FIPAMESSAGE_ACCEPT
 _FIPAMESSAGE.fields_by_name['match_accept'].message_type = _FIPAMESSAGE_MATCHACCEPT
 _FIPAMESSAGE.fields_by_name['decline'].message_type = _FIPAMESSAGE_DECLINE
 _FIPAMESSAGE.fields_by_name['inform'].message_type = _FIPAMESSAGE_INFORM
-_FIPAMESSAGE.fields_by_name['accept_w_address'].message_type = _FIPAMESSAGE_ACCEPTWADDRESS
-_FIPAMESSAGE.fields_by_name['match_accept_w_address'].message_type = _FIPAMESSAGE_MATCHACCEPTWADDRESS
+_FIPAMESSAGE.fields_by_name['accept_w_inform'].message_type = _FIPAMESSAGE_ACCEPTWINFORM
+_FIPAMESSAGE.fields_by_name['match_accept_w_inform'].message_type = _FIPAMESSAGE_MATCHACCEPTWINFORM
 _FIPAMESSAGE.oneofs_by_name['performative'].fields.append(
   _FIPAMESSAGE.fields_by_name['cfp'])
 _FIPAMESSAGE.fields_by_name['cfp'].containing_oneof = _FIPAMESSAGE.oneofs_by_name['performative']
@@ -503,11 +441,11 @@ _FIPAMESSAGE.oneofs_by_name['performative'].fields.append(
   _FIPAMESSAGE.fields_by_name['inform'])
 _FIPAMESSAGE.fields_by_name['inform'].containing_oneof = _FIPAMESSAGE.oneofs_by_name['performative']
 _FIPAMESSAGE.oneofs_by_name['performative'].fields.append(
-  _FIPAMESSAGE.fields_by_name['accept_w_address'])
-_FIPAMESSAGE.fields_by_name['accept_w_address'].containing_oneof = _FIPAMESSAGE.oneofs_by_name['performative']
+  _FIPAMESSAGE.fields_by_name['accept_w_inform'])
+_FIPAMESSAGE.fields_by_name['accept_w_inform'].containing_oneof = _FIPAMESSAGE.oneofs_by_name['performative']
 _FIPAMESSAGE.oneofs_by_name['performative'].fields.append(
-  _FIPAMESSAGE.fields_by_name['match_accept_w_address'])
-_FIPAMESSAGE.fields_by_name['match_accept_w_address'].containing_oneof = _FIPAMESSAGE.oneofs_by_name['performative']
+  _FIPAMESSAGE.fields_by_name['match_accept_w_inform'])
+_FIPAMESSAGE.fields_by_name['match_accept_w_inform'].containing_oneof = _FIPAMESSAGE.oneofs_by_name['performative']
 DESCRIPTOR.message_types_by_name['FIPAMessage'] = _FIPAMESSAGE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -548,20 +486,6 @@ FIPAMessage = _reflection.GeneratedProtocolMessageType('FIPAMessage', (_message.
     ))
   ,
 
-  Accept_W_Address = _reflection.GeneratedProtocolMessageType('Accept_W_Address', (_message.Message,), dict(
-    DESCRIPTOR = _FIPAMESSAGE_ACCEPT_W_ADDRESS,
-    __module__ = 'fipa_pb2'
-    # @@protoc_insertion_point(class_scope:fetch.aea.fipa.FIPAMessage.Accept_W_Address)
-    ))
-  ,
-
-  MatchAccept_W_Address = _reflection.GeneratedProtocolMessageType('MatchAccept_W_Address', (_message.Message,), dict(
-    DESCRIPTOR = _FIPAMESSAGE_MATCHACCEPT_W_ADDRESS,
-    __module__ = 'fipa_pb2'
-    # @@protoc_insertion_point(class_scope:fetch.aea.fipa.FIPAMessage.MatchAccept_W_Address)
-    ))
-  ,
-
   Decline = _reflection.GeneratedProtocolMessageType('Decline', (_message.Message,), dict(
     DESCRIPTOR = _FIPAMESSAGE_DECLINE,
     __module__ = 'fipa_pb2'
@@ -576,17 +500,17 @@ FIPAMessage = _reflection.GeneratedProtocolMessageType('FIPAMessage', (_message.
     ))
   ,
 
-  AcceptWAddress = _reflection.GeneratedProtocolMessageType('AcceptWAddress', (_message.Message,), dict(
-    DESCRIPTOR = _FIPAMESSAGE_ACCEPTWADDRESS,
+  AcceptWInform = _reflection.GeneratedProtocolMessageType('AcceptWInform', (_message.Message,), dict(
+    DESCRIPTOR = _FIPAMESSAGE_ACCEPTWINFORM,
     __module__ = 'fipa_pb2'
-    # @@protoc_insertion_point(class_scope:fetch.aea.fipa.FIPAMessage.AcceptWAddress)
+    # @@protoc_insertion_point(class_scope:fetch.aea.fipa.FIPAMessage.AcceptWInform)
     ))
   ,
 
-  MatchAcceptWAddress = _reflection.GeneratedProtocolMessageType('MatchAcceptWAddress', (_message.Message,), dict(
-    DESCRIPTOR = _FIPAMESSAGE_MATCHACCEPTWADDRESS,
+  MatchAcceptWInform = _reflection.GeneratedProtocolMessageType('MatchAcceptWInform', (_message.Message,), dict(
+    DESCRIPTOR = _FIPAMESSAGE_MATCHACCEPTWINFORM,
     __module__ = 'fipa_pb2'
-    # @@protoc_insertion_point(class_scope:fetch.aea.fipa.FIPAMessage.MatchAcceptWAddress)
+    # @@protoc_insertion_point(class_scope:fetch.aea.fipa.FIPAMessage.MatchAcceptWInform)
     ))
   ,
   DESCRIPTOR = _FIPAMESSAGE,
@@ -599,12 +523,10 @@ _sym_db.RegisterMessage(FIPAMessage.CFP.Nothing)
 _sym_db.RegisterMessage(FIPAMessage.Propose)
 _sym_db.RegisterMessage(FIPAMessage.Accept)
 _sym_db.RegisterMessage(FIPAMessage.MatchAccept)
-_sym_db.RegisterMessage(FIPAMessage.Accept_W_Address)
-_sym_db.RegisterMessage(FIPAMessage.MatchAccept_W_Address)
 _sym_db.RegisterMessage(FIPAMessage.Decline)
 _sym_db.RegisterMessage(FIPAMessage.Inform)
-_sym_db.RegisterMessage(FIPAMessage.AcceptWAddress)
-_sym_db.RegisterMessage(FIPAMessage.MatchAcceptWAddress)
+_sym_db.RegisterMessage(FIPAMessage.AcceptWInform)
+_sym_db.RegisterMessage(FIPAMessage.MatchAcceptWInform)
 
 
 # @@protoc_insertion_point(module_scope)

--- a/tests/data/dummy_aea/protocols/fipa/message.py
+++ b/tests/data/dummy_aea/protocols/fipa/message.py
@@ -43,8 +43,8 @@ class FIPAMessage(Message):
         MATCH_ACCEPT = "match_accept"
         DECLINE = "decline"
         INFORM = "inform"
-        ACCEPT_W_ADDRESS = "accept_w_address"
-        MATCH_ACCEPT_W_ADDRESS = "match_accept_w_address"
+        ACCEPT_W_INFORM = "accept_w_inform"
+        MATCH_ACCEPT_W_INFORM = "match_accept_w_inform"
 
         def __str__(self):
             """Get string representation."""
@@ -97,13 +97,11 @@ class FIPAMessage(Message):
                     or performative == FIPAMessage.Performative.MATCH_ACCEPT \
                     or performative == FIPAMessage.Performative.DECLINE:
                 assert len(self.body) == 4
-            elif performative == FIPAMessage.Performative.ACCEPT_W_ADDRESS\
-                    or performative == FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS:
-                assert self.is_set("address")
-                assert len(self.body) == 5
-            elif performative == FIPAMessage.Performative.INFORM:
-                assert self.is_set("json_data")
-                json_data = self.get("json_data")
+            elif performative == FIPAMessage.Performative.ACCEPT_W_INFORM\
+                    or performative == FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM\
+                    or performative == FIPAMessage.Performative.INFORM:
+                assert self.is_set("info")
+                json_data = self.get("info")
                 assert isinstance(json_data, dict)
                 assert len(self.body) == 5
             else:
@@ -119,9 +117,9 @@ VALID_PREVIOUS_PERFORMATIVES = {
     FIPAMessage.Performative.CFP: [None],
     FIPAMessage.Performative.PROPOSE: [FIPAMessage.Performative.CFP],
     FIPAMessage.Performative.ACCEPT: [FIPAMessage.Performative.PROPOSE],
-    FIPAMessage.Performative.ACCEPT_W_ADDRESS: [FIPAMessage.Performative.PROPOSE],
-    FIPAMessage.Performative.MATCH_ACCEPT: [FIPAMessage.Performative.ACCEPT, FIPAMessage.Performative.ACCEPT_W_ADDRESS],
-    FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS: [FIPAMessage.Performative.ACCEPT, FIPAMessage.Performative.ACCEPT_W_ADDRESS],
-    FIPAMessage.Performative.INFORM: [FIPAMessage.Performative.MATCH_ACCEPT, FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS, FIPAMessage.Performative.INFORM],
-    FIPAMessage.Performative.DECLINE: [FIPAMessage.Performative.CFP, FIPAMessage.Performative.PROPOSE, FIPAMessage.Performative.ACCEPT, FIPAMessage.Performative.ACCEPT_W_ADDRESS]
+    FIPAMessage.Performative.ACCEPT_W_INFORM: [FIPAMessage.Performative.PROPOSE],
+    FIPAMessage.Performative.MATCH_ACCEPT: [FIPAMessage.Performative.ACCEPT, FIPAMessage.Performative.ACCEPT_W_INFORM],
+    FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM: [FIPAMessage.Performative.ACCEPT, FIPAMessage.Performative.ACCEPT_W_INFORM],
+    FIPAMessage.Performative.INFORM: [FIPAMessage.Performative.MATCH_ACCEPT, FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM, FIPAMessage.Performative.INFORM],
+    FIPAMessage.Performative.DECLINE: [FIPAMessage.Performative.CFP, FIPAMessage.Performative.PROPOSE, FIPAMessage.Performative.ACCEPT, FIPAMessage.Performative.ACCEPT_W_INFORM]
 }  # type: Dict[FIPAMessage.Performative, List[Union[None, FIPAMessage.Performative]]]

--- a/tests/data/dummy_aea/protocols/fipa/serialization.py
+++ b/tests/data/dummy_aea/protocols/fipa/serialization.py
@@ -69,24 +69,24 @@ class FIPASerializer(Serializer):
         elif performative_id == FIPAMessage.Performative.MATCH_ACCEPT:
             performative = fipa_pb2.FIPAMessage.MatchAccept()  # type: ignore
             fipa_msg.match_accept.CopyFrom(performative)
-        elif performative_id == FIPAMessage.Performative.ACCEPT_W_ADDRESS:
-            performative = fipa_pb2.FIPAMessage.AcceptWAddress()  # type: ignore
-            address = msg.get("address")
-            if type(address) == str:
-                performative.address = address
-            fipa_msg.accept_w_address.CopyFrom(performative)
-        elif performative_id == FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS:
-            performative = fipa_pb2.FIPAMessage.MatchAcceptWAddress()  # type: ignore
-            address = msg.get("address")
-            if type(address) == str:
-                performative.address = address
-            fipa_msg.match_accept_w_address.CopyFrom(performative)
+        elif performative_id == FIPAMessage.Performative.ACCEPT_W_INFORM:
+            performative = fipa_pb2.FIPAMessage.AcceptWInform()  # type: ignore
+            data = msg.get("info")
+            data_bytes = json.dumps(data).encode("utf-8")
+            performative.bytes = data_bytes
+            fipa_msg.accept_w_inform.CopyFrom(performative)
+        elif performative_id == FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM:
+            performative = fipa_pb2.FIPAMessage.MatchAcceptWInform()  # type: ignore
+            data = msg.get("info")
+            data_bytes = json.dumps(data).encode("utf-8")
+            performative.bytes = data_bytes
+            fipa_msg.match_accept_w_inform.CopyFrom(performative)
         elif performative_id == FIPAMessage.Performative.DECLINE:
             performative = fipa_pb2.FIPAMessage.Decline()  # type: ignore
             fipa_msg.decline.CopyFrom(performative)
         elif performative_id == FIPAMessage.Performative.INFORM:
             performative = fipa_pb2.FIPAMessage.Inform()  # type: ignore
-            data = msg.get("json_data")
+            data = msg.get("info")
             data_bytes = json.dumps(data).encode("utf-8")
             performative.bytes = data_bytes
             fipa_msg.inform.CopyFrom(performative)
@@ -128,17 +128,17 @@ class FIPASerializer(Serializer):
             pass
         elif performative_id == FIPAMessage.Performative.MATCH_ACCEPT:
             pass
-        elif performative_id == FIPAMessage.Performative.ACCEPT_W_ADDRESS:
-            address = fipa_pb.accept_w_address.address
-            performative_content['address'] = address
-        elif performative_id == FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS:
-            address = fipa_pb.match_accept_w_address.address
-            performative_content['address'] = address
+        elif performative_id == FIPAMessage.Performative.ACCEPT_W_INFORM:
+            info = json.loads(fipa_pb.accept_w_inform.bytes)
+            performative_content['info'] = info
+        elif performative_id == FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM:
+            info = json.loads(fipa_pb.match_accept_w_inform.bytes)
+            performative_content['info'] = info
         elif performative_id == FIPAMessage.Performative.DECLINE:
             pass
         elif performative_id == FIPAMessage.Performative.INFORM:
-            data = json.loads(fipa_pb.inform.bytes)
-            performative_content["json_data"] = data
+            info = json.loads(fipa_pb.inform.bytes)
+            performative_content["info"] = info
         else:
             raise ValueError("Performative not valid: {}.".format(performative))
 

--- a/tests/test_connections/test_oef/test_communication.py
+++ b/tests/test_connections/test_oef/test_communication.py
@@ -390,10 +390,10 @@ class TestFIPA:
     def test_match_accept_w_inform(self):
         """Test that a match accept with inform can be sent correctly."""
         match_accept_w_inform = FIPAMessage(message_id=0,
-                                             dialogue_reference=(str(0), ''),
-                                             target=0,
-                                             performative=FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM,
-                                             info={"address": "my_address"})
+                                            dialogue_reference=(str(0), ''),
+                                            target=0,
+                                            performative=FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM,
+                                            info={"address": "my_address"})
         self.multiplexer1.put(Envelope(to=self.crypto2.public_key,
                                        sender=self.crypto1.public_key,
                                        protocol_id=FIPAMessage.protocol_id,
@@ -405,10 +405,10 @@ class TestFIPA:
     def test_accept_w_inform(self):
         """Test that an accept with address can be sent correctly."""
         accept_w_inform = FIPAMessage(message_id=0,
-                                       dialogue_reference=(str(0), ''),
-                                       target=0,
-                                       performative=FIPAMessage.Performative.ACCEPT_W_INFORM,
-                                       info={"address": "my_address"})
+                                      dialogue_reference=(str(0), ''),
+                                      target=0,
+                                      performative=FIPAMessage.Performative.ACCEPT_W_INFORM,
+                                      info={"address": "my_address"})
         self.multiplexer1.put(Envelope(to=self.crypto2.public_key,
                                        sender=self.crypto1.public_key,
                                        protocol_id=FIPAMessage.protocol_id,

--- a/tests/test_connections/test_oef/test_communication.py
+++ b/tests/test_connections/test_oef/test_communication.py
@@ -387,9 +387,9 @@ class TestFIPA:
         expected_decline = FIPASerializer().decode(envelope.message)
         assert expected_decline == decline
 
-    def test_match_accept_w_address(self):
-        """Test that a match accept with address can be sent correctly."""
-        match_accept_w_address = FIPAMessage(message_id=0,
+    def test_match_accept_w_inform(self):
+        """Test that a match accept with inform can be sent correctly."""
+        match_accept_w_inform = FIPAMessage(message_id=0,
                                              dialogue_reference=(str(0), ''),
                                              target=0,
                                              performative=FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM,
@@ -397,14 +397,14 @@ class TestFIPA:
         self.multiplexer1.put(Envelope(to=self.crypto2.public_key,
                                        sender=self.crypto1.public_key,
                                        protocol_id=FIPAMessage.protocol_id,
-                                       message=FIPASerializer().encode(match_accept_w_address)))
+                                       message=FIPASerializer().encode(match_accept_w_inform)))
         envelope = self.multiplexer2.get(block=True, timeout=2.0)
-        returned_match_accept_w_address = FIPASerializer().decode(envelope.message)
-        assert returned_match_accept_w_address == match_accept_w_address
+        returned_match_accept_w_inform = FIPASerializer().decode(envelope.message)
+        assert returned_match_accept_w_inform == match_accept_w_inform
 
-    def test_accept_w_address(self):
+    def test_accept_w_inform(self):
         """Test that an accept with address can be sent correctly."""
-        accept_w_address = FIPAMessage(message_id=0,
+        accept_w_inform = FIPAMessage(message_id=0,
                                        dialogue_reference=(str(0), ''),
                                        target=0,
                                        performative=FIPAMessage.Performative.ACCEPT_W_INFORM,
@@ -412,10 +412,10 @@ class TestFIPA:
         self.multiplexer1.put(Envelope(to=self.crypto2.public_key,
                                        sender=self.crypto1.public_key,
                                        protocol_id=FIPAMessage.protocol_id,
-                                       message=FIPASerializer().encode(accept_w_address)))
+                                       message=FIPASerializer().encode(accept_w_inform)))
         envelope = self.multiplexer2.get(block=True, timeout=2.0)
-        returned_accept_w_address = FIPASerializer().decode(envelope.message)
-        assert returned_accept_w_address == accept_w_address
+        returned_accept_w_inform = FIPASerializer().decode(envelope.message)
+        assert returned_accept_w_inform == accept_w_inform
 
     def test_inform(self):
         """Test that an inform can be sent correctly."""

--- a/tests/test_connections/test_oef/test_communication.py
+++ b/tests/test_connections/test_oef/test_communication.py
@@ -392,8 +392,8 @@ class TestFIPA:
         match_accept_w_address = FIPAMessage(message_id=0,
                                              dialogue_reference=(str(0), ''),
                                              target=0,
-                                             performative=FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS,
-                                             address='my_address')
+                                             performative=FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM,
+                                             info={"address": "my_address"})
         self.multiplexer1.put(Envelope(to=self.crypto2.public_key,
                                        sender=self.crypto1.public_key,
                                        protocol_id=FIPAMessage.protocol_id,
@@ -407,8 +407,8 @@ class TestFIPA:
         accept_w_address = FIPAMessage(message_id=0,
                                        dialogue_reference=(str(0), ''),
                                        target=0,
-                                       performative=FIPAMessage.Performative.ACCEPT_W_ADDRESS,
-                                       address='my_address')
+                                       performative=FIPAMessage.Performative.ACCEPT_W_INFORM,
+                                       info={"address": "my_address"})
         self.multiplexer1.put(Envelope(to=self.crypto2.public_key,
                                        sender=self.crypto1.public_key,
                                        protocol_id=FIPAMessage.protocol_id,
@@ -424,7 +424,7 @@ class TestFIPA:
                              dialogue_reference=(str(0), ''),
                              target=0,
                              performative=FIPAMessage.Performative.INFORM,
-                             json_data=payload)
+                             info=payload)
         self.multiplexer1.put(Envelope(to=self.crypto2.public_key,
                                        sender=self.crypto1.public_key,
                                        protocol_id=FIPAMessage.protocol_id,

--- a/tests/test_protocols/test_fipa.py
+++ b/tests/test_protocols/test_fipa.py
@@ -252,9 +252,9 @@ def test_performative_string_value():
     assert str(FIPAMessage.Performative.MATCH_ACCEPT) == "match_accept",\
         "The str value must be match_accept"
     assert str(FIPAMessage.Performative.ACCEPT_W_INFORM) == "accept_w_inform", \
-        "The str value must be accept_w_address"
+        "The str value must be accept_w_inform"
     assert str(FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM) == "match_accept_w_inform", \
-        "The str value must be match_accept_w_address"
+        "The str value must be match_accept_w_inform"
     assert str(FIPAMessage.Performative.INFORM) == "inform", \
         "The str value must be inform"
 

--- a/tests/test_protocols/test_fipa.py
+++ b/tests/test_protocols/test_fipa.py
@@ -173,13 +173,13 @@ def test_performative_not_recognized():
             "We expect that the check_consistency will return False"
 
 
-def test_performative_accept_with_address():
+def test_performative_accept_with_inform():
     """Test the serialization - deserialization of the accept_with_address performative."""
     msg = FIPAMessage(message_id=0,
                       dialogue_reference=(str(0), ''),
                       target=1,
-                      performative=FIPAMessage.Performative.ACCEPT_W_ADDRESS,
-                      address="dummy_address")
+                      performative=FIPAMessage.Performative.ACCEPT_W_INFORM,
+                      info={"address": "dummy_address"})
 
     msg_bytes = FIPASerializer().encode(msg)
     envelope = Envelope(to="receiver",
@@ -195,13 +195,13 @@ def test_performative_accept_with_address():
     assert msg.get("performative") == deserialised_msg.get("performative")
 
 
-def test_performative_match_accept_with_address():
+def test_performative_match_accept_with_inform():
     """Test the serialization - deserialization of the match_accept_with_address performative."""
     msg = FIPAMessage(message_id=0,
                       dialogue_reference=(str(0), ''),
                       target=1,
-                      performative=FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS,
-                      address="dummy_address")
+                      performative=FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM,
+                      info={"address": "dummy_address", "signature": "my_signature"})
 
     msg_bytes = FIPASerializer().encode(msg)
     envelope = Envelope(to="receiver",
@@ -223,7 +223,7 @@ def test_performative_inform():
                       dialogue_reference=(str(0), ''),
                       target=1,
                       performative=FIPAMessage.Performative.INFORM,
-                      json_data={"foo": "bar"})
+                      info={"foo": "bar"})
 
     msg_bytes = FIPASerializer().encode(msg)
     envelope = Envelope(to="receiver",
@@ -251,9 +251,9 @@ def test_performative_string_value():
         "The str value must be accept"
     assert str(FIPAMessage.Performative.MATCH_ACCEPT) == "match_accept",\
         "The str value must be match_accept"
-    assert str(FIPAMessage.Performative.ACCEPT_W_ADDRESS) == "accept_w_address", \
+    assert str(FIPAMessage.Performative.ACCEPT_W_INFORM) == "accept_w_inform", \
         "The str value must be accept_w_address"
-    assert str(FIPAMessage.Performative.MATCH_ACCEPT_W_ADDRESS) == "match_accept_w_address", \
+    assert str(FIPAMessage.Performative.MATCH_ACCEPT_W_INFORM) == "match_accept_w_inform", \
         "The str value must be match_accept_w_address"
     assert str(FIPAMessage.Performative.INFORM) == "inform", \
         "The str value must be inform"


### PR DESCRIPTION
## Proposed changes

This PR:
- refactors fipa to include `W_INFORM` rather than `W_ADDRESS`. This makes it more versatile and is needed for TAC.

## Fixes

Related to #214 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

-