### PR TITLE
AEA-220 Using config set for strategy variables.

### DIFF
--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -40,7 +40,7 @@ from aea.configurations.loader import ConfigLoader
 logger = logging.getLogger("aea")
 logger = default_logging_config(logger)
 
-DEFAULT_REGISTRY_PATH = str(Path(aea.AEA_DIR, "..", "packages").resolve())
+DEFAULT_REGISTRY_PATH = str(Path("..", "packages"))
 DEFAULT_CONNECTION = "oef"
 DEFAULT_SKILL = "error"
 

--- a/aea/cli/config.py
+++ b/aea/cli/config.py
@@ -177,6 +177,7 @@ def set(ctx: Context, json_path: List[str], value):
 
     try:
         configuration_obj = config_loader.configuration_type.from_json(configuration_dict)
+        config_loader.validator.validate(instance=configuration_obj.json)
         config_loader.dump(configuration_obj, open(configuration_file_path, "w"))
     except Exception:
         logger.error("Attribute or value not valid.")

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -243,7 +243,7 @@ class ConnectionConfig(Configuration):
             restricted_to_protocols=cast(Set[str], restricted_to_protocols),
             excluded_protocols=cast(Set[str], excluded_protocols),
             dependencies=dependencies,
-            description=cast(str, obj.get("description")),
+            description=cast(str, obj.get("description", "")),
             **cast(dict, obj.get("config"))
         )
 
@@ -294,7 +294,7 @@ class ProtocolConfig(Configuration):
             license=cast(str, obj.get("license")),
             url=cast(str, obj.get("url")),
             dependencies=dependencies,
-            description=cast(str, obj.get("description")),
+            description=cast(str, obj.get("description", "")),
         )
 
 
@@ -458,7 +458,7 @@ class SkillConfig(Configuration):
         url = cast(str, obj.get("url"))
         protocols = cast(List[str], obj.get("protocols", []))
         dependencies = cast(Dependencies, obj.get("dependencies", {}))
-        description = cast(str, obj.get("description"))
+        description = cast(str, obj.get("description", ""))
         skill_config = SkillConfig(
             name=name,
             author=author,
@@ -595,7 +595,7 @@ class AgentConfig(Configuration):
             license=cast(str, obj.get("license")),
             url=cast(str, obj.get("url")),
             registry_path=cast(str, obj.get("registry_path")),
-            description=cast(str, obj.get("description")),
+            description=cast(str, obj.get("description", "")),
             logging_config=cast(Dict, obj.get("logging_config", {})),
             private_key_paths=cast(Dict, private_key_paths),
             ledger_apis=cast(Dict, ledger_apis)

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -5,6 +5,8 @@
 | `add connection/protocol/skill [name]`      | Add connection, protocol, or skill, called `[name]`, to the agent.           |	
 | `add-key default/fetchai/ethereum file`     | Add a private key from a file.	                                             |
 | `create NAME`                               | Create a new aea project called `[name]`.                                    |		
+| `config get [path]`                         | Reads 'aea-config.yaml' and prints the agent name.                           |
+| `config set [path]`                         | Sets a new name for the agent.                                               |
 | `delete NAME`                               | Delete an aea project. See below for disabling a resource.                   |		
 | `fetch NAME`                                | Fetch an aea project called `[name]`.                                        |		
 | `freeze`                                    | Get all the dependencies needed for the aea project and its components.      |		
@@ -24,6 +26,8 @@ Command  | Description
 `add connection/protocol/skill [name]`  | Add connection, protocol, or skill, called `[name]`, to the agent.
 `add-key default/fetchai/ethereum file`  | add a private key from a file.
 `create NAME` | Create a new aea project called `[name]`.
+`config get [path]` | reads 'aea-config.yaml' and prints the agent name.
+`config set [path]` | sets a new name for the agent.
 `delete NAME`  | Delete an aea project. See below for disabling a resource.
 `deploy {using [connection, ...]}`  | Deploy the agent to a server and run it on the Fetch.ai network with default or specified connections.
 `fetch NAME`   | Fetch an aea project called `[name]`.

--- a/packages/skills/carpark_client/strategy.py
+++ b/packages/skills/carpark_client/strategy.py
@@ -22,8 +22,10 @@
 import time
 from typing import cast
 
+from aea.cli import cli
 from aea.protocols.oef.models import Description, Query, Constraint, ConstraintType
 from aea.skills.base import SharedClass
+from tests.common.click_testing import CliRunner
 
 DEFAULT_COUNTRY = 'UK'
 SEARCH_TERM = 'country'
@@ -31,6 +33,8 @@ DEFAULT_SEARCH_INTERVAL = 5.0
 DEFAULT_MAX_PRICE = 4000
 DEFAULT_MAX_DETECTION_AGE = 60 * 60   # 1 hour
 DEFAULT_NO_FINDSEARCH_INTERVAL = 5
+
+CLI_LOG_OPTION = ["-v", "OFF"]
 
 
 class Strategy(SharedClass):
@@ -47,6 +51,29 @@ class Strategy(SharedClass):
         self._no_find_search_interval = cast(float, kwargs.pop('no_find_search_interval')) if 'no_find_search_interval' in kwargs.keys() else DEFAULT_NO_FINDSEARCH_INTERVAL
         self._max_price = kwargs.pop('max_price') if 'max_price' in kwargs.keys() else DEFAULT_MAX_PRICE
         self._max_detection_age = kwargs.pop('max_detection_age') if 'max_detection_age' in kwargs.keys() else DEFAULT_MAX_DETECTION_AGE
+
+        self.runner = CliRunner()
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.carpark_client.shared_classes.strategy.args.country",
+                                 DEFAULT_COUNTRY], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.carpark_client.shared_classes.strategy.args.search_interval",
+                                 DEFAULT_SEARCH_INTERVAL], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.carpark_client.shared_classes.strategy.args.no_find_search_interval",
+                                 DEFAULT_NO_FINDSEARCH_INTERVAL], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.carpark_client.shared_classes.strategy.args.max_price",
+                                 DEFAULT_MAX_PRICE], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.carpark_client.shared_classes.strategy.args.max_detection_age",
+                                 DEFAULT_MAX_DETECTION_AGE], standalone_mode=False)
+
         super().__init__(**kwargs)
 
         self.is_searching = True

