### PR TITLE
let 'aea remove' to remove by public id.

### DIFF
--- a/aea/cli/remove.py
+++ b/aea/cli/remove.py
@@ -75,7 +75,11 @@ def _remove_item(ctx: Context, item_type, item_name):
 @click.argument('connection_name', type=str, required=True)
 @pass_ctx
 def connection(ctx: Context, connection_name):
-    """Remove a connection from the agent."""
+    """
+    Remove a connection from the agent.
+
+    It expects the name or public id of the connection to remove from the local registry.
+    """
     _remove_item(ctx, "connection", connection_name)
 
 
@@ -83,7 +87,11 @@ def connection(ctx: Context, connection_name):
 @click.argument('protocol_name', type=str, required=True)
 @pass_ctx
 def protocol(ctx: Context, protocol_name):
-    """Remove a protocol from the agent."""
+    """
+    Remove a protocol from the agent.
+
+    It expects the name or public id of the protocol to remove from the local registry.
+    """
     _remove_item(ctx, "protocol", protocol_name)
 
 
@@ -91,5 +99,9 @@ def protocol(ctx: Context, protocol_name):
 @click.argument('skill_name', type=str, required=True)
 @pass_ctx
 def skill(ctx: Context, skill_name):
-    """Remove a skill from the agent."""
+    """
+    Remove a skill from the agent.
+
+    It expects the name or public id of the skill to remove from the local registry.
+    """
     _remove_item(ctx, "skill", skill_name)

--- a/aea/cli/remove.py
+++ b/aea/cli/remove.py
@@ -26,7 +26,7 @@ import sys
 import click
 
 from aea.cli.common import Context, pass_ctx, logger, _try_to_load_agent_config
-from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE
+from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, PublicId
 
 
 @click.group()
@@ -38,16 +38,23 @@ def remove(ctx: Context):
 
 def _remove_item(ctx: Context, item_type, item_name):
     """Remove an item from the configuration file and agent."""
+    # try to parse the item_name as public id
+    try:
+        item_id = PublicId.from_string(item_name)
+        item_name = item_id.name
+    except ValueError:
+        item_id = item_name
+
     item_type_plural = "{}s".format(item_type)
     existing_item_ids = getattr(ctx.agent_config, item_type_plural)
     existing_items_name_to_ids = {public_id.name: public_id for public_id in existing_item_ids}
 
     agent_name = ctx.agent_config.agent_name
-    logger.info("Removing {item_type} '{item_name}' from the agent '{agent_name}'..."
-                .format(agent_name=agent_name, item_type=item_type, item_name=item_name))
+    logger.info("Removing {item_type} '{item_id}' from the agent '{agent_name}'..."
+                .format(agent_name=agent_name, item_type=item_type, item_id=item_id))
 
-    if item_name not in existing_items_name_to_ids.keys():
-        logger.error("The {} '{}' is not supported.".format(item_type, item_name))
+    if item_id not in existing_items_name_to_ids.keys() and item_id not in existing_item_ids:
+        logger.error("The {} '{}' is not supported.".format(item_type, item_id))
         sys.exit(1)
 
     item_folder = os.path.join(item_type_plural, item_name)

--- a/aea/cli/remove.py
+++ b/aea/cli/remove.py
@@ -36,22 +36,27 @@ def remove(ctx: Context):
     _try_to_load_agent_config(ctx)
 
 
-def _remove_item(ctx: Context, item_type, item_name):
-    """Remove an item from the configuration file and agent."""
-    # try to parse the item_name as public id
+def _remove_item(ctx: Context, item_type, item):
+    """
+    Remove an item from the configuration file and agent.
+
+    The parameter 'item' can be either the public id (e.g. 'fetchai/default:0.1.0') or
+    the name of the package (e.g. 'default').
+    """
     try:
-        item_id = PublicId.from_string(item_name)
+        item_id = PublicId.from_string(item)
         item_name = item_id.name
     except ValueError:
-        item_id = item_name
+        item_id = item
+        item_name = item
 
     item_type_plural = "{}s".format(item_type)
     existing_item_ids = getattr(ctx.agent_config, item_type_plural)
     existing_items_name_to_ids = {public_id.name: public_id for public_id in existing_item_ids}
 
     agent_name = ctx.agent_config.agent_name
-    logger.info("Removing {item_type} '{item_id}' from the agent '{agent_name}'..."
-                .format(agent_name=agent_name, item_type=item_type, item_id=item_id))
+    logger.info("Removing {item_type} '{item_name}' from the agent '{agent_name}'..."
+                .format(agent_name=agent_name, item_type=item_type, item_name=item_name))
 
     if item_id not in existing_items_name_to_ids.keys() and item_id not in existing_item_ids:
         logger.error("The {} '{}' is not supported.".format(item_type, item_id))

