### PR TITLE
Change skill configuration resources types from lists to dictionaries.

### DIFF
--- a/aea/cli/install.py
+++ b/aea/cli/install.py
@@ -30,7 +30,7 @@ from aea.configurations.base import Dependency
 
 
 def _install_dependency(dependency_name: str, dependency: Dependency):
-    logger.info("Installing {}...".format(pprint.pformat(dependency)))
+    logger.info("Installing {}...".format(pprint.pformat(dependency_name)))
     try:
         index = dependency.get("index", None)
         git_url = dependency.get("git", None)

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -434,10 +434,10 @@ class SkillConfig(Configuration):
             "url": self.url,
             "protocols": self.protocols,
             "dependencies": self.dependencies,
-            "handlers": [{"handler": h.json} for _, h in self.handlers.read_all()],
-            "behaviours": [{"behaviour": b.json} for _, b in self.behaviours.read_all()],
-            "tasks": [{"task": t.json} for _, t in self.tasks.read_all()],
-            "shared_classes": [{"shared_class": s.json} for _, s in self.shared_classes.read_all()],
+            "handlers": {key: h.json for key, h in self.handlers.read_all()},
+            "behaviours": {key: b.json for key, b in self.behaviours.read_all()},
+            "tasks": {key: t.json for key, t in self.tasks.read_all()},
+            "shared_classes": {key: s.json for key, s in self.shared_classes.read_all()},
             "description": self.description
         }
 
@@ -463,21 +463,21 @@ class SkillConfig(Configuration):
             description=description
         )
 
-        for b in obj.get("behaviours", []):  # type: ignore
-            behaviour_config = BehaviourConfig.from_json(b["behaviour"])
-            skill_config.behaviours.create(behaviour_config.class_name, behaviour_config)
+        for behaviour_id, behaviour_data in obj.get("behaviours", {}).items():  # type: ignore
+            behaviour_config = BehaviourConfig.from_json(behaviour_data)
+            skill_config.behaviours.create(behaviour_id, behaviour_config)
 
-        for t in obj.get("tasks", []):  # type: ignore
-            task_config = TaskConfig.from_json(t["task"])
-            skill_config.tasks.create(task_config.class_name, task_config)
+        for task_id, task_data in obj.get("tasks", {}).items():  # type: ignore
+            task_config = TaskConfig.from_json(task_data)
+            skill_config.tasks.create(task_id, task_config)
 
-        for h in obj.get("handlers", []):  # type: ignore
-            handler_config = HandlerConfig.from_json(h["handler"])
-            skill_config.handlers.create(handler_config.class_name, handler_config)
+        for handler_id, handler_data in obj.get("handlers", {}).items():  # type: ignore
+            handler_config = HandlerConfig.from_json(handler_data)
+            skill_config.handlers.create(handler_id, handler_config)
 
-        for s in obj.get("shared_classes", []):  # type: ignore
-            shared_class_config = SharedClassConfig.from_json(s["shared_class"])
-            skill_config.shared_classes.create(shared_class_config.class_name, shared_class_config)
+        for shared_class_id, shared_class_data in obj.get("shared_classes", {}).items():  # type: ignore
+            shared_class_config = SharedClassConfig.from_json(shared_class_data)
+            skill_config.shared_classes.create(shared_class_id, shared_class_config)
 
         return skill_config
 

--- a/aea/configurations/schemas/skill-config_schema.json
+++ b/aea/configurations/schemas/skill-config_schema.json
@@ -36,14 +36,16 @@
       }
     },
     "handlers": {
-      "type": "array",
+      "type": "object",
       "additionalProperties": false,
       "uniqueItems": true,
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/definitions/handler"
+        }
+      },
       "items": {
         "type": "object",
-        "required": [
-          "handler"
-        ],
         "properties": {
           "handler": {
             "$ref": "#/definitions/handler"
@@ -52,46 +54,29 @@
       }
     },
     "behaviours": {
-      "type": "array",
+      "type": "object",
       "uniqueItems": true,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "behaviour"
-        ],
-        "properties": {
-          "behaviour": {
-            "$ref": "#/definitions/behaviour"
-          }
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/definitions/behaviour"
         }
       }
     },
     "tasks": {
-      "type": "array",
+      "type": "object",
       "uniqueItems": true,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "task"
-        ],
-        "properties": {
-          "task": {
-            "$ref": "#/definitions/task"
-          }
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/definitions/task"
         }
       }
     },
     "shared_classes": {
-      "type": "array",
+      "type": "object",
       "uniqueItems": true,
-      "items": {
-        "type": "object",
-        "properties": {
-          "task": {
-            "$ref": "#/definitions/shared_class"
-          }
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/definitions/shared_class"
         }
       }
     },

--- a/aea/configurations/schemas/skill-config_schema.json
+++ b/aea/configurations/schemas/skill-config_schema.json
@@ -40,16 +40,8 @@
       "additionalProperties": false,
       "uniqueItems": true,
       "patternProperties": {
-        ".*": {
+        "^[^\\d\\W]\\w*\\Z": {
           "$ref": "#/definitions/handler"
-        }
-      },
-      "items": {
-        "type": "object",
-        "properties": {
-          "handler": {
-            "$ref": "#/definitions/handler"
-          }
         }
       }
     },
