### PR TITLE
Fix issues in internal message tests.

### DIFF
--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -34,7 +34,7 @@ ProtocolId = str
 SkillId = str
 """
 A dependency is a dictionary with the following (optional) keys:
-    - version: a version specifier(s) (e.g. '==0.1.0'). 
+    - version: a version specifier(s) (e.g. '==0.1.0').
     - index: the PyPI index where to download the package from (default: https://pypi.org)
     - git: the URL to the Git repository (e.g. https://github.com/fetchai/agents-aea.git)
     - ref: either the branch name, the tag, the commit number or a Git reference (default: 'master'.)
@@ -47,8 +47,8 @@ A dictionary from package name to dependency data structure (see above).
 The package name must satisfy the constraints on Python packages names.
 For details, see https://www.python.org/dev/peps/pep-0426/#name.
 
-The main advantage of having a dictionary is that we implicitly filter out dependency duplicates. 
-We cannot have two items with the same package name since the keys of a YAML object form a set. 
+The main advantage of having a dictionary is that we implicitly filter out dependency duplicates.
+We cannot have two items with the same package name since the keys of a YAML object form a set.
 """
 Dependencies = Dict[str, Dependency]
 

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -314,7 +314,9 @@ class TestFilter:
                                sender_tx_fee=0,
                                counterparty_tx_fee=0,
                                ledger_id="fetchai",
-                               quantities_by_good_pbk={"Unknown": 10})
+                               quantities_by_good_pbk={"Unknown": 10},
+                               info={},
+                               transaction_digest="this-is-a-digest")
         self.aea.decision_maker.message_out_queue.put(t)
         self.aea.filter.handle_internal_messages()
 


### PR DESCRIPTION
## Proposed changes

Fix test `TestFilter:test_handle_internal_messages` in `test_registries.py`:
- The mandatory 'info' parameter of TransactionMessage was missing.
- The non-mandatory 'transaction_digest' parameter was missing, and it caused an error in the consistency check.
- Solved `flake8` issues.

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that code coverage does not decrease.
- [X] I have checked that the documentation about the `aea cli` tool works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