--- a/packages/skills/ml_data_provider/strategy.py
+++ b/packages/skills/ml_data_provider/strategy.py
@@ -22,8 +22,10 @@
 import numpy as np
 from tensorflow import keras
 
+from aea.cli import cli
 from aea.protocols.oef.models import Attribute, DataModel, Description, Query
 from aea.skills.base import SharedClass
+from tests.common.click_testing import CliRunner
 
 DEFAULT_PRICE_PER_DATA_BATCH = 10
 DEFAULT_DATASET_ID = "fmnist"
@@ -33,19 +35,44 @@ DEFAULT_BUYER_TX_FEE = 0
 DEFAULT_CURRENCY_PBK = 'FET'
 DEFAULT_LEDGER_ID = 'fetchai'
 
+CLI_LOG_OPTION = ["-v", "OFF"]
+
 
 class Strategy(SharedClass):
     """This class defines a strategy for the agent."""
 
     def __init__(self, **kwargs) -> None:
         """Initialize the strategy of the agent."""
-        self.price_per_data_batch = kwargs.pop('price_per_data_batch', DEFAULT_PRICE_PER_DATA_BATCH)
-        self.batch_size = kwargs.pop('batch_size', DEFAULT_BATCH_SIZE)
-        self.dataset_id = kwargs.pop('dataset_id', DEFAULT_DATASET_ID)
-        self.seller_tx_fee = kwargs.pop('seller_tx_fee', DEFAULT_SELLER_TX_FEE)
-        self.buyer_tx_fee = kwargs.pop('buyer_tx_fee', DEFAULT_BUYER_TX_FEE)
-        self.currency_id = kwargs.pop('currency_id', DEFAULT_CURRENCY_PBK)
-        self.ledger_id = kwargs.pop('ledger_id', DEFAULT_LEDGER_ID)
+        self.runner = CliRunner()
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.ml_data_provider.shared_classes.strategy.args.price_per_data_batch",
+                                 DEFAULT_PRICE_PER_DATA_BATCH], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.ml_data_provider.shared_classes.strategy.args.batch_size",
+                                 DEFAULT_BATCH_SIZE], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.ml_data_provider.shared_classes.strategy.args.dataset_id",
+                                 DEFAULT_DATASET_ID], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.ml_data_provider.shared_classes.strategy.args.seller_tx_fee",
+                                 DEFAULT_SELLER_TX_FEE], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.ml_data_provider.shared_classes.strategy.args.buyer_tx_fee",
+                                 DEFAULT_BUYER_TX_FEE], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.ml_data_provider.shared_classes.strategy.args.currency_id",
+                                 DEFAULT_CURRENCY_PBK], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.ml_data_provider.shared_classes.strategy.args.ledger_id",
+                                 DEFAULT_LEDGER_ID], standalone_mode=False)
+
         super().__init__(**kwargs)
         self._oef_msg_id = 0
 
@@ -69,7 +96,7 @@ class Strategy(SharedClass):
         :return: a description of the offered services
         """
         dm = DataModel("ml_datamodel", [Attribute("dataset_id", str, True)])
-        desc = Description({'dataset_id': self.dataset_id}, data_model=dm)
+        desc = Description({'dataset_id': DEFAULT_DATASET_ID}, data_model=dm)
         return desc
 
     def sample_data(self, n: int):
@@ -100,13 +127,13 @@ class Strategy(SharedClass):
 
         :return: a tuple of proposal and the weather data
         """
