### PR TITLE
Fix minor issues in CLI GUI tests.

### DIFF
--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -31,6 +31,7 @@ import click
 import jsonschema  # type: ignore
 from dotenv import load_dotenv
 
+import aea
 from aea.cli.loggers import default_logging_config
 from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig, SkillConfig, ConnectionConfig, ProtocolConfig, \
     DEFAULT_PROTOCOL_CONFIG_FILE, DEFAULT_CONNECTION_CONFIG_FILE, DEFAULT_SKILL_CONFIG_FILE, Dependencies
@@ -39,7 +40,7 @@ from aea.configurations.loader import ConfigLoader
 logger = logging.getLogger("aea")
 logger = default_logging_config(logger)
 
-DEFAULT_REGISTRY_PATH = "../packages"
+DEFAULT_REGISTRY_PATH = str(Path(aea.AEA_DIR, "..", "packages").resolve())
 DEFAULT_CONNECTION = "oef"
 DEFAULT_SKILL = "error"
 

--- a/aea/cli_gui/aea_cli_rest.yaml
+++ b/aea/cli_gui/aea_cli_rest.yaml
@@ -243,9 +243,7 @@ paths:
         200:
           description: Successfully read item list operation
           schema:
-            type: array
-            items:
-              type: string
+            type: object
 
   /oef:
     post:

--- a/aea/cli_gui/templates/home.js
+++ b/aea/cli_gui/templates/home.js
@@ -517,8 +517,8 @@ class Controller{
         });
 
         this.$event_pump.on('model_searchReadSuccess', function(e, data) {
-            self.view.setSearchType(data[1])
-            self.view.build_table(data[0], 'searchItemsTable');
+            self.view.setSearchType(data["item_type"])
+            self.view.build_table(data["search_result"], 'searchItemsTable');
             self.handleButtonStates()
         });
 

--- a/develop-image/Dockerfile
+++ b/develop-image/Dockerfile
@@ -68,6 +68,6 @@ RUN sudo make clean
 
 RUN pipenv --python python3.7
 RUN pipenv install --dev
-RUN pipenv run pip3 install .
+RUN pipenv run pip3 install .[all]
 
 CMD ["/bin/bash"]

--- a/tests/test_gui/test_add.py
+++ b/tests/test_gui/test_add.py
@@ -20,6 +20,7 @@
 
 """This test module contains the tests for the `aea gui` sub-commands."""
 import json
+import sys
 
 import unittest.mock
 
@@ -37,10 +38,12 @@ def test_add_item():
     connection_name = "test_connection"
 
     def _dummy_call_aea(param_list, dir):
-        assert param_list[0] == "aea"
-        assert param_list[1] == "add"
-        assert param_list[2] == "connection"
-        assert param_list[3] == connection_name
+        assert param_list[0] == sys.executable
+        assert param_list[1] == "-m"
+        assert param_list[2] == "aea.cli"
+        assert param_list[3] == "add"
+        assert param_list[4] == "connection"
+        assert param_list[5] == connection_name
         assert agent_name in dir
         return 0
 
@@ -66,10 +69,12 @@ def test_delete_agent_fail():
     connection_name = "test_connection"
 
     def _dummy_call_aea(param_list, dir):
-        assert param_list[0] == "aea"
-        assert param_list[1] == "add"
-        assert param_list[2] == "connection"
-        assert param_list[3] == connection_name
+        assert param_list[0] == sys.executable
+        assert param_list[1] == "-m"
+        assert param_list[2] == "aea.cli"
+        assert param_list[3] == "add"
+        assert param_list[4] == "connection"
+        assert param_list[5] == connection_name
         assert agent_name in dir
         return 1
 

--- a/tests/test_gui/test_base.py
+++ b/tests/test_gui/test_base.py
@@ -58,6 +58,14 @@ class TempCWD:
         self.cwd = os.getcwd()
         os.chdir(self.temp_dir)
 
+    def __enter__(self):
+        """Create the empty directory in a context manager."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Restore the initial conditions."""
+        self.destroy()
+
     def destroy(self):
         """Destroy the cwd and restore the old one."""
         os.chdir(self.cwd)

--- a/tests/test_gui/test_delete.py
+++ b/tests/test_gui/test_delete.py
@@ -20,6 +20,7 @@
 
 """This test module contains the tests for the `aea gui` sub-commands."""
 import json