@@ -57,7 +49,7 @@
       "type": "object",
       "uniqueItems": true,
       "patternProperties": {
-        ".*": {
+        "^[^\\d\\W]\\w*\\Z": {
           "$ref": "#/definitions/behaviour"
         }
       }
@@ -66,7 +58,7 @@
       "type": "object",
       "uniqueItems": true,
       "patternProperties": {
-        ".*": {
+        "^[^\\d\\W]\\w*\\Z": {
           "$ref": "#/definitions/task"
         }
       }
@@ -75,7 +67,7 @@
       "type": "object",
       "uniqueItems": true,
       "patternProperties": {
-        ".*": {
+        "^[^\\d\\W]\\w*\\Z": {
           "$ref": "#/definitions/shared_class"
         }
       }

--- a/aea/registries/base.py
+++ b/aea/registries/base.py
@@ -509,11 +509,11 @@ class Resources(object):
         skill_id = skill.config.name
         self._skills[skill_id] = skill
         if skill.handlers is not None:
-            self.handler_registry.register((None, skill_id), cast(List[Handler], skill.handlers))
+            self.handler_registry.register((None, skill_id), cast(List[Handler], list(skill.handlers.values())))
         if skill.behaviours is not None:
-            self.behaviour_registry.register((None, skill_id), cast(List[Behaviour], skill.behaviours))
+            self.behaviour_registry.register((None, skill_id), cast(List[Behaviour], list(skill.behaviours.values())))
         if skill.tasks is not None:
-            self.task_registry.register((None, skill_id), cast(List[Task], skill.tasks))
+            self.task_registry.register((None, skill_id), cast(List[Task], list(skill.tasks.values())))
 
     def get_skill(self, skill_id: SkillId) -> Optional[Skill]:
         """Get the skill."""

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -26,6 +26,7 @@ import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
 from queue import Queue
+from types import SimpleNamespace
 from typing import Optional, List, Dict, Any, cast
 
 from aea.connections.base import ConnectionStatus
@@ -127,22 +128,22 @@ class SkillContext:
         return self._agent_context.task_queue
 
     @property
-    def handlers(self) -> Optional[Dict[str, 'Handler']]:
+    def handlers(self) -> SimpleNamespace:
         """Get handlers of the skill."""
         assert self._skill is not None, "Skill not initialized."
-        return self._skill.handlers
+        return SimpleNamespace(**self._skill.handlers)
 
     @property
-    def behaviours(self) -> Optional[Dict[str, 'Behaviour']]:
+    def behaviours(self) -> SimpleNamespace:
         """Get behaviours of the skill."""
         assert self._skill is not None, "Skill not initialized."
-        return self._skill.behaviours
+        return SimpleNamespace(**self._skill.behaviours)
 
     @property
-    def tasks(self) -> Optional[Dict[str, 'Task']]:
+    def tasks(self) -> SimpleNamespace:
         """Get tasks of the skill."""
         assert self._skill is not None, "Skill not initialized."
-        return self._skill.tasks
+        return SimpleNamespace(**self._skill.tasks)
 
     def __getattr__(self, item) -> Any:
         """Get attribute."""

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -27,12 +27,12 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from queue import Queue
 from types import SimpleNamespace
-from typing import Optional, List, Dict, Any, cast
+from typing import Optional, Dict, Any, cast
 
-from aea.connections.base import ConnectionStatus
 from aea.configurations.base import BehaviourConfig, HandlerConfig, TaskConfig, SharedClassConfig, SkillConfig, \
     ProtocolId, DEFAULT_SKILL_CONFIG_FILE
 from aea.configurations.loader import ConfigLoader
+from aea.connections.base import ConnectionStatus
 from aea.context.base import AgentContext
 from aea.crypto.ledger_apis import LedgerApis
 from aea.decision_maker.base import OwnershipState, Preferences, GoalPursuitReadiness
@@ -504,10 +504,10 @@ class Skill:
         """
         self.config = config
         self.skill_context = skill_context
-        self.handlers = handlers
-        self.behaviours = behaviours
-        self.tasks = tasks
-        self.shared_classes = shared_classes
+        self.handlers = handlers if handlers is not None else {}
+        self.behaviours = behaviours if behaviours is not None else {}
+        self.tasks = tasks if tasks is not None else {}
+        self.shared_classes = shared_classes if shared_classes is not None else {}
 
     @classmethod
     def from_dir(cls, directory: str, agent_context: AgentContext) -> 'Skill':

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -127,19 +127,19 @@ class SkillContext:
         return self._agent_context.task_queue
 
     @property
-    def handlers(self) -> Optional[List['Handler']]:
+    def handlers(self) -> Optional[Dict[str, 'Handler']]:
         """Get handlers of the skill."""
         assert self._skill is not None, "Skill not initialized."
         return self._skill.handlers
 
     @property
-    def behaviours(self) -> Optional[List['Behaviour']]:
+    def behaviours(self) -> Optional[Dict[str, 'Behaviour']]:
         """Get behaviours of the skill."""
         assert self._skill is not None, "Skill not initialized."
         return self._skill.behaviours
 
     @property
-    def tasks(self) -> Optional[List['Task']]:
+    def tasks(self) -> Optional[Dict[str, 'Task']]:
         """Get tasks of the skill."""
         assert self._skill is not None, "Skill not initialized."
         return self._skill.tasks
@@ -205,7 +205,7 @@ class Behaviour(ABC):
         self.act()
 
     @classmethod
-    def parse_module(cls, path: str, behaviours_configs: List[BehaviourConfig], skill_context: SkillContext) -> List['Behaviour']:
+    def parse_module(cls, path: str, behaviours_configs: Dict[str, BehaviourConfig], skill_context: SkillContext) -> Dict[str, 'Behaviour']:
         """
         Parse the behaviours module.
 
@@ -214,7 +214,7 @@ class Behaviour(ABC):
         :param skill_context: the skill context
         :return: a list of Behaviour.
         """
-        behaviours = []
+        behaviours = {}
         behaviours_spec = importlib.util.spec_from_file_location("behaviours", location=path)
         behaviour_module = importlib.util.module_from_spec(behaviours_spec)
         behaviours_spec.loader.exec_module(behaviour_module)  # type: ignore
@@ -222,9 +222,10 @@ class Behaviour(ABC):
         behaviours_classes = list(filter(lambda x: re.match("\\w+Behaviour", x[0]), classes))
 
         name_to_class = dict(behaviours_classes)
-        for behaviour_config in behaviours_configs:
+        for behaviour_id, behaviour_config in behaviours_configs.items():
             behaviour_class_name = cast(str, behaviour_config.class_name)
             logger.debug("Processing behaviour {}".format(behaviour_class_name))
+            assert behaviour_id.isidentifier(), "'{}' is not a valid identifier.".format(behaviour_id)
             behaviour_class = name_to_class.get(behaviour_class_name, None)
             if behaviour_class is None:
                 logger.warning("Behaviour '{}' cannot be found.".format(behaviour_class_name))
@@ -233,7 +234,7 @@ class Behaviour(ABC):
                 assert 'skill_context' not in args.keys(), "'skill_context' is a reserved key. Please rename your arguments!"
                 args['skill_context'] = skill_context
                 behaviour = behaviour_class(**args)
-                behaviours.append(behaviour)
+                behaviours[behaviour_id] = behaviour
 
         return behaviours
 
@@ -289,7 +290,7 @@ class Handler(ABC):
         """
 
     @classmethod
-    def parse_module(cls, path: str, handler_configs: List[HandlerConfig], skill_context: SkillContext) -> List['Handler']:
+    def parse_module(cls, path: str, handler_configs: Dict[str, HandlerConfig], skill_context: SkillContext) -> Dict[str, 'Handler']:
         """
         Parse the handler module.
 
@@ -298,7 +299,7 @@ class Handler(ABC):
         :param skill_context: the skill context
         :return: an handler, or None if the parsing fails.
         """
-        handlers = []
+        handlers = {}
         handler_spec = importlib.util.spec_from_file_location("handlers", location=path)
         handler_module = importlib.util.module_from_spec(handler_spec)
         handler_spec.loader.exec_module(handler_module)  # type: ignore
@@ -306,9 +307,10 @@ class Handler(ABC):
         handler_classes = list(filter(lambda x: re.match("\\w+Handler", x[0]), classes))
 
         name_to_class = dict(handler_classes)
-        for handler_config in handler_configs:
+        for handler_id, handler_config in handler_configs.items():
             handler_class_name = cast(str, handler_config.class_name)
             logger.debug("Processing handler {}".format(handler_class_name))
+            assert handler_id.isidentifier(), "'{}' is not a valid identifier.".format(handler_id)
             handler_class = name_to_class.get(handler_class_name, None)
             if handler_class is None:
                 logger.warning("Handler '{}' cannot be found.".format(handler_class_name))
@@ -317,7 +319,7 @@ class Handler(ABC):
                 assert 'skill_context' not in args.keys(), "'skill_context' is a reserved key. Please rename your arguments!"
                 args['skill_context'] = skill_context
                 handler = handler_class(**args)
-                handlers.append(handler)
+                handlers[handler_id] = handler
 
         return handlers
 
@@ -371,7 +373,7 @@ class Task(ABC):
         """
 
     @classmethod
-    def parse_module(cls, path: str, tasks_configs: List[TaskConfig], skill_context: SkillContext) -> List['Task']:
+    def parse_module(cls, path: str, tasks_configs: Dict[str, TaskConfig], skill_context: SkillContext) -> Dict[str, 'Task']:
         """
         Parse the tasks module.
 
@@ -380,7 +382,7 @@ class Task(ABC):
         :param skill_context: the skill context
         :return: a list of Tasks.
         """
-        tasks = []
+        tasks = {}
         tasks_spec = importlib.util.spec_from_file_location("tasks", location=path)
         task_module = importlib.util.module_from_spec(tasks_spec)
         tasks_spec.loader.exec_module(task_module)  # type: ignore
@@ -388,9 +390,10 @@ class Task(ABC):
         tasks_classes = list(filter(lambda x: re.match("\\w+Task", x[0]), classes))
 
         name_to_class = dict(tasks_classes)
-        for task_config in tasks_configs:
+        for task_id, task_config in tasks_configs.items():
             task_class_name = task_config.class_name
             logger.debug("Processing task {}".format(task_class_name))
+            assert task_id.isidentifier(), "'{}' is not a valid identifier.".format(task_id)
             task_class = name_to_class.get(task_class_name, None)
             if task_class is None:
                 logger.warning("Task '{}' cannot be found.".format(task_class_name))
@@ -399,7 +402,7 @@ class Task(ABC):
                 assert 'skill_context' not in args.keys(), "'skill_context' is a reserved key. Please rename your arguments!"
                 args['skill_context'] = skill_context
                 task = task_class(**args)
-                tasks.append(task)
+                tasks[task_id] = task
 
         return tasks
 
@@ -428,7 +431,7 @@ class SharedClass(ABC):
         return self._config
 
     @classmethod
-    def parse_module(cls, path: str, shared_classes_configs: List[SharedClassConfig], skill_context: SkillContext) -> List['SharedClass']:
+    def parse_module(cls, path: str, shared_classes_configs: Dict[str, SharedClassConfig], skill_context: SkillContext) -> Dict[str, 'SharedClass']:
         """
         Parse the tasks module.
 
@@ -437,10 +440,10 @@ class SharedClass(ABC):
         :param skill_context: the skill context
         :return: a list of SharedClass.
         """
-        instances = []
+        instances = {}
         shared_classes = []
 
-        shared_classes_names = set(config.class_name for config in shared_classes_configs)
+        shared_classes_names = set(config.class_name for _, config in shared_classes_configs.items())
 
         # get all Python modules except the standard ones
         ignore_regex = "|".join(["handlers.py", "behaviours.py", "tasks.py", "__.*"])
@@ -463,9 +466,10 @@ class SharedClass(ABC):
             shared_classes.extend(filtered_classes)
 
         name_to_class = dict(shared_classes)
-        for shared_class_config in shared_classes_configs:
+        for shared_class_id, shared_class_config in shared_classes_configs.items():
             shared_class_name = shared_class_config.class_name
-            logger.debug("Processing shared class {}".format(shared_class_name))
+            logger.debug("Processing shared class id={}, class={}".format(shared_class_id, shared_class_name))
+            assert shared_class_id.isidentifier(), "'{}' is not a valid identifier.".format(shared_class_id)
             shared_class = name_to_class.get(shared_class_name, None)
             if shared_class is None:
                 logger.warning("Shared class '{}' cannot be found.".format(shared_class_name))
@@ -474,8 +478,8 @@ class SharedClass(ABC):
                 assert 'skill_context' not in args.keys(), "'skill_context' is a reserved key. Please rename your arguments!"
                 args['skill_context'] = skill_context
                 shared_class_instance = shared_class(**args)
-                instances.append(shared_class_instance)
-                setattr(skill_context, shared_class_name.lower(), shared_class_instance)
+                instances[shared_class_id] = shared_class_instance
+                setattr(skill_context, shared_class_id, shared_class_instance)
         return instances
 
 
@@ -484,10 +488,10 @@ class Skill:
 
     def __init__(self, config: SkillConfig,
                  skill_context: SkillContext,
-                 handlers: Optional[List[Handler]],
-                 behaviours: Optional[List[Behaviour]],
-                 tasks: Optional[List[Task]],
-                 shared_classes: Optional[List[SharedClass]]):
+                 handlers: Optional[Dict[str, Handler]],
+                 behaviours: Optional[Dict[str, Behaviour]],
+                 tasks: Optional[Dict[str, Task]],
+                 shared_classes: Optional[Dict[str, SharedClass]]):
         """
         Initialize a skill.
 
@@ -526,33 +530,29 @@ class Skill:
 
         skill_context = SkillContext(agent_context)
 
-        handlers_by_id = skill_config.handlers.read_all()
+        handlers_by_id = dict(skill_config.handlers.read_all())
         if len(handlers_by_id) > 0:
-            handlers_configurations = list(dict(handlers_by_id).values())
-            handlers = Handler.parse_module(os.path.join(directory, "handlers.py"), handlers_configurations, skill_context)
+            handlers = Handler.parse_module(os.path.join(directory, "handlers.py"), handlers_by_id, skill_context)
         else:
-            handlers = []
+            handlers = {}
 
-        behaviours_by_id = skill_config.behaviours.read_all()
+        behaviours_by_id = dict(skill_config.behaviours.read_all())
         if len(behaviours_by_id) > 0:
-            behaviours_configurations = list(dict(behaviours_by_id).values())
-            behaviours = Behaviour.parse_module(os.path.join(directory, "behaviours.py"), behaviours_configurations, skill_context)
+            behaviours = Behaviour.parse_module(os.path.join(directory, "behaviours.py"), behaviours_by_id, skill_context)
         else:
-            behaviours = []
+            behaviours = {}
 
-        tasks_by_id = skill_config.tasks.read_all()
+        tasks_by_id = dict(skill_config.tasks.read_all())
         if len(tasks_by_id) > 0:
-            tasks_configurations = list(dict(tasks_by_id).values())
-            tasks = Task.parse_module(os.path.join(directory, "tasks.py"), tasks_configurations, skill_context)
+            tasks = Task.parse_module(os.path.join(directory, "tasks.py"), tasks_by_id, skill_context)
         else:
-            tasks = []
+            tasks = {}
 
-        shared_classes_by_id = skill_config.shared_classes.read_all()
+        shared_classes_by_id = dict(skill_config.shared_classes.read_all())
         if len(shared_classes_by_id) > 0:
-            shared_classes_configurations = list(dict(shared_classes_by_id).values())
-            shared_classes_instances = SharedClass.parse_module(directory, shared_classes_configurations, skill_context)
+            shared_classes_instances = SharedClass.parse_module(directory, shared_classes_by_id, skill_context)
         else:
-            shared_classes_instances = []
+            shared_classes_instances = {}
 
         skill = Skill(skill_config, skill_context, handlers, behaviours, tasks, shared_classes_instances)
         skill_context._skill = skill

--- a/aea/skills/error/skill.yaml
+++ b/aea/skills/error/skill.yaml
@@ -4,12 +4,12 @@ version: 0.1.0
 license: Apache 2.0
 url: ""
 description: "The error skill implements basic error handling required by all AEAs."
-behaviours: []
+behaviours: {}
 handlers:
-  - handler:
+  error_handler:
       class_name: ErrorHandler
       args:
         foo: bar
-tasks: []
-shared_classes: []
+tasks: {}
+shared_classes: {}
 protocols: ['default']

--- a/aea/skills/scaffold/skill.yaml
+++ b/aea/skills/scaffold/skill.yaml
@@ -5,23 +5,23 @@ license: Apache 2.0
 url: ""
 description: "The scaffold skill is a scaffold for your own skill implementation."
 behaviours:
-  - behaviour:
-      class_name: MyScaffoldBehaviour
-      args:
-        foo: bar
+  scaffold:
+    class_name: MyScaffoldBehaviour
+    args:
+      foo: bar
 handlers:
-  - handler:
-      class_name: MyScaffoldHandler
-      args:
-        foo: bar
+  scaffold:
+    class_name: MyScaffoldHandler
+    args:
+      foo: bar
 tasks:
-  - task:
-      class_name: MyScaffoldTask
-      args:
-        foo: bar
+  scaffold:
+    class_name: MyScaffoldTask
+    args:
+      foo: bar
 shared_classes:
-  - shared_class:
-      class_name: MySharedClass
-      args:
-        foo: bar
+  scaffold:
+    class_name: MySharedClass
+    args:
+      foo: bar
 protocols: []

--- a/packages/skills/carpark_client/skill.yaml
+++ b/packages/skills/carpark_client/skill.yaml
@@ -4,32 +4,32 @@ version: 0.1.0
 license: Apache 2.0
 url: ""
 behaviours:
-  - behaviour:
-      class_name: MySearchBehaviour
-      args:
-        tick_interval: 120
+  search:
+    class_name: MySearchBehaviour
+    args:
+      tick_interval: 120
 handlers:
-  - handler:
-      class_name: FIPAHandler
-      args: {}
-  - handler:
-      class_name: OEFHandler
-      args: {}
-  - handler:
-      class_name: MyTransactionHandler
-      args: {}
-tasks: []
+  fipa:
+    class_name: FIPAHandler
+    args: {}
+  oef:
+    class_name: OEFHandler
+    args: {}
+  transaction:
+    class_name: MyTransactionHandler
+    args: {}
+tasks: {}
 shared_classes:
-  - shared_class:
-      class_name: Strategy
-      args:
-        country: UK
-        search_interval: 120
-        no_find_search_interval: 5
-        max_price: 400000000
-        max_detection_age: 36000000
-  - shared_class:
-      class_name: Dialogues
-      args: {}
+  strategy:
+    class_name: Strategy
+    args:
+      country: UK
+      search_interval: 120
+      no_find_search_interval: 5
+      max_price: 400000000
+      max_detection_age: 36000000
+  dialogues:
+    class_name: Dialogues
+    args: {}
 protocols: ['fipa','default','oef']
 ledgers: ['fetchai']

--- a/packages/skills/carpark_detection/skill.yaml
+++ b/packages/skills/carpark_detection/skill.yaml
@@ -4,32 +4,30 @@ version: 0.1.0
 license: Apache 2.0
 url: ""
 behaviours:
-  - behaviour:
-      class_name: ServiceRegistrationBehaviour
-      args: {}
-  - behaviour:
-      class_name: CarParkDetectionAndGUIBehaviour
-      args:
-        default_longitude: -73.967491
-        default_latitude: 40.780343
-        image_capture_interval: 120
-
+  service_registration:
+    class_name: ServiceRegistrationBehaviour
+    args: {}
+  car_park_detection:
+    class_name: CarParkDetectionAndGUIBehaviour
+    args:
+      default_longitude: -73.967491
+      default_latitude: 40.780343
+      image_capture_interval: 120
 handlers:
-  - handler:
-      class_name: FIPAHandler
-      args: {}
-tasks: []
+  fipa:
+    class_name: FIPAHandler
+    args: {}
+tasks: {}
 shared_classes:
-  - shared_class:
-      class_name: Strategy
-      args:
-        data_price_fet: 200000000
-        db_is_rel_to_cwd: true
-        db_rel_dir: ../temp_files
-
-  - shared_class:
-      class_name: Dialogues
-      args: {}
+  strategy:
+    class_name: Strategy
+    args:
+      data_price_fet: 200000000
+      db_is_rel_to_cwd: true
+      db_rel_dir: ../temp_files
+  dialogues:
+    class_name: Dialogues
+    args: {}
 protocols: ['fipa', 'oef', 'default']
 ledgers: ['fetchai']
 dependencies:

--- a/packages/skills/echo/skill.yaml
+++ b/packages/skills/echo/skill.yaml
@@ -5,22 +5,22 @@ license: Apache 2.0
 description: "The echo skill implements simple echo functionality."
 url: ""
 behaviours:
-  - behaviour:
-      class_name: EchoBehaviour
-      args:
-        foo: bar
+  echo:
+    class_name: EchoBehaviour
+    args:
+      foo: bar
 handlers:
-  - handler:
-      class_name: EchoHandler
-      args:
-        foo: bar
-        bar: foo
+  echo:
+    class_name: EchoHandler
+    args:
+      foo: bar
+      bar: foo
 tasks:
-  - task:
-      class_name: EchoTask
-      args:
-        foo: bar
-        bar: foo
-shared_classes: []
+  echo:
+    class_name: EchoTask
+    args:
+      foo: bar
+      bar: foo
+shared_classes: {}
 protocols: ["default"]
 dependencies: {}

--- a/packages/skills/gym/handlers.py
+++ b/packages/skills/gym/handlers.py
@@ -59,8 +59,7 @@ class GymHandler(Handler):
         gym_msg = cast(GymMessage, message)
         if gym_msg.performative == GymMessage.Performative.PERCEPT:
             assert self.context.tasks is not None, "Incorrect initialization."
-            assert len(self.context.tasks) == 1, "Too many tasks loaded!"
-            gym_task = cast(GymTask, self.context.tasks[0])
+            gym_task = cast(GymTask, self.context.tasks.gym)
             gym_task.proxy_env_queue.put(gym_msg)
         else:
             raise ValueError("Unexpected performative or no step_id: {}".format(gym_msg.performative))

--- a/packages/skills/gym/skill.yaml
+++ b/packages/skills/gym/skill.yaml
@@ -4,18 +4,18 @@ version: 0.1.0
 license: Apache 2.0
 description: "The gym skill wraps an RL agent."
 url: ""
-behaviours: []
+behaviours: {}
 handlers:
-  - handler:
-      class_name: GymHandler
-      args:
-        foo: bar
+  gym:
+    class_name: GymHandler
+    args:
+      foo: bar
 tasks:
-  - task:
-      class_name: GymTask
-      args:
-        nb_steps: 4000
-shared_classes: []
+  gym:
+    class_name: GymTask
+    args:
+      nb_steps: 4000
+shared_classes: {}
 protocols: ["gym"]
 dependencies:
   gym: {}

--- a/packages/skills/ml_data_provider/skill.yaml
+++ b/packages/skills/ml_data_provider/skill.yaml
@@ -5,26 +5,26 @@ license: Apache 2.0
 description: "The ml data provider skill implements a provider for Machine Learning datasets in order to monetize data."
 url: ""
 behaviours:
-  - behaviour:
-      class_name: ServiceRegistrationBehaviour
-      args:
-        services_interval: 30
+  service_registration:
+    class_name: ServiceRegistrationBehaviour
+    args:
+      services_interval: 30
 handlers:
-  - handler:
-      class_name: MLTradeHandler
-      args: {}
-tasks: []
+  ml_trade:
+    class_name: MLTradeHandler
+    args: {}
+tasks: {}
 shared_classes:
-  - shared_class:
-      class_name: Strategy
-      args:
-        price_per_data_batch: 100
-        batch_size: 2
-        seller_tx_fee: 0
-        buyer_tx_fee: 10
-        dataset_id: 'fmnist'
-        currency_id: 'FET'
-        ledger_id: 'fetchai'
+  strategy:
+    class_name: Strategy
+    args:
+      price_per_data_batch: 100
+      batch_size: 2
+      seller_tx_fee: 0
+      buyer_tx_fee: 10
+      dataset_id: 'fmnist'
+      currency_id: 'FET'
+      ledger_id: 'fetchai'
 protocols: ['oef', 'ml_trade']
 dependencies:
   tensorflow: {}

--- a/packages/skills/ml_train/skill.yaml
+++ b/packages/skills/ml_train/skill.yaml
@@ -5,35 +5,35 @@ license: Apache 2.0
 description: "The ml train and predict skill implements a simple skill which buys training data, trains a model and sells predictions."
 url: ""
 behaviours:
-  - behaviour:
-      class_name: MySearchBehaviour
-      args:
-        search_interval: 30
+  search:
+    class_name: MySearchBehaviour
+    args:
+      search_interval: 30
 handlers:
-  - handler:
-      class_name: OEFHandler
-      args: {}
-  - handler:
-      class_name: TrainHandler
-      args: {}
-  - handler:
-      class_name: MyTransactionHandler
-      args: {}
-tasks: []
+  oef:
+    class_name: OEFHandler
+    args: {}
+  train:
+    class_name: TrainHandler
+    args: {}
+  transaction:
+    class_name: MyTransactionHandler
+    args: {}
+tasks: {}
 shared_classes:
-  - shared_class:
-      class_name: Strategy
-      args:
-        dataset_id: 'fmnist'
-        max_unit_price: 70
-        max_buyer_tx_fee: 20
-        currency_id: 'FET'
-        ledger_id: 'fetchai'
-        is_ledger_tx: False
-  - shared_class:
-      class_name: Model
-      args:
-        model_config_path: "./skills/ml_train/model.json"
+  strategy:
+    class_name: Strategy
+    args:
+      dataset_id: 'fmnist'
+      max_unit_price: 70
+      max_buyer_tx_fee: 20
+      currency_id: 'FET'
+      ledger_id: 'fetchai'
+      is_ledger_tx: False
+  model:
+    class_name: Model
+    args:
+      model_config_path: "./skills/ml_train/model.json"
 protocols: ['oef', 'ml_trade']
 dependencies:
   tensorflow: {}

--- a/packages/skills/tac_control/skill.yaml
+++ b/packages/skills/tac_control/skill.yaml
@@ -5,37 +5,37 @@ license: Apache 2.0
 description: "The tac control skill implements the logic for an AEA to control an instance of the TAC."
 url: ""
 behaviours:
-  - behaviour:
-      class_name: TACBehaviour
-      args: {}
+  tac:
+    class_name: TACBehaviour
+    args: {}
 handlers:
-  - handler:
-      class_name: TACHandler
-      args: {}
-  - handler:
-      class_name: OEFRegistrationHandler
-      args: {}
-tasks: []
+  tac:
+    class_name: TACHandler
+    args: {}
+  oef:
+    class_name: OEFRegistrationHandler
+    args: {}
+tasks: {}
 shared_classes:
-  - shared_class:
-      class_name: Parameters
-      args:
-        min_nb_agents: 2
-        money_endowment: 2000000
-        nb_goods: 10
-        tx_fee: 1
-        base_good_endowment: 2
-        lower_bound_factor: 1
-        upper_bound_factor: 1
-        start_time: 12 11 2019  15:01
-        registration_timeout: 60
-        competition_timeout: 180
-        inactivity_timeout: 60
-        whitelist: []
-        version_id: v1
-  - shared_class:
-      class_name: Game
-      args: {}
+  parameters:
+    class_name: Parameters
+    args:
+      min_nb_agents: 2
+      money_endowment: 2000000
+      nb_goods: 10
+      tx_fee: 1
+      base_good_endowment: 2
+      lower_bound_factor: 1
+      upper_bound_factor: 1
+      start_time: 12 11 2019  15:01
+      registration_timeout: 60
+      competition_timeout: 180
+      inactivity_timeout: 60
+      whitelist: []
+      version_id: v1
+  game:
+    class_name: Game
+    args: {}
 protocols: ['oef', 'tac']
 dependencies:
   numpy: {}

--- a/packages/skills/tac_negotiation/skill.yaml
+++ b/packages/skills/tac_negotiation/skill.yaml
@@ -5,43 +5,43 @@ license: Apache 2.0
 description: "The tac negotiation skill implements the logic for an AEA to do fipa negotiation in the TAC."
 url: ""
 behaviours:
-  - behaviour:
-      class_name: GoodsRegisterAndSearchBehaviour
-      args:
-        services_interval: 5
+  tac_negotiation:
+    class_name: GoodsRegisterAndSearchBehaviour
+    args:
+      services_interval: 5
 handlers:
-  - handler:
-      class_name: FIPANegotiationHandler
-      args: {}
-  - handler:
-      class_name: TransactionHandler
-      args: {}
-  - handler:
-      class_name: OEFSearchHandler
-      args: {}
+  fipa:
+    class_name: FIPANegotiationHandler
+    args: {}
+  transaction:
+    class_name: TransactionHandler
+    args: {}
+  oef:
+    class_name: OEFSearchHandler
+    args: {}
 tasks:
-  - task:
-      class_name: TransactionCleanUpTask
-      args: {}
+  clean_up:
+    class_name: TransactionCleanUpTask
+    args: {}
 shared_classes:
-  - shared_class:
-      class_name: Search
-      args:
-        search_interval: 5
-  - shared_class:
-      class_name: Registration
-      args:
-        update_interval: 5
-  - shared_class:
-      class_name: Strategy
-      args:
-        register_as: both
-        search_for: both
-  - shared_class:
-      class_name: Dialogues
-      args: {}
-  - shared_class:
-      class_name: Transactions
-      args:
-        pending_transaction_timeout: 30
+  search:
+    class_name: Search
+    args:
+      search_interval: 5
+  registration:
+    class_name: Registration
+    args:
+      update_interval: 5
+  strategy:
+    class_name: Strategy
+    args:
+      register_as: both
+      search_for: both
+  dialogues:
+    class_name: Dialogues
+    args: {}
+  transactions:
+    class_name: Transactions
+    args:
+      pending_transaction_timeout: 30
 protocols: ['oef', 'fipa']

--- a/packages/skills/tac_participation/skill.yaml
+++ b/packages/skills/tac_participation/skill.yaml
@@ -5,28 +5,28 @@ license: Apache 2.0
 url: ""
 description: "The tac participation skill implements the logic for an AEA to participate in the TAC."
 behaviours:
-  - behaviour:
-      class_name: TACBehaviour
-      args: {}
+  tac:
+    class_name: TACBehaviour
+    args: {}
 handlers:
-  - handler:
-      class_name: OEFHandler
-      args: {}
-  - handler:
-      class_name: TACHandler
-      args: {}
-  - handler:
-      class_name: TransactionHandler
-      args: {}
-tasks: []
+  oef:
+    class_name: OEFHandler
+    args: {}
+  tac:
+    class_name: TACHandler
+    args: {}
+  transaction:
+    class_name: TransactionHandler
+    args: {}
+tasks: {}
 shared_classes:
-  - shared_class:
-      class_name: Search
-      args:
-        search_interval: 5
-  - shared_class:
-      class_name: Game
-      args:
-        expected_version_id: v1
-        # expected_controller_addr: '' # optionally, provide an address for the controller you expect!
+  search:
+    class_name: Search
+    args:
+      search_interval: 5
+  game:
+    class_name: Game
+    args:
+      expected_version_id: v1
+      # expected_controller_addr: '' # optionally, provide an address for the controller you expect!
 protocols: ['oef', 'tac']

--- a/packages/skills/weather_client/skill.yaml
+++ b/packages/skills/weather_client/skill.yaml
@@ -4,29 +4,29 @@ version: 0.1.0
 license: Apache 2.0
 url: ""
 behaviours:
-  - behaviour:
-      class_name: MySearchBehaviour
-      args:
-        search_interval: 5
+  search:
+    class_name: MySearchBehaviour
+    args:
+      search_interval: 5
 handlers:
-  - handler:
-      class_name: FIPAHandler
-      args: {}
-  - handler:
-      class_name: OEFHandler
-      args: {}
-tasks: []
+  fipa:
+    class_name: FIPAHandler
+    args: {}
+  oef:
+    class_name: OEFHandler
+    args: {}
+tasks: {}
 shared_classes:
-  - shared_class:
-      class_name: Strategy
-      args:
-        country: UK
-        max_row_price: 4
-        max_buyer_tx_fee: 1
-        currency_id: 'FET'
-        ledger_id: 'None'
-  - shared_class:
-      class_name: Dialogues
-      args: {}
+  strategy:
+    class_name: Strategy
+    args:
+      country: UK
+      max_row_price: 4
+      max_buyer_tx_fee: 1
+      currency_id: 'FET'
+      ledger_id: 'None'
+  dialogues:
+    class_name: Dialogues
+    args: {}
 protocols: ['fipa','default','oef']
 ledgers: []

--- a/packages/skills/weather_client_ledger/skill.yaml
+++ b/packages/skills/weather_client_ledger/skill.yaml
@@ -4,32 +4,32 @@ version: 0.1.0
 license: Apache 2.0
 url: ""
 behaviours:
-  - behaviour:
-      class_name: MySearchBehaviour
-      args:
-        search_interval: 5
+  search:
+    class_name: MySearchBehaviour
+    args:
+      search_interval: 5
 handlers:
-  - handler:
-      class_name: FIPAHandler
-      args: {}
-  - handler:
-      class_name: OEFHandler
-      args: {}
-  - handler:
-      class_name: MyTransactionHandler
-      args: {}
-tasks: []
+  fipa:
+    class_name: FIPAHandler
+    args: {}
+  oef:
+    class_name: OEFHandler
+    args: {}
+  transaction:
+    class_name: MyTransactionHandler
+    args: {}
+tasks: {}
 shared_classes:
-  - shared_class:
-      class_name: Strategy
-      args:
-        country: UK
-        max_row_price: 4
-        max_buyer_tx_fee: 1
-        currency_id: 'FET'
-        ledger_id: 'fetchai'
-  - shared_class:
-      class_name: Dialogues
-      args: {}
+  strategy:
+    class_name: Strategy
+    args:
+      country: UK
+      max_row_price: 4
+      max_buyer_tx_fee: 1
+      currency_id: 'FET'
+      ledger_id: 'fetchai'
+  dialogues:
+    class_name: Dialogues
+    args: {}
 protocols: ['fipa','default','oef']
 ledgers: ['fetchai']

--- a/packages/skills/weather_station/skill.yaml
+++ b/packages/skills/weather_station/skill.yaml
@@ -4,27 +4,27 @@ version: 0.1.0
 license: Apache 2.0
 url: ""
 behaviours:
-  - behaviour:
-      class_name: ServiceRegistrationBehaviour
-      args:
-        services_interval: 60
+  service_registration:
+    class_name: ServiceRegistrationBehaviour
+    args:
+      services_interval: 60
 handlers:
-  - handler:
-      class_name: FIPAHandler
-      args: {}
-tasks: []
+  fipa:
+    class_name: FIPAHandler
+    args: {}
+tasks: {}
 shared_classes:
-  - shared_class:
-      class_name: Strategy
-      args:
-        date_one: "1/10/2019"
-        date_two: "1/12/2019"
-        price_per_row: 1
-        seller_tx_fee: 0
-        currency_id: 'FET'
-        ledger_id: 'None'
-  - shared_class:
-      class_name: Dialogues
-      args: {}
+  strategy:
+    class_name: Strategy
+    args:
+      date_one: "1/10/2019"
+      date_two: "1/12/2019"
+      price_per_row: 1
+      seller_tx_fee: 0
+      currency_id: 'FET'
+      ledger_id: 'None'
+  dialogues:
+    class_name: Dialogues
+    args: {}
 protocols: ['fipa', 'oef', 'default']
 ledgers: []

--- a/packages/skills/weather_station_ledger/skill.yaml
+++ b/packages/skills/weather_station_ledger/skill.yaml
@@ -4,27 +4,27 @@ version: 0.1.0
 license: Apache 2.0
 url: ""
 behaviours:
-  - behaviour:
-      class_name: ServiceRegistrationBehaviour
-      args:
-        services_interval: 60
+  service_registration:
+    class_name: ServiceRegistrationBehaviour
+    args:
+      services_interval: 60
 handlers:
-  - handler:
-      class_name: FIPAHandler
-      args: {}
-tasks: []
+  fipa:
+    class_name: FIPAHandler
+    args: {}
+tasks: {}
 shared_classes:
-  - shared_class:
-      class_name: Strategy
-      args:
-        date_one: "1/10/2019"
-        date_two: "1/12/2019"
-        price_per_row: 1
-        seller_tx_fee: 0
-        currency_id: 'FET'
-        ledger_id: 'fetchai'
-  - shared_class:
-      class_name: Dialogues
-      args: {}
+  strategy:
+    class_name: Strategy
+    args:
+      date_one: "1/10/2019"
+      date_two: "1/12/2019"
+      price_per_row: 1
+      seller_tx_fee: 0
+      currency_id: 'FET'
+      ledger_id: 'fetchai'
+  dialogues:
+    class_name: Dialogues
+    args: {}
 protocols: ['fipa', 'oef', 'default']
 ledgers: ['fetchai']

--- a/tests/data/dependencies_skill/skill.yaml
+++ b/tests/data/dependencies_skill/skill.yaml
@@ -3,10 +3,10 @@ authors: Fetch.AI Limited
 version: 0.1.0
 license: Apache 2.0
 url: ""
-behaviours: []
-handlers: []
-tasks: []
-shared_classes: []
+behaviours: {}
+handlers: {}
+tasks: {}
+shared_classes: {}
 protocols: ["default"]
 dependencies:
   dep1: {version: "==1.0.0"}

--- a/tests/data/dummy_aea/skills/dummy/skill.yaml
+++ b/tests/data/dummy_aea/skills/dummy/skill.yaml
@@ -4,34 +4,34 @@ version: 0.1.0
 license: Apache 2.0
 url: ""
 behaviours:
-  - behaviour:
-      class_name: DummyBehaviour
-      args:
-        behaviour_arg_1: 1
-        behaviour_arg_2: "2"
+  dummy:
+    class_name: DummyBehaviour
+    args:
+      behaviour_arg_1: 1
+      behaviour_arg_2: "2"
 handlers:
-  - handler:
-      class_name: DummyHandler
-      args:
-        handler_arg_1: 1
-        handler_arg_2: "2"
-  - handler:
-      class_name: DummyInternalHandler
-      args:
-        handler_arg_1: 1
-        handler_arg_2: "2"
+  dummy:
+    class_name: DummyHandler
+    args:
+      handler_arg_1: 1
+      handler_arg_2: "2"
+  dummy_internal:
+    class_name: DummyInternalHandler
+    args:
+      handler_arg_1: 1
+      handler_arg_2: "2"
 tasks:
-  - task:
-      class_name: DummyTask
-      args:
-        task_arg_1: 1
-        task_arg_2: "2"
+  dummy:
+    class_name: DummyTask
+    args:
+      task_arg_1: 1
+      task_arg_2: "2"
 shared_classes:
-  - shared_class:
-      class_name: DummySharedClass
-      args:
-        shared_class_arg_1: 1
-        shared_class_arg_2: "2"
+  dummy:
+    class_name: DummySharedClass
+    args:
+      shared_class_arg_1: 1
+      shared_class_arg_2: "2"
 protocols: ["default"]
 dependencies: {}
 description: "a dummy_skill for testing purposes."

--- a/tests/data/dummy_aea/skills/error/skill.yaml
+++ b/tests/data/dummy_aea/skills/error/skill.yaml
@@ -4,12 +4,12 @@ version: 0.1.0
 license: Apache 2.0
 url: ""
 description: "The error skill implements basic error handling required by all AEAs."
-behaviours: []
+behaviours: {}
 handlers:
-  - handler:
-      class_name: ErrorHandler
-      args:
-        foo: bar
-tasks: []
-shared_classes: []
+  error:
+    class_name: ErrorHandler
+    args:
+      foo: bar
+tasks: {}
+shared_classes: {}
 protocols: ['default']

--- a/tests/data/dummy_skill/skill.yaml
+++ b/tests/data/dummy_skill/skill.yaml
@@ -4,34 +4,34 @@ version: 0.1.0
 license: Apache 2.0
 url: ""
 behaviours:
-  - behaviour:
-      class_name: DummyBehaviour
-      args:
-        behaviour_arg_1: 1
-        behaviour_arg_2: "2"
+  dummy:
+    class_name: DummyBehaviour
+    args:
+      behaviour_arg_1: 1
+      behaviour_arg_2: "2"
 handlers:
-  - handler:
-      class_name: DummyHandler
-      args:
-        handler_arg_1: 1
-        handler_arg_2: "2"
-  - handler:
-      class_name: DummyInternalHandler
-      args:
-        handler_arg_1: 1
-        handler_arg_2: "2"
+  dummy:
+    class_name: DummyHandler
+    args:
+      handler_arg_1: 1
+      handler_arg_2: "2"
+  dummy_internal:
+    class_name: DummyInternalHandler
+    args:
+      handler_arg_1: 1
+      handler_arg_2: "2"
 tasks:
-  - task:
-      class_name: DummyTask
-      args:
-        task_arg_1: 1
-        task_arg_2: "2"
+  dummy:
+    class_name: DummyTask
+    args:
+      task_arg_1: 1
+      task_arg_2: "2"
 shared_classes:
-  - shared_class:
-      class_name: DummySharedClass
-      args:
-        shared_class_arg_1: 1
-        shared_class_arg_2: "2"
+  dummy:
+    class_name: DummySharedClass
+    args:
+      shared_class_arg_1: 1
+      shared_class_arg_2: "2"
 protocols: ["default"]
 dependencies: {}
 description: "a dummy_skill for testing purposes."

--- a/tests/data/exception_skill/skill.yaml
+++ b/tests/data/exception_skill/skill.yaml
@@ -3,13 +3,13 @@ authors: Fetch.AI Limited
 version: 0.1.0
 license: Apache 2.0
 url: ""
-behaviours: []
-handlers: []
+behaviours: {}
+handlers: {}
 tasks:
-  - task:
-      class_name: ExceptionTask
-      args: {}
-shared_classes: []
+  exception:
+    class_name: ExceptionTask
+    args: {}
+shared_classes: {}
 protocols: []
 dependencies: {}
 description: "Raise an exception, at some point."

--- a/tests/test_aea.py
+++ b/tests/test_aea.py
@@ -167,7 +167,7 @@ async def test_handle():
             t.start()
             time.sleep(2.0)
             dummy_skill = agent.resources.get_skill("dummy")
-            dummy_handler = dummy_skill.handlers[0]
+            dummy_handler = dummy_skill.handlers["dummy"]
 
             expected_envelope = envelope
             agent.outbox.put(expected_envelope)

--- a/tests/test_configurations/test_schema.py
+++ b/tests/test_configurations/test_schema.py
@@ -97,6 +97,7 @@ class TestProtocolsSchema:
                                  os.path.join(ROOT_DIR, "aea", "protocols", "oef"),
                                  os.path.join(ROOT_DIR, "aea", "protocols", "scaffold"),
                                  os.path.join(ROOT_DIR, "packages", "protocols", "gym"),
+                                 os.path.join(ROOT_DIR, "packages", "protocols", "ml_trade"),
                                  os.path.join(ROOT_DIR, "packages", "protocols", "tac"),
                              ])
     def test_validate_protocol_config(self, protocol_path):
@@ -143,9 +144,22 @@ class TestSkillsSchema:
                              [
                                  os.path.join(ROOT_DIR, "aea", "skills", "error"),
                                  os.path.join(ROOT_DIR, "aea", "skills", "scaffold"),
+                                 os.path.join(ROOT_DIR, "packages", "skills", "carpark_client"),
+                                 os.path.join(ROOT_DIR, "packages", "skills", "carpark_detection"),
                                  os.path.join(ROOT_DIR, "packages", "skills", "echo"),
                                  os.path.join(ROOT_DIR, "packages", "skills", "gym"),
+                                 os.path.join(ROOT_DIR, "packages", "skills", "ml_data_provider"),
+                                 os.path.join(ROOT_DIR, "packages", "skills", "ml_train"),
+                                 os.path.join(ROOT_DIR, "packages", "skills", "tac_control"),
+                                 os.path.join(ROOT_DIR, "packages", "skills", "tac_negotiation"),
+                                 os.path.join(ROOT_DIR, "packages", "skills", "tac_participation"),
+                                 os.path.join(ROOT_DIR, "packages", "skills", "weather_client"),
+                                 os.path.join(ROOT_DIR, "packages", "skills", "weather_client_ledger"),
+                                 os.path.join(ROOT_DIR, "packages", "skills", "weather_station"),
+                                 os.path.join(ROOT_DIR, "packages", "skills", "weather_station_ledger"),
                                  os.path.join(CUR_PATH, "data", "dummy_skill"),
+                                 os.path.join(CUR_PATH, "data", "dummy_aea", "skills", "dummy"),
+                                 os.path.join(CUR_PATH, "data", "dummy_aea", "skills", "error"),
                                  os.path.join(CUR_PATH, "data", "dependencies_skill"),
                                  os.path.join(CUR_PATH, "data", "exception_skill")
                              ])