-        address = self.context.agent_addresses[self.ledger_id]
-        proposal = Description({"batch_size": self.batch_size,
-                                "price": self.price_per_data_batch,
-                                "seller_tx_fee": self.seller_tx_fee,
-                                "buyer_tx_fee": self.buyer_tx_fee,
-                                "currency_id": self.currency_id,
-                                "ledger_id": self.ledger_id,
+        address = self.context.agent_addresses[DEFAULT_LEDGER_ID]
+        proposal = Description({"batch_size": DEFAULT_BATCH_SIZE,
+                                "price": DEFAULT_PRICE_PER_DATA_BATCH,
+                                "seller_tx_fee": DEFAULT_SELLER_TX_FEE,
+                                "buyer_tx_fee": DEFAULT_BUYER_TX_FEE,
+                                "currency_id": DEFAULT_CURRENCY_PBK,
+                                "ledger_id": DEFAULT_LEDGER_ID,
                                 "address": address})
         return proposal
 

--- a/packages/skills/ml_train/handlers.py
+++ b/packages/skills/ml_train/handlers.py
@@ -32,13 +32,13 @@ from aea.skills.base import Handler
 if TYPE_CHECKING or "pytest" in sys.modules:
     from packages.protocols.ml_trade.message import MLTradeMessage
     from packages.protocols.ml_trade.serialization import MLTradeSerializer
-    from packages.skills.ml_train.strategy import Strategy
+    from packages.skills.ml_train.strategy import Strategy, DEFAULT_IS_LEDGER_TX
     from packages.skills.ml_train.tasks import MLTrainTask
     # from packages.skills.ml_train.tasks import MLTask
 else:
     from ml_trade_protocol.message import MLTradeMessage
     from ml_trade_protocol.serialization import MLTradeSerializer
-    from ml_train_skill.strategy import Strategy
+    from ml_train_skill.strategy import Strategy, DEFAULT_IS_LEDGER_TX
     from ml_train_skill.tasks import MLTrainTask
 
 logger = logging.getLogger("aea.ml_train_skill")
@@ -94,7 +94,7 @@ class TrainHandler(Handler):
             logger.info("[{}]: rejecting, terms are not acceptable and/or affordable".format(self.context.agent_name))
             return
 
-        if strategy.is_ledger_tx:
+        if DEFAULT_IS_LEDGER_TX:
             # propose the transaction to the decision maker for settlement on the ledger
             tx_msg = TransactionMessage(performative=TransactionMessage.Performative.PROPOSE_FOR_SETTLEMENT,
                                         skill_callback_ids=['ml_train'],

--- a/packages/skills/ml_train/strategy.py
+++ b/packages/skills/ml_train/strategy.py
@@ -21,14 +21,18 @@
 import datetime
 from typing import cast
 
+from aea.cli import cli
 from aea.protocols.oef.models import Attribute, DataModel, Query, Constraint, ConstraintType, Description
 from aea.skills.base import SharedClass
+from tests.common.click_testing import CliRunner
 
 DEFAULT_DATASET_ID = 'UK'
 DEFAULT_MAX_ROW_PRICE = 5
 DEFAULT_MAX_TX_FEE = 2
 DEFAULT_CURRENCY_PBK = 'FET'
 DEFAULT_LEDGER_ID = 'None'
+DEFAULT_IS_LEDGER_TX = False
+CLI_LOG_OPTION = ["-v", "OFF"]
 
 
 class Strategy(SharedClass):
@@ -36,12 +40,32 @@ class Strategy(SharedClass):
 
     def __init__(self, **kwargs) -> None:
         """Initialize the strategy of the agent."""
-        self._dataset_id = kwargs.pop('dataset_id', DEFAULT_DATASET_ID)
-        self._max_unit_price = kwargs.pop('max_unit_price', DEFAULT_MAX_ROW_PRICE)
-        self._max_buyer_tx_fee = kwargs.pop('max_buyer_tx_fee', DEFAULT_MAX_TX_FEE)
-        self._currency_id = kwargs.pop('currency_id', DEFAULT_CURRENCY_PBK)
-        self._ledger_id = kwargs.pop('ledger_id', DEFAULT_LEDGER_ID)
-        self.is_ledger_tx = kwargs.pop('is_ledger_tx', False)
+        self.runner = CliRunner()
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.ml_train.shared_classes.strategy.args.country",
+                                 DEFAULT_DATASET_ID], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.ml_train.shared_classes.strategy.args.max_unit_price",
+                                 DEFAULT_MAX_ROW_PRICE], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.ml_train.shared_classes.strategy.args.max_buyer_tx_fee",
+                                 DEFAULT_MAX_TX_FEE], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.ml_train.shared_classes.strategy.args.currency_id",
+                                 DEFAULT_CURRENCY_PBK], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.ml_train.shared_classes.strategy.args.ledger_id",
+                                 DEFAULT_LEDGER_ID], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.ml_train.shared_classes.strategy.args.is_ledger_tx",
+                                 DEFAULT_IS_LEDGER_TX], standalone_mode=False)
+
         super().__init__(**kwargs)
         self._search_id = 0
         self.is_searching = True