+import sys
 
 import unittest.mock
 
@@ -32,9 +33,11 @@ def test_delete_agent():
     agent_name = "test_agent_id"
 
     def _dummy_call_aea(param_list, dir):
-        assert param_list[0] == "aea"
-        assert param_list[1] == "delete"
-        assert param_list[2] == agent_name
+        assert param_list[0] == sys.executable
+        assert param_list[1] == "-m"
+        assert param_list[2] == "aea.cli"
+        assert param_list[3] == "delete"
+        assert param_list[4] == agent_name
         return 0
 
     with unittest.mock.patch("aea.cli_gui._call_aea", _dummy_call_aea):
@@ -54,9 +57,11 @@ def test_delete_agent_fail():
     agent_name = "test_agent_id"
 
     def _dummy_call_aea(param_list, dir):
-        assert param_list[0] == "aea"
-        assert param_list[1] == "delete"
-        assert param_list[2] == agent_name
+        assert param_list[0] == sys.executable
+        assert param_list[1] == "-m"
+        assert param_list[2] == "aea.cli"
+        assert param_list[3] == "delete"
+        assert param_list[4] == agent_name
         return 1
 
     with unittest.mock.patch("aea.cli_gui._call_aea", _dummy_call_aea):

--- a/tests/test_gui/test_list.py
+++ b/tests/test_gui/test_list.py
@@ -19,6 +19,7 @@
 
 """This test module contains the tests for the `aea gui` sub-commands."""
 import json
+import sys
 
 import unittest.mock
 
@@ -47,9 +48,11 @@ def _test_list_items(item_type: str):
     agent_name = "test_agent_id"
 
     def _dummy_call_aea_async(param_list, dir_arg):
-        assert param_list[0] == "aea"
-        assert param_list[1] == "list"
-        assert param_list[2] == item_type + "s"
+        assert param_list[0] == sys.executable
+        assert param_list[1] == "-m"
+        assert param_list[2] == "aea.cli"
+        assert param_list[3] == "list"
+        assert param_list[4] == item_type + "s"
         assert agent_name in dir_arg
         return pid
 
@@ -76,9 +79,11 @@ def _test_list_items_none(item_type: str):
     agent_name = "NONE"
 
     def _dummy_call_aea_async(param_list, dir_arg):
-        assert param_list[0] == "aea"
-        assert param_list[1] == "list"
-        assert param_list[2] == item_type + "s"
+        assert param_list[0] == sys.executable
+        assert param_list[1] == "-m"
+        assert param_list[2] == "aea.cli"
+        assert param_list[3] == "list"
+        assert param_list[4] == item_type + "s"
         return pid
 
     with unittest.mock.patch("aea.cli_gui._call_aea_async", _dummy_call_aea_async):
@@ -99,9 +104,11 @@ def _test_list_items_fail(item_type: str):
     agent_name = "test_agent_id"
 
     def _dummy_call_aea_async(param_list, dir_arg):
-        assert param_list[0] == "aea"
-        assert param_list[1] == "list"
-        assert param_list[2] == item_type + "s"
+        assert param_list[0] == sys.executable
+        assert param_list[1] == "-m"
+        assert param_list[2] == "aea.cli"
+        assert param_list[3] == "list"
+        assert param_list[4] == item_type + "s"
         assert agent_name in dir_arg
         return pid
 

--- a/tests/test_gui/test_remove.py
+++ b/tests/test_gui/test_remove.py
@@ -20,6 +20,7 @@
 
 """This test module contains the tests for the `aea gui` sub-commands."""
 import json
+import sys
 
 import unittest.mock
 
@@ -37,10 +38,12 @@ def test_remove_item():
     connection_name = "test_connection"
 
     def _dummy_call_aea(param_list, dir):
-        assert param_list[0] == "aea"
-        assert param_list[1] == "remove"
-        assert param_list[2] == "connection"
-        assert param_list[3] == connection_name
+        assert param_list[0] == sys.executable
+        assert param_list[1] == "-m"
+        assert param_list[2] == "aea.cli"
+        assert param_list[3] == "remove"
+        assert param_list[4] == "connection"
+        assert param_list[5] == connection_name
         assert agent_name in dir
         return 0
 
@@ -66,10 +69,12 @@ def test_delete_agent_fail():
     connection_name = "test_connection"
 
     def _dummy_call_aea(param_list, dir):