--- a/tests/test_packages/test_skills/test_gym.py
+++ b/tests/test_packages/test_skills/test_gym.py
@@ -87,7 +87,7 @@ class TestGymSkill:
         # change number of training steps
         skill_config_path = Path(self.t, self.agent_name, "skills", "gym", "skill.yaml")
         skill_config = SkillConfig.from_json(yaml.safe_load(open(skill_config_path)))
-        skill_config.tasks.read("GymTask").args["nb_steps"] = 100
+        skill_config.tasks.read("gym").args["nb_steps"] = 100
         yaml.safe_dump(skill_config.json, open(skill_config_path, "w"))
 
         process = subprocess.Popen([

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -222,10 +222,10 @@ class TestResources:
         assert tasks == error_skill_context.tasks
         assert getattr(error_skill_context, "agent_name") == self.agent_name
 
-        assert handlers[0].context == dummy_skill.skill_context
-        assert behaviours[0].context == dummy_skill.skill_context
-        assert tasks[0].context == dummy_skill.skill_context
-        assert shared_classes[0].context == dummy_skill.skill_context
+        assert handlers["dummy"].context == dummy_skill.skill_context
+        assert behaviours["dummy"].context == dummy_skill.skill_context
+        assert tasks["dummy"].context == dummy_skill.skill_context
+        assert shared_classes["dummy"].context == dummy_skill.skill_context
 
     def test_handler_configuration_loading(self):
         """Test that the handler configurations are loaded correctly."""
@@ -265,7 +265,7 @@ class TestResources:
         """Test that the shared class configurations are loaded correctly."""
         dummy_skill = self.resources.get_skill("dummy")
         assert len(dummy_skill.shared_classes) == 1
-        dummy_shared_class = dummy_skill.shared_classes[0]
+        dummy_shared_class = dummy_skill.shared_classes["dummy"]
 
         assert dummy_shared_class.config == {
             "shared_class_arg_1": 1,

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -210,17 +210,21 @@ class TestResources:
     def test_skill_loading(self):
         """Test that the skills have been loaded correctly."""
         dummy_skill = self.resources.get_skill("dummy")
-        error_skill_context = dummy_skill.skill_context
+        skill_context = dummy_skill.skill_context
 
         handlers = dummy_skill.handlers
         behaviours = dummy_skill.behaviours
         tasks = dummy_skill.tasks
         shared_classes = dummy_skill.shared_classes
 
-        assert handlers == error_skill_context.handlers
-        assert behaviours == error_skill_context.behaviours
-        assert tasks == error_skill_context.tasks
-        assert getattr(error_skill_context, "agent_name") == self.agent_name
+        assert len(handlers) == len(skill_context.handlers.__dict__)
+        assert len(behaviours) == len(skill_context.behaviours.__dict__)
+        assert len(tasks) == len(skill_context.tasks.__dict__)
+
+        assert handlers["dummy"] == skill_context.handlers.dummy
+        assert behaviours["dummy"] == skill_context.behaviours.dummy
+        assert tasks["dummy"] == skill_context.tasks.dummy
+        assert shared_classes["dummy"] == skill_context.dummy
 
         assert handlers["dummy"].context == dummy_skill.skill_context
         assert behaviours["dummy"].context == dummy_skill.skill_context


### PR DESCRIPTION
## Proposed changes

Before this PR, a skill.yaml would have the following format:
```yaml
...
behaviours:
- behaviour:
  class_name: {..}
  args: {...}
tasks: [...] # analogous structure as 'behaviours'
handlers: [...] # analogous structure as 'behaviours'
shared_classes: [...] # analogous structure as 'behaviours'
```

That is, the components are listed as 'lists'. Instead, change with the following format:
```yaml

...
behaviours:
  behaviour_1_id:
    class_name: {...}
    args: {...}
    ...
...
```
The same for the other component types. That means the actual components, e.g. a single behaviour, can be retrived by using its identifier, instead of having an indexing based on the position.
## Fixes

Fixes #205 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that code coverage does not decrease.
- [X] I have checked that the documentation about the `aea cli` tool works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