@@ -74,7 +98,7 @@ class Strategy(SharedClass):
         :return: the query
         """
         dm = DataModel("ml_datamodel", [Attribute("dataset_id", str, True)])
-        query = Query([Constraint("dataset_id", ConstraintType("==", self._dataset_id))], model=dm)
+        query = Query([Constraint("dataset_id", ConstraintType("==", DEFAULT_DATASET_ID))], model=dm)
         return query
 
     def is_acceptable_terms(self, terms: Description) -> bool:
@@ -85,10 +109,10 @@ class Strategy(SharedClass):
         :return: boolean
         """
         result = (terms.values['price'] - terms.values['seller_tx_fee'] > 0) and \
-            (terms.values['price'] <= self._max_unit_price * terms.values['batch_size']) and \
-            (terms.values['buyer_tx_fee'] <= self._max_buyer_tx_fee) and \
-            (terms.values['currency_id'] == self._currency_id) and \
-            (terms.values['ledger_id'] == self._ledger_id)
+            (terms.values['price'] <= DEFAULT_MAX_ROW_PRICE * terms.values['batch_size']) and \
+            (terms.values['buyer_tx_fee'] <= DEFAULT_MAX_TX_FEE) and \
+            (terms.values['currency_id'] == DEFAULT_CURRENCY_PBK) and \
+            (terms.values['ledger_id'] == DEFAULT_LEDGER_ID)
         return result
 
     def is_affordable_terms(self, terms: Description) -> bool:
@@ -98,7 +122,7 @@ class Strategy(SharedClass):
         :params terms: the terms
         :return: whether it is affordable
         """
-        if self.is_ledger_tx:
+        if DEFAULT_IS_LEDGER_TX:
             payable = terms.values['price'] - terms.values['seller_tx_fee'] + terms.values['buyer_tx_fee']
             ledger_id = terms.values['ledger_id']
             address = cast(str, self.context.agent_addresses.get(ledger_id))

--- a/packages/skills/weather_client/strategy.py
+++ b/packages/skills/weather_client/strategy.py
@@ -18,9 +18,10 @@
 # ------------------------------------------------------------------------------
 
 """This module contains the strategy class."""
-
+from aea.cli import cli
 from aea.protocols.oef.models import Description, Query, Constraint, ConstraintType
 from aea.skills.base import SharedClass
+from tests.common.click_testing import CliRunner
 
 DEFAULT_COUNTRY = 'UK'
 SEARCH_TERM = 'country'
@@ -28,6 +29,7 @@ DEFAULT_MAX_ROW_PRICE = 5
 DEFAULT_MAX_TX_FEE = 2
 DEFAULT_CURRENCY_PBK = 'FET'
 DEFAULT_LEDGER_ID = 'None'
+CLI_LOG_OPTION = ["-v", "OFF"]
 
 
 class Strategy(SharedClass):
@@ -39,11 +41,27 @@ class Strategy(SharedClass):
 
         :return: None
         """
-        self._country = kwargs.pop('country') if 'country' in kwargs.keys() else DEFAULT_COUNTRY
-        self._max_row_price = kwargs.pop('max_row_price') if 'max_row_price' in kwargs.keys() else DEFAULT_MAX_ROW_PRICE
-        self.max_buyer_tx_fee = kwargs.pop('max_tx_fee') if 'max_tx_fee' in kwargs.keys() else DEFAULT_MAX_TX_FEE
-        self._currency_id = kwargs.pop('currency_id') if 'currency_id' in kwargs.keys() else DEFAULT_CURRENCY_PBK
-        self._ledger_id = kwargs.pop('ledger_id') if 'ledger_id' in kwargs.keys() else DEFAULT_LEDGER_ID
+        self.runner = CliRunner()
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.country",
+                                 DEFAULT_COUNTRY], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.max_row_price",
+                                 DEFAULT_MAX_ROW_PRICE], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.max_tx_fee",
+                                 DEFAULT_MAX_TX_FEE], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.currency_id",
+                                 DEFAULT_CURRENCY_PBK], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.ledger_id",
+                                 DEFAULT_LEDGER_ID], standalone_mode=False)
         super().__init__(**kwargs)
         self._search_id = 0
         self.is_searching = True

--- a/packages/skills/weather_client/strategy.py
+++ b/packages/skills/weather_client/strategy.py
@@ -44,23 +44,23 @@ class Strategy(SharedClass):
         self.runner = CliRunner()
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.country",
+                                 "skills.weather_client.shared_classes.strategy.args.country",
                                  DEFAULT_COUNTRY], standalone_mode=False)
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.max_row_price",
+                                 "skills.weather_client.shared_classes.strategy.args.max_row_price",
                                  DEFAULT_MAX_ROW_PRICE], standalone_mode=False)
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.max_tx_fee",
+                                 "skills.weather_client.shared_classes.strategy.args.max_tx_fee",
                                  DEFAULT_MAX_TX_FEE], standalone_mode=False)
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.currency_id",
+                                 "skills.weather_client.shared_classes.strategy.args.currency_id",
                                  DEFAULT_CURRENCY_PBK], standalone_mode=False)
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.ledger_id",
+                                 "skills.weather_client.shared_classes.strategy.args.ledger_id",
                                  DEFAULT_LEDGER_ID], standalone_mode=False)
         super().__init__(**kwargs)
         self._search_id = 0