-        assert param_list[0] == "aea"
-        assert param_list[1] == "remove"
-        assert param_list[2] == "connection"
-        assert param_list[3] == connection_name
+        assert param_list[0] == sys.executable
+        assert param_list[1] == "-m"
+        assert param_list[2] == "aea.cli"
+        assert param_list[3] == "remove"
+        assert param_list[4] == "connection"
+        assert param_list[5] == connection_name
         assert agent_name in dir
         return 1
 

--- a/tests/test_gui/test_run_agent.py
+++ b/tests/test_gui/test_run_agent.py
@@ -19,6 +19,7 @@
 
 """This test module contains the tests for the `aea gui` sub-commands."""
 import json
+import sys
 import time
 
 import unittest.mock
@@ -30,192 +31,191 @@ from .test_base import create_app, TempCWD
 def test_create_and_run_agent():
     """Test for running and agent, reading TTY and errors."""
     # Set up a temporary current working directory in which to make agents
-    temp_cwd = TempCWD()
-    app = create_app()
+    with TempCWD():
+        app = create_app()
 
-    agent_id = "test_agent"
+        agent_id = "test_agent"
 
-    # Make an agent
-    response_create = app.post(
-        'api/agent',
-        content_type='application/json',
-        data=json.dumps(agent_id))
-    assert response_create.status_code == 201
-    data = json.loads(response_create.get_data(as_text=True))
-    assert data == agent_id
+        # Make an agent
+        response_create = app.post(
+            'api/agent',
+            content_type='application/json',
+            data=json.dumps(agent_id))
+        assert response_create.status_code == 201
+        data = json.loads(response_create.get_data(as_text=True))
+        assert data == agent_id
 
-    # Add the local connection
-    response_add = app.post(
-        'api/agent/' + agent_id + "/connection",
-        content_type='application/json',
-        data=json.dumps("local")
-    )
-    assert response_add.status_code == 201
+        # Add the local connection
+        response_add = app.post(
+            'api/agent/' + agent_id + "/connection",
+            content_type='application/json',
+            data=json.dumps("local")
+        )
+        assert response_add.status_code == 201
 