--- a/tests/test_cli/test_remove/test_connection.py
+++ b/tests/test_cli/test_remove/test_connection.py
@@ -71,7 +71,55 @@ class TestRemoveConnection:
     def test_connection_not_present_in_agent_config(self):
         """Test that the name of the removed connection is not present in the agent configuration file."""
         agent_config = aea.configurations.base.AgentConfig.from_json(yaml.safe_load(open(DEFAULT_AEA_CONFIG_FILE)))
-        assert self.connection_name not in agent_config.connections
+        assert self.connection_id not in agent_config.connections
+
+    @classmethod
+    def teardown_class(cls):
+        """Tear the test down."""
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass
+
+
+class TestRemoveConnectionWithPublicId:
+    """Test that the command 'aea remove connection' works correctly when using the public id."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        cls.runner = CliRunner()
+        cls.agent_name = "myagent"
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        # copy the 'packages' directory in the parent of the agent folder.
+        shutil.copytree(Path(CUR_PATH, "..", "packages"), Path(cls.t, "packages"))
+        cls.connection_id = "fetchai/local:0.1.0"
+        cls.connection_name = "local"
+        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
+        cls.mocked_logger_error = cls.patch.__enter__()
+
+        os.chdir(cls.t)
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name], standalone_mode=False)
+        assert result.exit_code == 0
+        os.chdir(cls.agent_name)
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", cls.connection_id], standalone_mode=False)
+        assert result.exit_code == 0
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "remove", "connection", cls.connection_id], standalone_mode=False)
+
+    def test_exit_code_equal_to_zero(self):
+        """Test that the exit code is equal to 1 (i.e. catchall for general errors)."""
+        assert self.result.exit_code == 0
+
+    def test_directory_does_not_exist(self):
+        """Test that the directory of the removed connection does not exist."""
+        assert not Path("connections", self.connection_name).exists()
+
+    def test_connection_not_present_in_agent_config(self):
+        """Test that the name of the removed connection is not present in the agent configuration file."""
+        agent_config = aea.configurations.base.AgentConfig.from_json(yaml.safe_load(open(DEFAULT_AEA_CONFIG_FILE)))
+        assert self.connection_id not in agent_config.connections
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_cli/test_remove/test_skill.py
+++ b/tests/test_cli/test_remove/test_skill.py
@@ -75,7 +75,59 @@ class TestRemoveSkill:
     def test_skill_not_present_in_agent_config(self):
         """Test that the name of the removed skill is not present in the agent configuration file."""
         agent_config = aea.configurations.base.AgentConfig.from_json(yaml.safe_load(open(DEFAULT_AEA_CONFIG_FILE)))
-        assert self.skill_name not in agent_config.skills
+        assert self.skill_id not in agent_config.skills
+
+    @classmethod
+    def teardown_class(cls):
+        """Tear the test down."""
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass
+
+
+class TestRemoveSkillWithPublicId:
+    """Test that the command 'aea remove skill' works correctly when using the public id."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        cls.runner = CliRunner()
+        cls.agent_name = "myagent"
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        cls.skill_id = "fetchai/gym:0.1.0"
+        cls.skill_name = "gym"
+        cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
+        cls.mocked_logger_error = cls.patch.__enter__()
+
+        os.chdir(cls.t)
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "create", cls.agent_name], standalone_mode=False)
+        assert result.exit_code == 0
+        os.chdir(cls.agent_name)
+
+        # change default registry path
+        config = AgentConfig.from_json(yaml.safe_load(open(DEFAULT_AEA_CONFIG_FILE)))
+        config.registry_path = os.path.join(ROOT_DIR, "packages")
+        yaml.safe_dump(config.json, open(DEFAULT_AEA_CONFIG_FILE, "w"))
+
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", cls.skill_id], standalone_mode=False)
+        assert result.exit_code == 0
+        cls.result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "remove", "skill", cls.skill_id], standalone_mode=False)
+
+    def test_exit_code_equal_to_zero(self):
+        """Test that the exit code is equal to 1 (i.e. catchall for general errors)."""
+        assert self.result.exit_code == 0
+
+    def test_directory_does_not_exist(self):
+        """Test that the directory of the removed skill does not exist."""
+        assert not Path("skills", self.skill_name).exists()
+
+    def test_skill_not_present_in_agent_config(self):
+        """Test that the name of the removed skill is not present in the agent configuration file."""
+        agent_config = aea.configurations.base.AgentConfig.from_json(yaml.safe_load(open(DEFAULT_AEA_CONFIG_FILE)))
+        assert self.skill_id not in agent_config.skills
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
## Proposed changes

Now it is possible to remove packages from their public id.

```
aea remove skill error
aea remove skill fetchai/error:0.1.0  # this now works.
```

The CLI will try to parse the provided package name as if it were a public id. If it fails, it will remove the package with the same name.

## Fixes

Fixes part of #564 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