@@ -81,7 +81,7 @@ class Strategy(SharedClass):
 
         :return: the query
         """
-        query = Query([Constraint(SEARCH_TERM, ConstraintType("==", self._country))], model=None)
+        query = Query([Constraint(SEARCH_TERM, ConstraintType("==", DEFAULT_COUNTRY))], model=None)
         return query
 
     def is_acceptable_proposal(self, proposal: Description) -> bool:
@@ -91,7 +91,7 @@ class Strategy(SharedClass):
         :return: whether it is acceptable
         """
         result = (proposal.values['price'] - proposal.values['seller_tx_fee'] > 0) and \
-            (proposal.values['price'] <= self._max_row_price * proposal.values['rows']) and \
-            (proposal.values['currency_id'] == self._currency_id) and \
-            (proposal.values['ledger_id'] == self._ledger_id)
+                 (proposal.values['price'] <= DEFAULT_MAX_ROW_PRICE * proposal.values['rows']) and \
+                 (proposal.values['currency_id'] == DEFAULT_CURRENCY_PBK) and \
+                 (proposal.values['ledger_id'] == DEFAULT_LEDGER_ID)
         return result

--- a/packages/skills/weather_client_ledger/handlers.py
+++ b/packages/skills/weather_client_ledger/handlers.py
@@ -37,10 +37,10 @@ from aea.decision_maker.messages.transaction import TransactionMessage
 
 if TYPE_CHECKING or "pytest" in sys.modules:
     from packages.skills.weather_client_ledger.dialogues import Dialogue, Dialogues
-    from packages.skills.weather_client_ledger.strategy import Strategy
+    from packages.skills.weather_client_ledger.strategy import Strategy, DEFAULT_MAX_TX_FEE
 else:
     from weather_client_ledger_skill.dialogues import Dialogue, Dialogues
-    from weather_client_ledger_skill.strategy import Strategy
+    from weather_client_ledger_skill.strategy import Strategy, DEFAULT_MAX_TX_FEE
 
 logger = logging.getLogger("aea.weather_client_ledger_skill")
 
@@ -186,7 +186,7 @@ class FIPAHandler(Handler):
         logger.info("[{}]: received MATCH_ACCEPT_W_INFORM from sender={}".format(self.context.agent_name, msg.counterparty[-5:]))
         info = msg.info
         address = cast(str, info.get("address"))