-    # Get the running status before we have run it
-    response_status = app.get(
-        'api/agent/' + agent_id + "/run",
-        data=None,
-        content_type='application/json',
-    )
-    assert response_status.status_code == 200
-    data = json.loads(response_status.get_data(as_text=True))
-    assert "NOT_STARTED" in data["status"]
-
-    # run the agent with a non existent connection
-    response_run = app.post(
-        'api/agent/' + agent_id + "/run",
-        content_type='application/json',
-        data=json.dumps("non-existent-connection")
-    )
-    assert response_run.status_code == 400
-
-    # run the agent with default connection - should be something in the error output?
-    response_run = app.post(
-        'api/agent/' + agent_id + "/run",
-        content_type='application/json',
-        data=json.dumps("")
-    )
-    assert response_run.status_code == 201
-    time.sleep(2)
-
-    # Stop the agent running
-    response_stop = app.delete(
-        'api/agent/' + agent_id + "/run",
-        data=None,
-        content_type='application/json',
-    )
-    assert response_stop.status_code == 200
-    time.sleep(2)
-
-    # run the agent with local connection (as no OEF node is running)
-    response_run = app.post(
-        'api/agent/' + agent_id + "/run",
-        content_type='application/json',
-        data=json.dumps("local")
-    )
-    assert response_run.status_code == 201
-
-    time.sleep(2)
-
-    # Try running it again (this should fail)
-    response_run = app.post(
-        'api/agent/' + agent_id + "/run",
-        content_type='application/json',
-        data=json.dumps("local")
-    )
-    assert response_run.status_code == 400
-
-    # Get the running status
-    response_status = app.get(
-        'api/agent/' + agent_id + "/run",
-        data=None,
-        content_type='application/json',
-    )
-    assert response_status.status_code == 200
-    data = json.loads(response_status.get_data(as_text=True))
-
-    assert data["error"] == ""
-    assert "RUNNING" in data["status"]
-
-    # Create a stop agent function that behaves as if the agent had stopped itself
-    def _stop_agent_override(loc_agent_id: str):
-        # Test if we have the process id
-        assert loc_agent_id in aea.cli_gui.app_context.agent_processes
-
-        aea.cli_gui.app_context.agent_processes[loc_agent_id].terminate()
-        aea.cli_gui.app_context.agent_processes[loc_agent_id].wait()
-
-        return "stop_agent: All fine {}".format(loc_agent_id), 200  # 200 (OK)
-
-    with unittest.mock.patch("aea.cli_gui._stop_agent", _stop_agent_override):
-        app.delete(
+        # Get the running status before we have run it
+        response_status = app.get(
             'api/agent/' + agent_id + "/run",
             data=None,
             content_type='application/json',
         )
-    time.sleep(1)
+        assert response_status.status_code == 200
+        data = json.loads(response_status.get_data(as_text=True))
+        assert "NOT_STARTED" in data["status"]
 
-    # Get the running status
-    response_status = app.get(
-        'api/agent/' + agent_id + "/run",
-        data=None,
-        content_type='application/json',
-    )
-    assert response_status.status_code == 200
-    data = json.loads(response_status.get_data(as_text=True))
-    assert "process terminate" in data["error"]
-    assert "FINISHED" in data["status"]
+        # run the agent with a non existent connection
+        response_run = app.post(
+            'api/agent/' + agent_id + "/run",
+            content_type='application/json',
+            data=json.dumps("non-existent-connection")
+        )
+        assert response_run.status_code == 400
 
-    # run the agent again (takes a different path through code)
-    response_run = app.post(
-        'api/agent/' + agent_id + "/run",
-        content_type='application/json',
-        data=json.dumps("local")
-    )
-    assert response_run.status_code == 201
+        # run the agent with default connection - should be something in the error output?
+        response_run = app.post(
+            'api/agent/' + agent_id + "/run",
+            content_type='application/json',
+            data=json.dumps("")
+        )
+        assert response_run.status_code == 201
+        time.sleep(2)
 
-    time.sleep(2)
+        # Stop the agent running
+        response_stop = app.delete(
+            'api/agent/' + agent_id + "/run",
+            data=None,
+            content_type='application/json',
+        )
+        assert response_stop.status_code == 200
+        time.sleep(2)
 
-    # Get the running status
-    response_status = app.get(
-        'api/agent/' + agent_id + "/run",
-        data=None,
-        content_type='application/json',
-    )
-    assert response_status.status_code == 200
-    data = json.loads(response_status.get_data(as_text=True))
-
-    assert data["error"] == ""
-    assert "RUNNING" in data["status"]
-
-    # Stop the agent running
-    response_stop = app.delete(
-        'api/agent/' + agent_id + "/run",
-        data=None,
-        content_type='application/json',
-    )
-    assert response_stop.status_code == 200
-    time.sleep(2)
-
-    # Get the running status
-    response_status = app.get(
-        'api/agent/' + agent_id + "/run",
-        data=None,
-        content_type='application/json',
-    )
-    assert response_status.status_code == 200
-    data = json.loads(response_status.get_data(as_text=True))
-
-    assert "process terminate" in data["error"]
-    assert "NOT_STARTED" in data["status"]
-
-    # Stop a none existent agent running
-    response_stop = app.delete(
-        'api/agent/' + agent_id + "_NOT" + "/run",
-        data=None,
-        content_type='application/json',
-    )
-    assert response_stop.status_code == 400
-    time.sleep(2)
-
-    genuine_func = aea.cli_gui._call_aea_async
-
-    def _dummy_call_aea_async(param_list, dir_arg):
-        assert param_list[0] == "aea"
-        if param_list[1] == "run":
-            return None
-        else:
-            return genuine_func(param_list, dir_arg)
-
-    # Run when process files (but other call - such as status should not fail)
-    with unittest.mock.patch("aea.cli_gui._call_aea_async", _dummy_call_aea_async):
+        # run the agent with local connection (as no OEF node is running)
         response_run = app.post(
             'api/agent/' + agent_id + "/run",
             content_type='application/json',
             data=json.dumps("local")
         )
-    assert response_run.status_code == 400
+        assert response_run.status_code == 201
 
-    # Destroy the temporary current working directory and put cwd back to what it was before
-    temp_cwd.destroy()
+        time.sleep(2)
+
+        # Try running it again (this should fail)
+        response_run = app.post(
+            'api/agent/' + agent_id + "/run",
+            content_type='application/json',
+            data=json.dumps("local")
+        )
+        assert response_run.status_code == 400
+
+        # Get the running status
+        response_status = app.get(
+            'api/agent/' + agent_id + "/run",
+            data=None,
+            content_type='application/json',
+        )
+        assert response_status.status_code == 200
+        data = json.loads(response_status.get_data(as_text=True))
+
+        assert data["error"] == ""
+        assert "RUNNING" in data["status"]
+
+        # Create a stop agent function that behaves as if the agent had stopped itself
+        def _stop_agent_override(loc_agent_id: str):
+            # Test if we have the process id
+            assert loc_agent_id in aea.cli_gui.app_context.agent_processes
+
+            aea.cli_gui.app_context.agent_processes[loc_agent_id].terminate()
+            aea.cli_gui.app_context.agent_processes[loc_agent_id].wait()
+
+            return "stop_agent: All fine {}".format(loc_agent_id), 200  # 200 (OK)
+
+        with unittest.mock.patch("aea.cli_gui._stop_agent", _stop_agent_override):
+            app.delete(
+                'api/agent/' + agent_id + "/run",
+                data=None,
+                content_type='application/json',
+            )
+        time.sleep(1)
+
+        # Get the running status
+        response_status = app.get(
+            'api/agent/' + agent_id + "/run",
+            data=None,
+            content_type='application/json',
+        )
+        assert response_status.status_code == 200
+        data = json.loads(response_status.get_data(as_text=True))
+        assert "process terminate" in data["error"]
+        assert "FINISHED" in data["status"]
+
+        # run the agent again (takes a different path through code)
+        response_run = app.post(
+            'api/agent/' + agent_id + "/run",
+            content_type='application/json',
+            data=json.dumps("local")
+        )
+        assert response_run.status_code == 201
+
+        time.sleep(2)
+
+        # Get the running status
+        response_status = app.get(
+            'api/agent/' + agent_id + "/run",
+            data=None,
+            content_type='application/json',
+        )
+        assert response_status.status_code == 200
+        data = json.loads(response_status.get_data(as_text=True))
+
+        assert data["error"] == ""
+        assert "RUNNING" in data["status"]
+
+        # Stop the agent running
+        response_stop = app.delete(
+            'api/agent/' + agent_id + "/run",
+            data=None,
+            content_type='application/json',
+        )
+        assert response_stop.status_code == 200
+        time.sleep(2)
+
+        # Get the running status
+        response_status = app.get(
+            'api/agent/' + agent_id + "/run",
+            data=None,
+            content_type='application/json',
+        )
+        assert response_status.status_code == 200
+        data = json.loads(response_status.get_data(as_text=True))
+
+        assert "process terminate" in data["error"]
+        assert "NOT_STARTED" in data["status"]
+
+        # Stop a none existent agent running
+        response_stop = app.delete(
+            'api/agent/' + agent_id + "_NOT" + "/run",
+            data=None,
+            content_type='application/json',
+        )
+        assert response_stop.status_code == 400
+        time.sleep(2)
+
+        genuine_func = aea.cli_gui._call_aea_async
+
+        def _dummy_call_aea_async(param_list, dir_arg):
+            assert param_list[0] == sys.executable
+            assert param_list[1] == "-m"
+            assert param_list[2] == "aea.cli"
+            if param_list[3] == "run":
+                return None
+            else:
+                return genuine_func(param_list, dir_arg)
+
+        # Run when process files (but other call - such as status should not fail)
+        with unittest.mock.patch("aea.cli_gui._call_aea_async", _dummy_call_aea_async):
+            response_run = app.post(
+                'api/agent/' + agent_id + "/run",
+                content_type='application/json',
+                data=json.dumps("local")
+            )
+        assert response_run.status_code == 400

--- a/tests/test_gui/test_run_oef.py
+++ b/tests/test_gui/test_run_oef.py
@@ -19,6 +19,7 @@
 
 """This test module contains the tests for the `aea gui` sub-commands."""
 import json
+import sys
 import time
 import unittest.mock
 
@@ -32,7 +33,7 @@ def test_create_and_run_oef():
     pid = DummyPID(None, "A thing of beauty is a joy forever\n", "Testing Error\n")
 
     def _dummy_call_aea_async(param_list, dir_arg):
-        assert param_list[0] == "python"
+        assert param_list[0] == sys.executable
         assert "launch.py" in param_list[1]
         return pid
 
@@ -116,7 +117,7 @@ def test_create_and_run_oef_fail():
     app = create_app()
 
     def _dummy_call_aea_async(param_list, dir_arg):
-        assert param_list[0] == "python"
+        assert param_list[0] == sys.executable
         assert "launch.py" in param_list[1]
         return None
 

--- a/tests/test_gui/test_scaffold.py
+++ b/tests/test_gui/test_scaffold.py
@@ -20,6 +20,7 @@
 
 """This test module contains the tests for the `aea gui` sub-commands."""
 import json
+import sys
 
 import unittest.mock
 
@@ -37,10 +38,12 @@ def test_scaffold_item():
     connection_name = "test_connection"
 
     def _dummy_call_aea(param_list, dir):
-        assert param_list[0] == "aea"
-        assert param_list[1] == "scaffold"
-        assert param_list[2] == "connection"
-        assert param_list[3] == connection_name
+        assert param_list[0] == sys.executable
+        assert param_list[1] == "-m"
+        assert param_list[2] == "aea.cli"
+        assert param_list[3] == "scaffold"
+        assert param_list[4] == "connection"
+        assert param_list[5] == connection_name
         assert agent_name in dir
         return 0
 
@@ -66,10 +69,12 @@ def test_scaffold_agent_fail():
     connection_name = "test_connection"
 
     def _dummy_call_aea(param_list, dir):
-        assert param_list[0] == "aea"
-        assert param_list[1] == "scaffold"
-        assert param_list[2] == "connection"
-        assert param_list[3] == connection_name
+        assert param_list[0] == sys.executable
+        assert param_list[1] == "-m"
+        assert param_list[2] == "aea.cli"
+        assert param_list[3] == "scaffold"
+        assert param_list[4] == "connection"
+        assert param_list[5] == connection_name
         assert agent_name in dir
         return 1
 

--- a/tests/test_gui/test_search.py
+++ b/tests/test_gui/test_search.py
@@ -56,14 +56,13 @@ def _test_search_items_with_query(item_type: str, query: str):
         )
     assert response_list.status_code == 200
     data = json.loads(response_list.get_data(as_text=True))