-        strategy = cast(Strategy, self.context.strategy)
+        # strategy = cast(Strategy, self.context.strategy)
         proposal = cast(Description, dialogue.proposal)
         tx_msg = TransactionMessage(performative=TransactionMessage.Performative.PROPOSE_FOR_SETTLEMENT,
                                     skill_callback_ids=["weather_client_ledger"],
@@ -194,7 +194,7 @@ class FIPAHandler(Handler):
                                     tx_sender_addr=self.context.agent_addresses[proposal.values['ledger_id']],
                                     tx_counterparty_addr=address,
                                     tx_amount_by_currency_id={proposal.values['currency_id']: proposal.values['price']},
-                                    tx_sender_fee=strategy.max_buyer_tx_fee,
+                                    tx_sender_fee=DEFAULT_MAX_TX_FEE,
                                     tx_counterparty_fee=proposal.values['seller_tx_fee'],
                                     tx_quantities_by_good_id={},
                                     ledger_id=proposal.values['ledger_id'],

--- a/packages/skills/weather_client_ledger/strategy.py
+++ b/packages/skills/weather_client_ledger/strategy.py
@@ -45,27 +45,26 @@ class Strategy(SharedClass):
 
         :return: None
         """
-
         self.runner = CliRunner()
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.country",
+                                 "skills.weather_client_ledger.shared_classes.strategy.args.country",
                                  DEFAULT_COUNTRY], standalone_mode=False)
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.max_row_price",
+                                 "skills.weather_client_ledger.shared_classes.strategy.args.max_row_price",
                                  DEFAULT_MAX_ROW_PRICE], standalone_mode=False)
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.max_tx_fee",
+                                 "skills.weather_client_ledger.shared_classes.strategy.args.max_tx_fee",
                                  DEFAULT_MAX_TX_FEE], standalone_mode=False)
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.currency_id",
+                                 "skills.weather_client_ledger.shared_classes.strategy.args.currency_id",
                                  DEFAULT_CURRENCY_PBK], standalone_mode=False)
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.ledger_id",
+                                 "skills.weather_client_ledger.shared_classes.strategy.args.ledger_id",
                                  DEFAULT_LEDGER_ID], standalone_mode=False)
 
         super().__init__(**kwargs)
@@ -87,7 +86,7 @@ class Strategy(SharedClass):
 
         :return: the query
         """
-        query = Query([Constraint(SEARCH_TERM, ConstraintType("==", self._country))], model=None)
+        query = Query([Constraint(SEARCH_TERM, ConstraintType("==", DEFAULT_COUNTRY))], model=None)
         return query
 
     def is_acceptable_proposal(self, proposal: Description) -> bool:
@@ -97,9 +96,9 @@ class Strategy(SharedClass):
         :return: whether it is acceptable
         """
         result = (proposal.values['price'] - proposal.values['seller_tx_fee'] > 0) and \
-            (proposal.values['price'] <= self._max_row_price * proposal.values['rows']) and \
-            (proposal.values['currency_id'] == self._currency_id) and \
-            (proposal.values['ledger_id'] == self._ledger_id)
+            (proposal.values['price'] <= DEFAULT_MAX_ROW_PRICE * proposal.values['rows']) and \
+            (proposal.values['currency_id'] == DEFAULT_CURRENCY_PBK) and \
+            (proposal.values['ledger_id'] == DEFAULT_LEDGER_ID)
         return result
 
     def is_affordable_proposal(self, proposal: Description) -> bool:
@@ -108,7 +107,7 @@ class Strategy(SharedClass):
 
         :return: whether it is affordable
         """
-        payable = proposal.values['price'] + self.max_buyer_tx_fee
+        payable = proposal.values['price'] + DEFAULT_MAX_TX_FEE
         ledger_id = proposal.values['ledger_id']
         address = cast(str, self.context.agent_addresses.get(ledger_id))
         balance = self.context.ledger_apis.token_balance(ledger_id, address)

--- a/packages/skills/weather_client_ledger/strategy.py
+++ b/packages/skills/weather_client_ledger/strategy.py
@@ -21,8 +21,10 @@
 
 from typing import cast
 
+from aea.cli import cli
 from aea.protocols.oef.models import Description, Query, Constraint, ConstraintType
 from aea.skills.base import SharedClass
+from tests.common.click_testing import CliRunner
 
 DEFAULT_COUNTRY = 'UK'
 SEARCH_TERM = 'country'
@@ -30,6 +32,8 @@ DEFAULT_MAX_ROW_PRICE = 5
 DEFAULT_MAX_TX_FEE = 2
 DEFAULT_CURRENCY_PBK = 'FET'
 DEFAULT_LEDGER_ID = 'fetchai'
+
+CLI_LOG_OPTION = ["-v", "OFF"]
 
 
 class Strategy(SharedClass):
@@ -41,11 +45,29 @@ class Strategy(SharedClass):
 
         :return: None
         """
-        self._country = kwargs.pop('country') if 'country' in kwargs.keys() else DEFAULT_COUNTRY
-        self._max_row_price = kwargs.pop('max_row_price') if 'max_row_price' in kwargs.keys() else DEFAULT_MAX_ROW_PRICE
-        self.max_buyer_tx_fee = kwargs.pop('max_tx_fee') if 'max_tx_fee' in kwargs.keys() else DEFAULT_MAX_TX_FEE
-        self._currency_id = kwargs.pop('currency_id') if 'currency_id' in kwargs.keys() else DEFAULT_CURRENCY_PBK
-        self._ledger_id = kwargs.pop('ledger_id') if 'ledger_id' in kwargs.keys() else DEFAULT_LEDGER_ID
+
+        self.runner = CliRunner()
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.country",
+                                 DEFAULT_COUNTRY], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.max_row_price",
+                                 DEFAULT_MAX_ROW_PRICE], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.max_tx_fee",
+                                 DEFAULT_MAX_TX_FEE], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.currency_id",
+                                 DEFAULT_CURRENCY_PBK], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.ledger_id",
+                                 DEFAULT_LEDGER_ID], standalone_mode=False)
+
         super().__init__(**kwargs)
         self._search_id = 0
         self.is_searching = True

--- a/packages/skills/weather_station/strategy.py
+++ b/packages/skills/weather_station/strategy.py
@@ -22,8 +22,10 @@ import time
 import sys
 from typing import Any, Dict, List, Tuple, TYPE_CHECKING
 
+from aea.cli import cli
 from aea.protocols.oef.models import Description, Query
 from aea.skills.base import SharedClass
+from tests.common.click_testing import CliRunner
 
 if TYPE_CHECKING or "pytest" in sys.modules:
     from packages.skills.weather_station.db_communication import DBCommunication
@@ -38,6 +40,7 @@ DEFAULT_CURRENCY_PBK = 'FET'
 DEFAULT_LEDGER_ID = 'fetchai'
 DEFAULT_DATE_ONE = "3/10/2019"
 DEFAULT_DATE_TWO = "15/10/2019"
+CLI_LOG_OPTION = ["-v", "OFF"]
 
 
 class Strategy(SharedClass):
@@ -52,12 +55,31 @@ class Strategy(SharedClass):
 
         :return: None
         """
-        self._price_per_row = kwargs.pop('price_per_row') if 'price_per_row' in kwargs.keys() else DEFAULT_PRICE_PER_ROW
-        self._seller_tx_fee = kwargs.pop('seller_tx_fee') if 'seller_tx_fee' in kwargs.keys() else DEFAULT_SELLER_TX_FEE
-        self._currency_id = kwargs.pop('currency_id') if 'currency_id' in kwargs.keys() else DEFAULT_CURRENCY_PBK
-        self._ledger_id = kwargs.pop('ledger_id') if 'ledger_id' in kwargs.keys() else DEFAULT_LEDGER_ID
-        self._date_one = kwargs.pop('date_one') if 'date_one' in kwargs.keys() else DEFAULT_DATE_ONE
-        self._date_two = kwargs.pop('date_two') if 'date_two' in kwargs.keys() else DEFAULT_DATE_TWO
+        self.runner = CliRunner()
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.price_per_row",
+                                 DEFAULT_PRICE_PER_ROW], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.seller_tx_fee",
+                                 DEFAULT_SELLER_TX_FEE], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.currency_id",
+                                 DEFAULT_CURRENCY_PBK], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.ledger_id",
+                                 DEFAULT_LEDGER_ID], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.date_one",
+                                 DEFAULT_DATE_ONE], standalone_mode=False)
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.date_two",
+                                 DEFAULT_DATE_TWO], standalone_mode=False)
+
         super().__init__(**kwargs)
         self.db = DBCommunication()
         self._oef_msg_id = 0

--- a/packages/skills/weather_station/strategy.py
+++ b/packages/skills/weather_station/strategy.py
@@ -119,15 +119,15 @@ class Strategy(SharedClass):
         :param query: the query
         :return: a tuple of proposal and the weather data
         """
-        fetched_data = self.db.get_data_for_specific_dates(self._date_one, self._date_two)  # TODO: fetch real data
+        fetched_data = self.db.get_data_for_specific_dates(DEFAULT_DATE_ONE, DEFAULT_DATE_TWO)  # TODO: fetch real data
         weather_data, rows = self._build_data_payload(fetched_data)
-        total_price = self._price_per_row * rows
-        assert total_price - self._seller_tx_fee > 0, "This sale would generate a loss, change the configs!"
+        total_price = DEFAULT_PRICE_PER_ROW * rows
+        assert total_price - DEFAULT_SELLER_TX_FEE > 0, "This sale would generate a loss, change the configs!"
         proposal = Description({"rows": rows,
                                 "price": total_price,
-                                "seller_tx_fee": self._seller_tx_fee,
-                                "currency_id": self._currency_id,
-                                "ledger_id": self._ledger_id})
+                                "seller_tx_fee": DEFAULT_SELLER_TX_FEE,
+                                "currency_id": DEFAULT_CURRENCY_PBK,
+                                "ledger_id": DEFAULT_LEDGER_ID})
         return (proposal, weather_data)
 
     def _build_data_payload(self, fetched_data: Dict[str, int]) -> Tuple[Dict[str, List[Dict[str, Any]]], int]:

--- a/packages/skills/weather_station_ledger/strategy.py
+++ b/packages/skills/weather_station_ledger/strategy.py
@@ -23,8 +23,10 @@ import sys
 import time
 from typing import Any, Dict, List, Tuple, TYPE_CHECKING
 
+from aea.cli import cli
 from aea.protocols.oef.models import Description, Query
 from aea.skills.base import SharedClass
+from tests.common.click_testing import CliRunner
 
 if TYPE_CHECKING or "pytest" in sys.modules:
     from packages.skills.weather_station_ledger.db_communication import DBCommunication
@@ -40,6 +42,7 @@ DEFAULT_LEDGER_ID = 'fetchai'
 DEFAULT_DATE_ONE = "3/10/2019"
 DEFAULT_DATE_TWO = "15/10/2019"
 
+CLI_LOG_OPTION = ["-v", "OFF"]
 
 class Strategy(SharedClass):
     """This class defines a strategy for the agent."""
@@ -53,12 +56,30 @@ class Strategy(SharedClass):
 
         :return: None
         """