-    assert len(data[0]) == 2
-    assert data[0][0]['id'] == 'default'
-    assert data[0][0]['description'] == 'The default item allows for any byte logic.'
-    assert data[0][1]['id'] == 'oef'
-    assert data[0][1]['description'] == 'The oef item implements the OEF specific logic.'
-    assert data[0][1]['description'] == 'The oef item implements the OEF specific logic.'
-    assert data[1] == item_type
-    assert data[2] == 'test'
+    assert len(data["search_result"]) == 2
+    assert data["search_result"][0]['id'] == 'default'
+    assert data["search_result"][0]['description'] == 'The default item allows for any byte logic.'
+    assert data["search_result"][1]['id'] == 'oef'
+    assert data["search_result"][1]['description'] == 'The oef item implements the OEF specific logic.'
+    assert data["item_type"] == item_type
+    assert data["search_term"] == 'test'
 
 
 def _test_search_items(item_type: str):


### PR DESCRIPTION
## Proposed changes

Fix minor issues in the tests relative to the CLI GUI component.

- the main reason of this PR is about some tests that started failing for Python 3.8. Namely:
    - `tests/test_gui/test_search.py::test_search_protocols`
    - `tests/test_gui/test_search.py::test_search_connections`
    - `tests/test_gui/test_search.py::test_list_skills`

Each of them raised the following error:
```
  File ".../agents-aea/.tox/py38/lib/python3.8/site-packages/connexion/apis/abstract.py", line 325, in _response_from_handler
    raise TypeError(
TypeError: The view function did not return a valid response tuple. The tuple must have the form (body), (body, status, headers), (body, status), or (body, headers).
```
Indeed, the `aea/cli_gui/__init__.py::search_registered_items` returned 4 values instead of the allowed number between 1 and 3. It is probably due to a change in the `connexion` dependency. 
That change also implied a change in the `home.js` file in the front-end of the app.

- To call the `aea` command,  `["sys.executable", "-m", "aea.cli", ...]` is used, replacing `["aea", ...]`. That would probably give more robustness since we are sure to use the same executable that is being used by the calling process.


## Fixes


## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that code coverage does not decrease.
- [X] I have checked that the documentation about the `aea cli` tool works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