-        self._price_per_row = kwargs.pop('price_per_row') if 'price_per_row' in kwargs.keys() else DEFAULT_PRICE_PER_ROW
-        self._seller_tx_fee = kwargs.pop('seller_tx_fee') if 'seller_tx_fee' in kwargs.keys() else DEFAULT_SELLER_TX_FEE
-        self._currency_id = kwargs.pop('currency_id') if 'currency_id' in kwargs.keys() else DEFAULT_CURRENCY_PBK
-        self._ledger_id = kwargs.pop('ledger_id') if 'ledger_id' in kwargs.keys() else DEFAULT_LEDGER_ID
-        self._date_one = kwargs.pop('date_one') if 'date_one' in kwargs.keys() else DEFAULT_DATE_ONE
-        self._date_two = kwargs.pop('date_two') if 'date_two' in kwargs.keys() else DEFAULT_DATE_TWO
+        self.runner = CliRunner()
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.price_per_row",
+                                 DEFAULT_PRICE_PER_ROW], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.seller_tx_fee",
+                                 DEFAULT_SELLER_TX_FEE], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.currency_id",
+                                 DEFAULT_CURRENCY_PBK], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.ledger_id",
+                                 DEFAULT_LEDGER_ID], standalone_mode=False)
+
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.date_one",
+                                 DEFAULT_DATE_ONE], standalone_mode=False)
+        self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
+                                 "skills.weather_station.shared_classes.strategy.args.date_two",
+                                 DEFAULT_DATE_TWO], standalone_mode=False)
         super().__init__(**kwargs)
         self.db = DBCommunication()
         self._oef_msg_id = 0

--- a/packages/skills/weather_station_ledger/strategy.py
+++ b/packages/skills/weather_station_ledger/strategy.py
@@ -44,6 +44,7 @@ DEFAULT_DATE_TWO = "15/10/2019"
 
 CLI_LOG_OPTION = ["-v", "OFF"]
 
+
 class Strategy(SharedClass):
     """This class defines a strategy for the agent."""
 
@@ -59,26 +60,26 @@ class Strategy(SharedClass):
         self.runner = CliRunner()
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.price_per_row",
+                                 "skills.weather_station_ledger.shared_classes.strategy.args.price_per_row",
                                  DEFAULT_PRICE_PER_ROW], standalone_mode=False)
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.seller_tx_fee",
+                                 "skills.weather_station_ledger.shared_classes.strategy.args.seller_tx_fee",
                                  DEFAULT_SELLER_TX_FEE], standalone_mode=False)
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.currency_id",
+                                 "skills.weather_station_ledger.shared_classes.strategy.args.currency_id",
                                  DEFAULT_CURRENCY_PBK], standalone_mode=False)
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.ledger_id",
+                                 "skills.weather_station_ledger.shared_classes.strategy.args.ledger_id",
                                  DEFAULT_LEDGER_ID], standalone_mode=False)
 
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.date_one",
+                                 "skills.weather_station_ledger.shared_classes.strategy.args.date_one",
                                  DEFAULT_DATE_ONE], standalone_mode=False)
         self.runner.invoke(cli, [*CLI_LOG_OPTION, "config", "set",
-                                 "skills.weather_station.shared_classes.strategy.args.date_two",
+                                 "skills.weather_station_ledger.shared_classes.strategy.args.date_two",
                                  DEFAULT_DATE_TWO], standalone_mode=False)
         super().__init__(**kwargs)
         self.db = DBCommunication()
@@ -119,15 +120,15 @@ class Strategy(SharedClass):
         :param query: the query
         :return: a tuple of proposal and the weather data
         """
-        fetched_data = self.db.get_data_for_specific_dates(self._date_one, self._date_two)  # TODO: fetch real data
+        fetched_data = self.db.get_data_for_specific_dates(DEFAULT_DATE_ONE, DEFAULT_DATE_TWO)  # TODO: fetch real data
         weather_data, rows = self._build_data_payload(fetched_data)
-        total_price = self._price_per_row * rows
-        assert total_price - self._seller_tx_fee > 0, "This sale would generate a loss, change the configs!"
+        total_price = DEFAULT_PRICE_PER_ROW * rows
+        assert total_price - DEFAULT_SELLER_TX_FEE > 0, "This sale would generate a loss, change the configs!"
         proposal = Description({"rows": rows,
                                 "price": total_price,
-                                "seller_tx_fee": self._seller_tx_fee,
-                                "currency_id": self._currency_id,
-                                "ledger_id": self._ledger_id})
+                                "seller_tx_fee": DEFAULT_SELLER_TX_FEE,
+                                "currency_id": DEFAULT_CURRENCY_PBK,
+                                "ledger_id": DEFAULT_LEDGER_ID})
         return (proposal, weather_data)
 
     def _build_data_payload(self, fetched_data: Dict[str, int]) -> Tuple[Dict[str, List[Dict[str, Any]]], int]:

--- a/tests/test_gui/test_search.py
+++ b/tests/test_gui/test_search.py
@@ -154,4 +154,3 @@ def test_real_search():
     i += 1
     assert data[i]['id'] == 'tcp'
     assert data[i]['description'] == ''
-


### PR DESCRIPTION
## Proposed changes

Demonstrate a way to use `aea config set [path]` to set a batch of variables to the .yaml file to be used for the strategy of the agent.

## Fixes

fixes: #512

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules