### PR TITLE
Change import path for agent components.

### DIFF
--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -19,7 +19,6 @@
 
 """Implementation of the common utils of the aea cli."""
 
-import importlib.util
 import logging
 import logging.config
 import os
@@ -36,6 +35,7 @@ from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig, SkillC
     DEFAULT_PROTOCOL_CONFIG_FILE, DEFAULT_CONNECTION_CONFIG_FILE, DEFAULT_SKILL_CONFIG_FILE, Dependencies, PublicId
 from aea.configurations.loader import ConfigLoader
 from aea.crypto.fetchai import FETCHAI
+from aea.helpers.base import load_module, add_agent_component_module_to_sys_modules
 
 logger = logging.getLogger("aea")
 logger = default_logging_config(logger)
@@ -126,10 +126,8 @@ def _try_to_load_protocols(ctx: Context):
             sys.exit(1)
 
         try:
-            protocol_spec = importlib.util.spec_from_file_location(protocol_name, os.path.join("protocols", protocol_name, "__init__.py"))
-            protocol_module = importlib.util.module_from_spec(protocol_spec)
-            protocol_spec.loader.exec_module(protocol_module)  # type: ignore
-            sys.modules[protocol_spec.name + "_protocol"] = protocol_module
+            protocol_package = load_module(protocol_name, Path("protocols", protocol_name, "__init__.py"))
+            add_agent_component_module_to_sys_modules("protocol", protocol_name, protocol_package)
         except Exception:
             logger.error("A problem occurred while processing protocol {}.".format(protocol_public_id))
             sys.exit(1)

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -33,7 +33,7 @@ from aea.aea import AEA
 from aea.cli.common import Context, logger, _try_to_load_agent_config, _try_to_load_protocols, \
     AEAConfigException, _load_env_file, ConnectionsOption
 from aea.cli.install import install
-from aea.configurations.base import AgentConfig, DEFAULT_AEA_CONFIG_FILE, PrivateKeyPathConfig, LedgerAPIConfig, \
+from aea.configurations.base import AgentConfig, DEFAULT_AEA_CONFIG_FILE, PrivateKeyPathConfig, \
     PublicId
 from aea.configurations.loader import ConfigLoader
 from aea.connections.base import Connection
@@ -124,17 +124,14 @@ def _verify_ledger_apis_access() -> None:
     if fetchai_ledger_api_config is None:
         logger.debug("No fetchai ledger api config specified.")
     else:
-        fetchai_ledger_api_config = cast(LedgerAPIConfig, fetchai_ledger_api_config)
-        _try_to_instantiate_fetchai_ledger_api(cast(str, fetchai_ledger_api_config.args.get('address')),
-                                               cast(int, fetchai_ledger_api_config.args.get('port')))
+        _try_to_instantiate_fetchai_ledger_api(cast(str, fetchai_ledger_api_config.get('addr')),
+                                               cast(int, fetchai_ledger_api_config.get('port')))
 
     ethereum_ledger_config = aea_conf.ledger_apis.read(ETHEREUM)
     if ethereum_ledger_config is None:
         logger.debug("No ethereum ledger api config specified.")
     else:
-        ethereum_ledger_config = cast(LedgerAPIConfig, ethereum_ledger_config)
-        _try_to_instantiate_ethereum_ledger_api(cast(str, ethereum_ledger_config.args.get('address')),
-                                                cast(int, ethereum_ledger_config.args.get('chain_id')))
+        _try_to_instantiate_ethereum_ledger_api(cast(str, ethereum_ledger_config.get('addr')))
 
 
 def _setup_connection(connection_name: str, address: str, ctx: Context) -> Connection:
@@ -196,7 +193,7 @@ def run(click_context, connection_names: List[str], env_file: str, install_deps:
     _verify_or_create_private_keys(ctx)
     _verify_ledger_apis_access()
     private_key_paths = dict([(identifier, config.path) for identifier, config in ctx.agent_config.private_key_paths.read_all()])
-    ledger_api_configs = dict([(identifier, cast(List[Union[str, int]], list(config.args.values()))) for identifier, config in ctx.agent_config.ledger_apis.read_all()])
+    ledger_api_configs = dict([(identifier, cast(List[Union[str, int]], list(config.values()))) for identifier, config in ctx.agent_config.ledger_apis.read_all()])
 
     wallet = Wallet(private_key_paths)
     ledger_apis = LedgerApis(ledger_api_configs, ctx.agent_config.default_ledger)

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -18,7 +18,6 @@
 # ------------------------------------------------------------------------------
 
 """Implementation of the 'aea run' subcommand."""
-import importlib.util
 import inspect
 import os
 import re
@@ -45,6 +44,7 @@ from aea.crypto.helpers import _create_default_private_key, _create_fetchai_priv
 from aea.crypto.ledger_apis import LedgerApis, _try_to_instantiate_fetchai_ledger_api, \
     _try_to_instantiate_ethereum_ledger_api, SUPPORTED_LEDGER_APIS
 from aea.crypto.wallet import Wallet, DEFAULT, SUPPORTED_CRYPTOS
+from aea.helpers.base import load_module, add_agent_component_module_to_sys_modules
 from aea.registries.base import Resources
 
 
@@ -155,13 +155,11 @@ def _setup_connection(connection_name: str, address: str, ctx: Context) -> Conne
         raise AEAConfigException("Connection config for '{}' not found.".format(connection_name))
 
     try:
-        connection_spec = importlib.util.spec_from_file_location(connection_config.name, os.path.join(ctx.cwd, "connections", connection_config.name, "connection.py"))
-        connection_module = importlib.util.module_from_spec(connection_spec)
-        connection_spec.loader.exec_module(connection_module)  # type: ignore
+        connection_module = load_module(connection_name, Path("connections", connection_name, "connection.py"))
+        add_agent_component_module_to_sys_modules("connection", connection_name, connection_module)
     except FileNotFoundError:
         raise AEAConfigException("Connection '{}' not found.".format(connection_name))
 
-    sys.modules[connection_spec.name + "_connection"] = connection_module
     classes = inspect.getmembers(connection_module, inspect.isclass)
     connection_classes = list(filter(lambda x: re.match("\\w+Connection", x[0]), classes))
     name_to_class = dict(connection_classes)

--- a/aea/configurations/loader.py
+++ b/aea/configurations/loader.py
@@ -74,7 +74,10 @@ class ConfigLoader(Generic[T]):
         :raises
         """
         configuration_file_json = yaml.safe_load(fp)
-        self.validator.validate(instance=configuration_file_json)
+        try:
+            self.validator.validate(instance=configuration_file_json)
+        except Exception:
+            raise
         return self.configuration_type.from_json(configuration_file_json)
 
     def dump(self, configuration: T, fp: TextIO) -> None:

--- a/aea/configurations/schemas/aea-config_schema.json
+++ b/aea/configurations/schemas/aea-config_schema.json
@@ -63,7 +63,7 @@
       "uniqueItems": true,
       "patternProperties": {
         "^[^\\d\\W]\\w*\\Z": {
-          "$ref": "#/definitions/ledger_api"
+          "$ref": "definitions.json#/definitions/ledger_api"
         }
       }
     },
@@ -99,37 +99,6 @@
     },
     "description": {
       "type": "string"
-    }
-  },
-  "definitions": {
-    "private_key_path": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "ledger",
-        "path"
-      ],
-      "properties": {
-        "ledger": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        }
-      }
-    },
-    "ledger_api": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "args": {
-          "type": "object"
-        }
-      }
-    },
-    "resource_name": {
-      "type": "string",
-      "pattern": "[a-zA-Z_][a-zA-Z0-9_]*"
     }
   }
 }

--- a/aea/configurations/schemas/definitions.json
+++ b/aea/configurations/schemas/definitions.json
@@ -53,24 +53,7 @@
       }
     },
     "ledger_api": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "ledger",
-        "addr",
-        "port"
-      ],
-      "properties": {
-        "ledger": {
-          "type": "string"
-        },
-        "addr": {
-          "type": "string"
-        },
-        "port": {
-          "type": "number"
-        }
-      }
+      "type": "object"
     },
     "author": {
       "type": "string",

--- a/aea/crypto/base.py
+++ b/aea/crypto/base.py
@@ -20,7 +20,9 @@
 
 """Abstract module wrapping the public and private key cryptography and ledger api."""
 from abc import ABC, abstractmethod
-from typing import Any, BinaryIO
+from typing import Any, BinaryIO, Union, Optional
+
+AddressLike = Union[str, bytes]
 
 
 class Crypto(ABC):
@@ -82,4 +84,60 @@ class Crypto(ABC):
 
         :param fp: the output file pointer. Must be set in binary mode (mode='wb')
         :return: None
+        """
+
+
+class LedgerApi(ABC):
+    """Interface for ledger APIs."""
+
+    identifier = "base"  # type: str
+
+    @property
+    @abstractmethod
+    def api(self) -> Optional[Any]:
+        """
+        Get the underlying API object.
+
+        This can be used for low-level operations with the concrete ledger APIs.
+        If there is no such object, return None.
+        """
+
+    @abstractmethod
+    def get_balance(self, address: AddressLike) -> int:
+        """
+        Get the balance of a given account.
+
+        This usually takes the form of a web request to be waited synchronously.
+
+        :param address: the address.
+        :return: the balance.
+        """
+
+    @abstractmethod
+    def send_transaction(self,
+                         crypto: Crypto,
+                         destination_address: AddressLike,
+                         amount: int,
+                         tx_fee: int,
+                         **kwargs) -> Optional[str]:
+        """
+        Submit a transaction to the ledger.
+
+        If the mandatory arguments are not enough for specifying a transaction
+        in the concrete ledger API, use keyword arguments for the additional parameters.
+
+        :param crypto: the crypto object associated to the payer.
+        :param destination_address: the destination address of the payee.
+        :param amount: the amount of wealth to be transferred.
+        :param tx_fee: the transaction fee.
+        :return: tx digest if successful, otherwise None
+        """
+
+    @abstractmethod
+    def is_transaction_settled(self, tx_digest: str) -> bool:
+        """
+        Check whether a transaction is settled or not.
+
+        :param tx_digest: the digest associated to the transaction.
+        :return: True if the transaction has been settled, False o/w.
         """

--- a/aea/crypto/ethereum.py
+++ b/aea/crypto/ethereum.py
@@ -50,7 +50,7 @@ class EthereumCrypto(Crypto):
         :param private_key_path: the private key path of the agent
         """
         self._account = self._generate_private_key() if private_key_path is None else self._load_private_key_from_path(private_key_path)
-        bytes_representation = Web3.toBytes(hexstr=self._account.privateKey.hex())
+        bytes_representation = Web3.toBytes(hexstr=self._account.key.hex())
         self._public_key = keys.PrivateKey(bytes_representation).public_key
 
     @property
@@ -148,7 +148,7 @@ class EthereumCrypto(Crypto):
         :param fp: the output file pointer. Must be set in binary mode (mode='wb')
         :return: None
         """
-        fp.write(self._account.privateKey.hex().encode("utf-8"))
+        fp.write(self._account.key.hex().encode("utf-8"))
 
 
 class EthereumApi(LedgerApi):
@@ -200,7 +200,7 @@ class EthereumApi(LedgerApi):
             'gas': tx_fee,
             'gasPrice': self._api.toWei(GAS_PRICE, GAS_ID)
         }
-        signed = self._api.eth.account.signTransaction(transaction, crypto.entity.privateKey)
+        signed = self._api.eth.account.signTransaction(transaction, crypto.entity.key)
         hex_value = self._api.eth.sendRawTransaction(signed.rawTransaction)
         logger.info("TX Hash: {}".format(str(hex_value.hex())))
         while True:

--- a/aea/crypto/ethereum.py
+++ b/aea/crypto/ethereum.py
@@ -19,19 +19,23 @@
 # ------------------------------------------------------------------------------
 
 """Ethereum module wrapping the public and private key cryptography and ledger api."""
+import time
 
-from web3 import Web3
+import web3
+from web3 import Web3, HTTPProvider
 from eth_account import Account
 from eth_keys import keys
 import logging
 from pathlib import Path
 from typing import Optional, BinaryIO
 
-from aea.crypto.base import Crypto
+from aea.crypto.base import Crypto, LedgerApi, AddressLike
 
 logger = logging.getLogger(__name__)
 
 ETHEREUM = "ethereum"
+GAS_PRICE = '50'
+GAS_ID = 'gwei'
 
 
 class EthereumCrypto(Crypto):
@@ -145,3 +149,75 @@ class EthereumCrypto(Crypto):
         :return: None
         """
         fp.write(self._account.privateKey.hex().encode("utf-8"))
+
+
+class EthereumApi(LedgerApi):
+    """Class to interact with the Ethereum Web3 APIs."""
+
+    identifier = ETHEREUM
+
+    def __init__(self, address: str):
+        """
+        Initialize the Ethereum ledger APIs.
+
+        :param address: the endpoint for Web3 APIs.
+        """
+        self._api = Web3(HTTPProvider(endpoint_uri=address))
+
+    @property
+    def api(self) -> Web3:
+        """Get the underlying API object."""
+        return self._api
+
+    def get_balance(self, address: AddressLike) -> int:
+        """Get the balance of a given account."""
+        return self._api.eth.getBalance(address)
+
+    def send_transaction(self,
+                         crypto: Crypto,
+                         destination_address: AddressLike,
+                         amount: int,
+                         tx_fee: int,
+                         chain_id: int = 1,
+                         **kwargs) -> Optional[str]:
+        """
+        Submit a transaction to the ledger.
+
+        :param crypto: the crypto object associated to the payer.
+        :param destination_address: the destination address of the payee.
+        :param amount: the amount of wealth to be transferred.
+        :param tx_fee: the transaction fee.
+        :param chain_id: the Chain ID of the Ethereum transaction. Default is 1 (i.e. mainnet).
+        :return: the transaction digest, or None if not available.
+        """
+        nonce = self._api.eth.getTransactionCount(self._api.toChecksumAddress(crypto.address))
+        # TODO : handle misconfiguration
+        transaction = {
+            'nonce': nonce,
+            'chainId': chain_id,
+            'to': destination_address,
+            'value': amount,
+            'gas': tx_fee,
+            'gasPrice': self._api.toWei(GAS_PRICE, GAS_ID)
+        }
+        signed = self._api.eth.account.signTransaction(transaction, crypto.entity.privateKey)
+        hex_value = self._api.eth.sendRawTransaction(signed.rawTransaction)
+        logger.info("TX Hash: {}".format(str(hex_value.hex())))
+        while True:
+            try:
+                self._api.eth.getTransactionReceipt(hex_value)
+                logger.info("transaction validated - exiting")
+                tx_digest = hex_value.hex()
+                break
+            except web3.exceptions.TransactionNotFound:  # pragma: no cover
+                logger.info("transaction not found - sleeping for 3.0 seconds")
+                time.sleep(3.0)
+        return tx_digest
+
+    def is_transaction_settled(self, tx_digest: str) -> bool:
+        """Check whether a transaction is settled or not."""
+        tx_status = self._api.eth.getTransactionReceipt(tx_digest)
+        is_successful = False
+        if tx_status is not None:
+            is_successful = True
+        return is_successful

--- a/aea/crypto/helpers.py
+++ b/aea/crypto/helpers.py
@@ -132,4 +132,4 @@ def _create_ethereum_private_key() -> None:
     """
     account = Account.create()
     with open(ETHEREUM_PRIVATE_KEY_FILE, "w+") as file:
-        file.write(account.privateKey.hex())
+        file.write(account.key.hex())

--- a/aea/crypto/ledger_apis.py
+++ b/aea/crypto/ledger_apis.py
@@ -22,20 +22,12 @@
 
 import logging
 import sys
-import time
-from typing import Any, Dict, Optional, cast, List, Union
+from typing import Dict, Optional, List, Union, cast
 
-import web3
-import web3.exceptions
-from fetchai.ledger.api import LedgerApi as FetchLedgerApi
-# from fetchai.ledger.api.tx import TxStatus
-from web3 import Web3, HTTPProvider
+from aea.crypto.base import Crypto, LedgerApi
+from aea.crypto.ethereum import ETHEREUM, EthereumApi
+from aea.crypto.fetchai import FETCHAI, FetchAIApi
 
-from aea.crypto.base import Crypto
-from aea.crypto.ethereum import ETHEREUM
-from aea.crypto.fetchai import FETCHAI
-
-DEFAULT_FETCHAI_CONFIG = ('alpha.fetch-ai.com', 80)
 SUCCESSFUL_TERMINAL_STATES = ('Executed', 'Submitted')
 SUPPORTED_LEDGER_APIS = [ETHEREUM, FETCHAI]
 SUPPORTED_CURRENCIES = {ETHEREUM: 'ETH', FETCHAI: 'FET'}
@@ -56,20 +48,23 @@ class LedgerApis(object):
         """
         Instantiate a wallet object.
 
-        :param ledger_api_configs: the ledger api configs
-        :param default_ledger: the default ledger
+        :param ledger_api_configs: the ledger api configs.
+        :param default_ledger_id: the default ledger id.
         """
-        apis = {}  # type: Dict[str, Any]
+        apis = {}  # type: Dict[str, LedgerApi]
         configs = {}  # type: Dict[str, List[Union[str, int]]]
         self._last_tx_statuses = {}  # type: Dict[str, str]
         for identifier, config in ledger_api_configs.items():
             self._last_tx_statuses[identifier] = UNKNOWN
             if identifier == FETCHAI:
-                api = FetchLedgerApi(config[0], config[1])
+                addr = cast(str, config[0])
+                port = cast(int, config[1])
+                api = FetchAIApi(addr, port)  # type: LedgerApi
                 apis[identifier] = api
                 configs[identifier] = config
             elif identifier == ETHEREUM:
-                api = Web3(HTTPProvider(config[0]))
+                address = cast(str, config[0])
+                api = EthereumApi(address)
                 apis[identifier] = api
                 configs[identifier] = config
             else:
@@ -85,7 +80,7 @@ class LedgerApis(object):
         return self._configs
 
     @property
-    def apis(self) -> Dict[str, Any]:
+    def apis(self) -> Dict[str, LedgerApi]:
         """Get the apis."""
         return self._apis
 
@@ -124,27 +119,17 @@ class LedgerApis(object):
         """
         assert identifier in self.apis.keys(), "Unsupported ledger identifier."
         api = self.apis[identifier]
-        if identifier == FETCHAI:
-            try:
-                balance = api.tokens.balance(address)
-                self._last_tx_statuses[identifier] = OK
-            except Exception:
-                logger.warning("An error occurred while attempting to get the current balance.")
-                balance = 0
-                self._last_tx_statuses[identifier] = ERROR
-        elif identifier == ETHEREUM:
-            try:
-                balance = api.eth.getBalance(address)
-                self._last_tx_statuses[identifier] = OK
-            except Exception:
-                logger.warning("An error occurred while attempting to get the current balance.")
-                balance = 0
-                self._last_tx_statuses[identifier] = ERROR
-        else:       # pragma: no cover
-            raise Exception("Ledger id is not known")
+        try:
+            balance = api.get_balance(address)
+            self._last_tx_statuses[identifier] = OK
+        except Exception:
+            logger.warning("An error occurred while attempting to get the current balance.")
+            self._last_tx_statuses[identifier] = ERROR
+            # TODO raise exception instead of returning zero.
+            balance = 0
         return balance
 
-    def transfer(self, crypto_object: Crypto, destination_address: str, amount: int, tx_fee: int) -> Optional[str]:
+    def transfer(self, crypto_object: Crypto, destination_address: str, amount: int, tx_fee: int, **kwargs) -> Optional[str]:
         """
         Transfer from self to destination.
 
@@ -158,53 +143,17 @@ class LedgerApis(object):
         assert crypto_object.identifier in self.apis.keys(), "Unsupported ledger identifier."
         api = self.apis[crypto_object.identifier]
         logger.info("Waiting for the validation of the transaction ...")
-        if crypto_object.identifier == FETCHAI:
-            try:
-                tx_digest = api.tokens.transfer(crypto_object.entity, destination_address, amount, tx_fee)
-                api.sync(tx_digest)
-                logger.info("Transaction validated ...")
-                self._last_tx_statuses[crypto_object.identifier] = OK
-            except Exception:
-                logger.warning("An error occurred while attempting the transfer.")
-                tx_digest = None
-                self._last_tx_statuses[crypto_object.identifier] = ERROR
-        elif crypto_object.identifier == ETHEREUM:
-            try:
-                nonce = api.eth.getTransactionCount(api.toChecksumAddress(crypto_object.address))
-                # TODO : handle misconfiguration
-                chain_id = self.configs.get(crypto_object.identifier)[1]  # type: ignore
-                transaction = {
-                    'nonce': nonce,
-                    'chainId': chain_id,
-                    'to': destination_address,
-                    'value': amount,
-                    'gas': tx_fee,
-                    'gasPrice': api.toWei(GAS_PRICE, GAS_ID)
-                }
-                signed = api.eth.account.signTransaction(transaction, crypto_object.entity.privateKey)
-                hex_value = api.eth.sendRawTransaction(signed.rawTransaction)
-                logger.info("TX Hash: {}".format(str(hex_value.hex())))
-                while True:
-                    try:
-                        api.eth.getTransactionReceipt(hex_value)
-                        logger.info("transaction validated - exiting")
-                        tx_digest = hex_value.hex()
-                        self._last_tx_statuses[crypto_object.identifier] = OK
-                        break
-                    except web3.exceptions.TransactionNotFound:     # pragma: no cover
-                        logger.info("transaction not found - sleeping for 3.0 seconds")
-                        self._last_tx_statuses[crypto_object.identifier] = ERROR
-                        time.sleep(3.0)
-                return tx_digest
-            except Exception:
-                logger.warning("An error occurred while attempting the transfer.")
-                tx_digest = None
-                self._last_tx_statuses[crypto_object.identifier] = ERROR
-        else:  # pragma: no cover
-            raise Exception("Ledger id is not known")
+        try:
+            tx_digest = api.send_transaction(crypto_object, destination_address, amount, tx_fee, **kwargs)
+            logger.info("transaction validated. TX digest: {}".format(tx_digest))
+            self._last_tx_statuses[crypto_object.identifier] = OK
+        except Exception:
+            logger.warning("An error occurred while attempting the transfer.")
+            tx_digest = None
+            self._last_tx_statuses[crypto_object.identifier] = ERROR
         return tx_digest
 
-    def is_tx_settled(self, identifier: str, tx_digest: str, amount: int) -> bool:
+    def is_tx_settled(self, identifier: str, tx_digest: str) -> bool:
         """
         Check whether the transaction is settled and correct.
 
@@ -213,36 +162,14 @@ class LedgerApis(object):
         :return: True if correctly settled, False otherwise
         """
         assert identifier in self.apis.keys(), "Unsupported ledger identifier."
-        is_successful = False
         api = self.apis[identifier]
-        if identifier == FETCHAI:
-            try:
-                logger.info("Checking the transaction ...")
-                # tx_status = cast(TxStatus, api.tx.status(tx_digest))
-                tx_status = cast(str, api.tx.status(tx_digest))
-                # if tx_status.successful:
-                if tx_status in SUCCESSFUL_TERMINAL_STATES:
-                    # tx_contents = cast(TxContents, api.tx.contents(tx_digest))
-                    # tx_contents.transfers_to()
-                    # TODO: check the amount of the transaction is correct
-                    is_successful = True
-                logger.info("Transaction validated ...")
-                self._last_tx_statuses[identifier] = OK
-            except Exception:
-                logger.warning("An error occurred while attempting to check the transaction.")
-                self._last_tx_statuses[identifier] = ERROR
-        elif identifier == ETHEREUM:
-            try:
-                logger.info("Checking the transaction ...")
-                tx_status = api.eth.getTransactionReceipt(tx_digest)
-                if tx_status is not None:
-                    is_successful = True
-                logger.info("Transaction validated ...")
-                self._last_tx_statuses[identifier] = OK
-            except Exception:
-                logger.warning("An error occured while attempting to check the transaction!")
-                self._last_tx_statuses[identifier] = ERROR
-
+        try:
+            is_successful = api.is_transaction_settled(tx_digest)
+            self._last_tx_statuses[identifier] = OK
+        except Exception:
+            logger.warning("An error occured while attempting to check the transaction!")
+            is_successful = False
+            self._last_tx_statuses[identifier] = ERROR
         return is_successful
 
 
@@ -261,12 +188,11 @@ def _try_to_instantiate_fetchai_ledger_api(addr: str, port: int) -> None:
         sys.exit(1)
 
 
-def _try_to_instantiate_ethereum_ledger_api(addr: str, chain_id: int) -> None:
+def _try_to_instantiate_ethereum_ledger_api(addr: str) -> None:
     """
     Try to instantiate the ethereum ledger api.
 
     :param addr: the address
-    :param chain_id: the id for the chain.
     """
     try:
         from web3 import Web3, HTTPProvider

--- a/aea/helpers/base.py
+++ b/aea/helpers/base.py
@@ -20,11 +20,11 @@
 """Miscellaneous helpers."""
 
 import builtins
-from typing import Optional
-
 import importlib.util
 import logging
 import os
+import sys
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +70,29 @@ def locate(path):
         except AttributeError:
             return None
     return object
+
+
+def load_module(name: str, filepath: os.PathLike):
+    """
+    Load a module.
+
+    :param name: the name of the package/module.
+    :param filepath: the file to the package/module.
+    :return: None
+    :raises ValueError: if the filepath provided is not a module.
+    :raises Exception: if the execution of the module raises exception.
+    """
+    spec = importlib.util.spec_from_file_location(name, filepath)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+
+def add_agent_component_module_to_sys_modules(item_type: str, item_name: str, module_obj):
+    """Add an agent component module to sys.modules."""
+    item_type_plural = item_type + "s"
+    dotted_path = "packages.{}.{}".format(item_type_plural, item_name)
+    sys.modules[dotted_path] = module_obj
 
 
 def generate_fingerprint(author: str, package_name: str, version: str, nonce: Optional[int] = None) -> str:

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -22,7 +22,6 @@ import inspect
 import logging
 import os
 import re
-import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
 from queue import Queue
@@ -36,6 +35,7 @@ from aea.connections.base import ConnectionStatus
 from aea.context.base import AgentContext
 from aea.crypto.ledger_apis import LedgerApis
 from aea.decision_maker.base import OwnershipState, Preferences, GoalPursuitReadiness
+from aea.helpers.base import load_module, add_agent_component_module_to_sys_modules
 from aea.mail.base import OutBox
 from aea.protocols.base import Message
 
@@ -221,9 +221,7 @@ class Behaviour(ABC):
         :return: a list of Behaviour.
         """
         behaviours = {}
-        behaviours_spec = importlib.util.spec_from_file_location("behaviours", location=path)
-        behaviour_module = importlib.util.module_from_spec(behaviours_spec)
-        behaviours_spec.loader.exec_module(behaviour_module)  # type: ignore
+        behaviour_module = load_module("behaviours", Path(path))
         classes = inspect.getmembers(behaviour_module, inspect.isclass)
         behaviours_classes = list(filter(lambda x: re.match("\\w+Behaviour", x[0]), classes))
 
@@ -389,9 +387,7 @@ class Task(ABC):
         :return: a list of Tasks.
         """
         tasks = {}
-        tasks_spec = importlib.util.spec_from_file_location("tasks", location=path)
-        task_module = importlib.util.module_from_spec(tasks_spec)
-        tasks_spec.loader.exec_module(task_module)  # type: ignore
+        task_module = load_module("tasks", Path(path))
         classes = inspect.getmembers(task_module, inspect.isclass)
         tasks_classes = list(filter(lambda x: re.match("\\w+Task", x[0]), classes))
 
@@ -459,9 +455,7 @@ class SharedClass(ABC):
         for module_path in module_paths:
             logger.debug("Trying to load module {}".format(module_path))
             module_name = module_path.replace(".py", "")
-            shared_class_spec = importlib.util.spec_from_file_location(module_name, location=module_path)
-            shared_class_module = importlib.util.module_from_spec(shared_class_spec)
-            shared_class_spec.loader.exec_module(shared_class_module)  # type: ignore
+            shared_class_module = load_module(module_name, Path(module_path))
             classes = inspect.getmembers(shared_class_module, inspect.isclass)
             filtered_classes = list(
                 filter(
@@ -527,9 +521,8 @@ class Skill:
         # check if there is the config file. If not, then return None.
         skill_loader = ConfigLoader("skill-config_schema.json", SkillConfig)
         skill_config = skill_loader.load(open(os.path.join(directory, DEFAULT_SKILL_CONFIG_FILE)))
-        skills_spec = importlib.util.spec_from_file_location(skill_config.name, os.path.join(directory, "__init__.py"))
-        skill_module = importlib.util.module_from_spec(skills_spec)
-        sys.modules[skill_config.name + "_skill"] = skill_module
+        skill_module = load_module(skill_config.name, Path(os.path.join(directory, "__init__.py")))
+        add_agent_component_module_to_sys_modules("skill", skill_config.name, skill_module)
         loader_contents = [path.name for path in Path(directory).iterdir()]
         skills_packages = list(filter(lambda x: not x.startswith("__"), loader_contents))  # type: ignore
         logger.debug("Processing the following skill package: {}".format(skills_packages))

--- a/examples/gym_ex/proxy/agent.py
+++ b/examples/gym_ex/proxy/agent.py
@@ -31,8 +31,8 @@ from aea.crypto.wallet import Wallet, DEFAULT
 from aea.helpers.base import locate
 from aea.mail.base import Envelope
 
-sys.modules["gym_connection"] = locate("packages.connections.gym")
-from gym_connection.connection import GymConnection  # noqa: E402
+sys.modules["packages.connections.gym"] = locate("packages.connections.gym")
+from packages.connections.gym.connection import GymConnection  # noqa: E402
 
 
 class ProxyAgent(Agent):

--- a/examples/gym_ex/proxy/env.py
+++ b/examples/gym_ex/proxy/env.py
@@ -34,10 +34,10 @@ from aea.crypto.wallet import DEFAULT
 from aea.mail.base import Envelope
 from aea.protocols.base import Message
 
-sys.modules["gym_connection"] = locate("packages.connections.gym")
-sys.modules["gym_protocol"] = locate("packages.protocols.gym")
-from gym_protocol.message import GymMessage  # noqa: E402
-from gym_protocol.serialization import GymSerializer  # noqa: E402
+sys.modules["packages.connections.gym"] = locate("packages.connections.gym")
+sys.modules["packages.protocols.gym"] = locate("packages.protocols.gym")
+from packages.protocols.gym.message import GymMessage  # noqa: E402
+from packages.protocols.gym.serialization import GymSerializer  # noqa: E402
 
 from .agent import ProxyAgent  # noqa: E402
 

--- a/packages/connections/gym/connection.py
+++ b/packages/connections/gym/connection.py
@@ -21,10 +21,9 @@
 """Gym connector and gym channel."""
 import asyncio
 import logging
-import sys
 import threading
 from asyncio import CancelledError
-from typing import Dict, Optional, cast, TYPE_CHECKING
+from typing import Dict, Optional, cast
 
 import gym
 
@@ -32,13 +31,8 @@ from aea.configurations.base import ConnectionConfig
 from aea.connections.base import Connection
 from aea.helpers.base import locate
 from aea.mail.base import Envelope, Address
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.gym.message import GymMessage
-    from packages.protocols.gym.serialization import GymSerializer
-else:
-    from gym_protocol.message import GymMessage
-    from gym_protocol.serialization import GymSerializer
+from packages.protocols.gym.message import GymMessage
+from packages.protocols.gym.serialization import GymSerializer
 
 logger = logging.getLogger(__name__)
 

--- a/packages/connections/local/connection.py
+++ b/packages/connections/local/connection.py
@@ -23,21 +23,15 @@ import asyncio
 import logging
 from asyncio import Queue, AbstractEventLoop
 from collections import defaultdict
-import sys
 from threading import Thread
-from typing import Dict, List, Optional, Set, cast, TYPE_CHECKING
+from typing import Dict, List, Optional, Set, cast
 
 from aea.configurations.base import ConnectionConfig
 from aea.connections.base import Connection
 from aea.helpers.search.models import Description, Query
 from aea.mail.base import Envelope, AEAConnectionError, Address
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
-else:
-    from oef_protocol.message import OEFMessage
-    from oef_protocol.serialization import OEFSerializer, DEFAULT_OEF
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
 
 logger = logging.getLogger(__name__)
 

--- a/packages/connections/oef/connection.py
+++ b/packages/connections/oef/connection.py
@@ -24,9 +24,8 @@ import logging
 import pickle
 import time
 from asyncio import AbstractEventLoop, CancelledError
-import sys
 from threading import Thread
-from typing import List, Optional, cast, Set, TYPE_CHECKING
+from typing import List, Optional, cast, Set
 
 import oef
 from oef.agents import OEFAgent
@@ -44,20 +43,14 @@ from oef.schema import Description as OEFDescription, DataModel as OEFDataModel,
 
 from aea.configurations.base import ConnectionConfig
 from aea.connections.base import Connection
-from aea.helpers.search.models import Description, Attribute, DataModel, Query, ConstraintExpr, And, Or, Not, Constraint, \
+from aea.helpers.search.models import Description, Attribute, DataModel, Query, ConstraintExpr, And, Or, Not, \
+    Constraint, \
     ConstraintType, ConstraintTypes
 from aea.mail.base import Envelope, Address
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.message import FIPAMessage
-    from packages.protocols.fipa.serialization import FIPASerializer
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
-else:
-    from fipa_protocol.message import FIPAMessage
-    from fipa_protocol.serialization import FIPASerializer
-    from oef_protocol.message import OEFMessage
-    from oef_protocol.serialization import OEFSerializer, DEFAULT_OEF
+from packages.protocols.fipa.message import FIPAMessage
+from packages.protocols.fipa.serialization import FIPASerializer
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
 
 logger = logging.getLogger(__name__)
 

--- a/packages/connections/tcp/tcp_client.py
+++ b/packages/connections/tcp/tcp_client.py
@@ -21,18 +21,13 @@
 import asyncio
 import logging
 import struct
-import sys
 from asyncio import StreamWriter, StreamReader, CancelledError
-from typing import Optional, cast, TYPE_CHECKING
+from typing import Optional, cast
 
 from aea.configurations.base import ConnectionConfig
 from aea.connections.base import Connection
 from aea.mail.base import Envelope, Address
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.connections.tcp.base import TCPConnection
-else:
-    from tcp_connection.base import TCPConnection
+from packages.connections.tcp.base import TCPConnection
 
 logger = logging.getLogger(__name__)
 

--- a/packages/connections/tcp/tcp_server.py
+++ b/packages/connections/tcp/tcp_server.py
@@ -21,18 +21,13 @@
 """Implementation of the TCP server."""
 import asyncio
 import logging
-import sys
 from asyncio import StreamReader, StreamWriter, AbstractServer, Future
-from typing import Dict, Optional, Tuple, cast, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, cast
 
 from aea.configurations.base import ConnectionConfig
 from aea.connections.base import Connection
 from aea.mail.base import Envelope, Address
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.connections.tcp.base import TCPConnection
-else:
-    from tcp_connection.base import TCPConnection
+from packages.connections.tcp.base import TCPConnection
 
 logger = logging.getLogger(__name__)
 

--- a/packages/protocols/fipa/dialogues.py
+++ b/packages/protocols/fipa/dialogues.py
@@ -27,17 +27,12 @@ This module contains the classes required for FIPA dialogue management.
 """
 
 from enum import Enum
-import sys
-from typing import Dict, Tuple, cast, TYPE_CHECKING
+from typing import Dict, Tuple, cast
 
 from aea.helpers.dialogue.base import DialogueLabel, Dialogue, Dialogues
 from aea.mail.base import Address
 from aea.protocols.base import Message
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.message import FIPAMessage, VALID_PREVIOUS_PERFORMATIVES
-else:
-    from fipa_protocol.message import FIPAMessage, VALID_PREVIOUS_PERFORMATIVES  # pragma: no cover
+from packages.protocols.fipa.message import FIPAMessage, VALID_PREVIOUS_PERFORMATIVES
 
 
 class FIPADialogue(Dialogue):

--- a/packages/protocols/fipa/serialization.py
+++ b/packages/protocols/fipa/serialization.py
@@ -20,19 +20,13 @@
 
 """Serialization for the FIPA protocol."""
 import pickle
-import sys
-from typing import cast, TYPE_CHECKING
+from typing import cast
 
 from aea.helpers.search.models import Description, Query
 from aea.protocols.base import Message
 from aea.protocols.base import Serializer
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa import fipa_pb2
-    from packages.protocols.fipa.message import FIPAMessage
-else:
-    import fipa_protocol.fipa_pb2 as fipa_pb2  # pragma: no cover
-    from fipa_protocol.message import FIPAMessage  # pragma: no cover
+from packages.protocols.fipa import fipa_pb2
+from packages.protocols.fipa.message import FIPAMessage
 
 
 class FIPASerializer(Serializer):

--- a/packages/protocols/gym/serialization.py
+++ b/packages/protocols/gym/serialization.py
@@ -23,16 +23,11 @@ import base64
 import copy
 import json
 import pickle
-import sys
-from typing import Any, TYPE_CHECKING, cast
+from typing import Any, cast
 
 from aea.protocols.base import Message
 from aea.protocols.base import Serializer
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.gym.message import GymMessage
-else:
-    from gym_protocol.message import GymMessage  # pragma: no cover
+from packages.protocols.gym.message import GymMessage
 
 
 class GymSerializer(Serializer):

--- a/packages/protocols/ml_trade/serialization.py
+++ b/packages/protocols/ml_trade/serialization.py
@@ -22,16 +22,11 @@
 import base64
 import json
 import pickle
-import sys
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 from aea.protocols.base import Message
 from aea.protocols.base import Serializer
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.ml_trade.message import MLTradeMessage
-else:
-    from ml_trade_protocol.message import MLTradeMessage  # pragma: no cover
+from packages.protocols.ml_trade.message import MLTradeMessage
 
 
 class MLTradeSerializer(Serializer):

--- a/packages/protocols/oef/serialization.py
+++ b/packages/protocols/oef/serialization.py
@@ -19,21 +19,15 @@
 # ------------------------------------------------------------------------------
 
 """Serialization for the FIPA protocol."""
-from typing import cast, TYPE_CHECKING
-
 import base64
 import copy
 import json
 import pickle
-import sys
+from typing import cast
 
 from aea.protocols.base import Message
 from aea.protocols.base import Serializer
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-else:
-    from oef_protocol.message import OEFMessage  # pragma: no cover
+from packages.protocols.oef.message import OEFMessage
 
 """default 'to' field for OEF envelopes."""
 DEFAULT_OEF = "oef"

--- a/packages/protocols/tac/serialization.py
+++ b/packages/protocols/tac/serialization.py
@@ -20,17 +20,11 @@
 
 """Serialization for the TAC protocol."""
 
-import sys
-from typing import Any, Dict, TYPE_CHECKING, cast
+from typing import Any, Dict, cast
 
 from aea.protocols.base import Message, Serializer
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.tac import tac_pb2
-    from packages.protocols.tac.message import TACMessage
-else:
-    import tac_protocol.tac_pb2 as tac_pb2  # pragma: no cover
-    from tac_protocol.message import TACMessage  # pragma: no cover
+from packages.protocols.tac import tac_pb2
+from packages.protocols.tac.message import TACMessage
 
 
 def _from_dict_to_pairs(d):

--- a/packages/skills/carpark_client/behaviours.py
+++ b/packages/skills/carpark_client/behaviours.py
@@ -19,19 +19,12 @@
 
 """This package contains a scaffold of a behaviour."""
 import logging
-import sys
-from typing import cast, TYPE_CHECKING
+from typing import cast
 
 from aea.skills.behaviours import TickerBehaviour
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.oef.serialization import DEFAULT_OEF, OEFSerializer
-    from packages.skills.carpark_client.strategy import Strategy
-else:
-    from oef_protocol.message import OEFMessage
-    from oef_protocol.serialization import DEFAULT_OEF, OEFSerializer
-    from carpark_client_skill.strategy import Strategy
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.oef.serialization import DEFAULT_OEF, OEFSerializer
+from packages.skills.carpark_client.strategy import Strategy
 
 logger = logging.getLogger("aea.carpark_client_skill")
 

--- a/packages/skills/carpark_client/dialogues.py
+++ b/packages/skills/carpark_client/dialogues.py
@@ -25,17 +25,12 @@ This module contains the classes required for dialogue management.
 - Dialogues: The dialogues class keeps track of all dialogues.
 """
 
-import sys
-from typing import Optional, TYPE_CHECKING
+from typing import Optional
 
 from aea.helpers.dialogue.base import DialogueLabel
 from aea.helpers.search.models import Description
 from aea.skills.base import SharedClass
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.dialogues import FIPADialogues, FIPADialogue
-else:
-    from fipa_protocol.dialogues import FIPADialogues, FIPADialogue
+from packages.protocols.fipa.dialogues import FIPADialogues, FIPADialogue
 
 
 class Dialogue(FIPADialogue):

--- a/packages/skills/carpark_client/handlers.py
+++ b/packages/skills/carpark_client/handlers.py
@@ -20,8 +20,7 @@
 """This package contains a scaffold of a handler."""
 import logging
 import pprint
-import sys
-from typing import Dict, List, Optional, cast, TYPE_CHECKING
+from typing import Dict, List, Optional, cast
 
 from aea.configurations.base import ProtocolId
 from aea.decision_maker.messages.transaction import TransactionMessage
@@ -31,19 +30,11 @@ from aea.protocols.base import Message
 from aea.protocols.default.message import DefaultMessage
 from aea.protocols.default.serialization import DefaultSerializer
 from aea.skills.base import Handler
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.message import FIPAMessage
-    from packages.protocols.fipa.serialization import FIPASerializer
-    from packages.protocols.oef.message import OEFMessage
-    from packages.skills.carpark_client.dialogues import Dialogue, Dialogues
-    from packages.skills.carpark_client.strategy import Strategy
-else:
-    from fipa_protocol.message import FIPAMessage
-    from fipa_protocol.serialization import FIPASerializer
-    from oef_protocol.message import OEFMessage
-    from carpark_client_skill.dialogues import Dialogue, Dialogues
-    from carpark_client_skill.strategy import Strategy
+from packages.protocols.fipa.message import FIPAMessage
+from packages.protocols.fipa.serialization import FIPASerializer
+from packages.protocols.oef.message import OEFMessage
+from packages.skills.carpark_client.dialogues import Dialogue, Dialogues
+from packages.skills.carpark_client.strategy import Strategy
 
 logger = logging.getLogger("aea.carpark_client_skill")
 

--- a/packages/skills/carpark_detection/behaviours.py
+++ b/packages/skills/carpark_detection/behaviours.py
@@ -22,21 +22,14 @@
 import logging
 import os
 import subprocess
-import sys
-from typing import Optional, cast, TYPE_CHECKING
+from typing import Optional, cast
 
 from aea.helpers.search.models import Description
 from aea.skills.base import Behaviour
 from aea.skills.behaviours import TickerBehaviour
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
-    from packages.skills.carpark_detection.strategy import Strategy
-else:
-    from oef_protocol.message import OEFMessage
-    from oef_protocol.serialization import OEFSerializer, DEFAULT_OEF
-    from carpark_detection_skill.strategy import Strategy
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
+from packages.skills.carpark_detection.strategy import Strategy
 
 logger = logging.getLogger("aea.carpark_detection_skill")
 

--- a/packages/skills/carpark_detection/dialogues.py
+++ b/packages/skills/carpark_detection/dialogues.py
@@ -25,17 +25,12 @@ This module contains the classes required for dialogue management.
 - Dialogues: The dialogues class keeps track of all dialogues.
 """
 
-import sys
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Dict, Optional
 
 from aea.helpers.dialogue.base import DialogueLabel
 from aea.helpers.search.models import Description
 from aea.skills.base import SharedClass
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.dialogues import FIPADialogues, FIPADialogue
-else:
-    from fipa_protocol.dialogues import FIPADialogues, FIPADialogue
+from packages.protocols.fipa.dialogues import FIPADialogues, FIPADialogue
 
 
 class Dialogue(FIPADialogue):

--- a/packages/skills/carpark_detection/handlers.py
+++ b/packages/skills/carpark_detection/handlers.py
@@ -20,8 +20,7 @@
 """This package contains a scaffold of a handler."""
 
 import logging
-import sys
-from typing import Optional, cast, TYPE_CHECKING
+from typing import Optional, cast
 
 from aea.configurations.base import ProtocolId
 from aea.helpers.search.models import Description, Query
@@ -29,17 +28,10 @@ from aea.protocols.base import Message
 from aea.protocols.default.message import DefaultMessage
 from aea.protocols.default.serialization import DefaultSerializer
 from aea.skills.base import Handler
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.message import FIPAMessage
-    from packages.protocols.fipa.serialization import FIPASerializer
-    from packages.skills.carpark_detection.dialogues import Dialogue, Dialogues
-    from packages.skills.carpark_detection.strategy import Strategy
-else:
-    from fipa_protocol.message import FIPAMessage
-    from fipa_protocol.serialization import FIPASerializer
-    from carpark_detection_skill.dialogues import Dialogue, Dialogues
-    from carpark_detection_skill.strategy import Strategy
+from packages.protocols.fipa.message import FIPAMessage
+from packages.protocols.fipa.serialization import FIPASerializer
+from packages.skills.carpark_detection.dialogues import Dialogue, Dialogues
+from packages.skills.carpark_detection.strategy import Strategy
 
 logger = logging.getLogger("aea.carpark_detection_skill")
 

--- a/packages/skills/carpark_detection/handlers.py
+++ b/packages/skills/carpark_detection/handlers.py
@@ -238,7 +238,7 @@ class FIPAHandler(Handler):
                                                                                              tx_digest))
             proposal = cast(Description, dialogue.proposal)
             total_price = cast(int, proposal.values.get("price"))
-            is_settled = self.context.ledger_apis.is_tx_settled('fetchai', tx_digest, total_price)
+            is_settled = self.context.ledger_apis.is_tx_settled('fetchai', tx_digest)
             if is_settled:
                 token_balance = self.context.ledger_apis.token_balance(
                     'fetchai',

--- a/packages/skills/carpark_detection/strategy.py
+++ b/packages/skills/carpark_detection/strategy.py
@@ -21,20 +21,13 @@
 
 import logging
 import os
-import sys
-from typing import Any, Dict, List, Tuple, TYPE_CHECKING, cast
+from typing import Any, Dict, List, Tuple, cast
 import time
 
 from aea.helpers.search.models import Description, Query
 from aea.skills.base import SharedClass
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.skills.carpark_detection.detection_database import DetectionDatabase
-    from packages.skills.carpark_detection.carpark_detection_data_model import CarParkDataModel
-
-else:
-    from carpark_detection_skill.detection_database import DetectionDatabase
-    from carpark_detection_skill.carpark_detection_data_model import CarParkDataModel
+from packages.skills.carpark_detection.detection_database import DetectionDatabase
+from packages.skills.carpark_detection.carpark_detection_data_model import CarParkDataModel
 
 DEFAULT_PRICE = 2000
 DEFAULT_DB_IS_REL_TO_CWD = False

--- a/packages/skills/gym/handlers.py
+++ b/packages/skills/gym/handlers.py
@@ -19,18 +19,12 @@
 
 """This module contains the handler for the 'gym' skill."""
 import logging
-import sys
-from typing import cast, TYPE_CHECKING
+from typing import cast
 
 from aea.protocols.base import Message
 from aea.skills.base import Handler
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.gym.message import GymMessage
-    from packages.skills.gym.tasks import GymTask
-else:
-    from gym_protocol.message import GymMessage
-    from gym_skill.tasks import GymTask
+from packages.protocols.gym.message import GymMessage
+from packages.skills.gym.tasks import GymTask
 
 logger = logging.getLogger("aea.gym_skill")
 

--- a/packages/skills/gym/helpers.py
+++ b/packages/skills/gym/helpers.py
@@ -20,21 +20,16 @@
 """This module contains the helpers for the 'gym' skill."""
 
 from abc import ABC, abstractmethod
-import gym
 from queue import Queue
-import sys
-from typing import Any, Tuple, cast, TYPE_CHECKING
+from typing import Any, Tuple, cast
+
+import gym
 
 from aea.mail.base import Envelope
-from aea.skills.base import SkillContext
 from aea.protocols.base import Message
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.gym.message import GymMessage
-    from packages.protocols.gym.serialization import GymSerializer
-else:
-    from gym_protocol.message import GymMessage
-    from gym_protocol.serialization import GymSerializer
+from aea.skills.base import SkillContext
+from packages.protocols.gym.message import GymMessage
+from packages.protocols.gym.serialization import GymSerializer
 
 Action = Any
 Observation = Any

--- a/packages/skills/gym/rl_agent.py
+++ b/packages/skills/gym/rl_agent.py
@@ -20,16 +20,12 @@
 """This contains the rl agent class."""
 
 import logging
-import numpy as np
 import random
-import sys
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, Dict
 
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.skills.gym.helpers import RLAgent, ProxyEnv
-else:
-    from gym_skill.helpers import RLAgent, ProxyEnv
+import numpy as np
 
+from packages.skills.gym.helpers import RLAgent, ProxyEnv
 
 DEFAULT_NB_STEPS = 4000
 NB_GOODS = 10

--- a/packages/skills/gym/tasks.py
+++ b/packages/skills/gym/tasks.py
@@ -20,19 +20,11 @@
 """This module contains the tasks for the 'gym' skill."""
 import logging
 from queue import Queue
-import sys
 from threading import Thread
-from typing import TYPE_CHECKING
-
 
 from aea.skills.base import Task
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.skills.gym.helpers import ProxyEnv
-    from packages.skills.gym.rl_agent import MyRLAgent, DEFAULT_NB_STEPS, NB_GOODS
-else:
-    from gym_skill.helpers import ProxyEnv
-    from gym_skill.rl_agent import MyRLAgent, DEFAULT_NB_STEPS, NB_GOODS
+from packages.skills.gym.helpers import ProxyEnv
+from packages.skills.gym.rl_agent import MyRLAgent, DEFAULT_NB_STEPS, NB_GOODS
 
 logger = logging.getLogger("aea.gym_skill")
 

--- a/packages/skills/ml_data_provider/behaviours.py
+++ b/packages/skills/ml_data_provider/behaviours.py
@@ -20,22 +20,15 @@
 """This package contains the behaviours."""
 
 import logging
-import sys
-from typing import cast, Optional, TYPE_CHECKING
+from typing import cast, Optional
 
 from aea.crypto.ethereum import ETHEREUM
 from aea.crypto.fetchai import FETCHAI
 from aea.helpers.search.models import Description
 from aea.skills.behaviours import TickerBehaviour
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
-    from packages.skills.ml_data_provider.strategy import Strategy
-else:
-    from oef_protocol.message import OEFMessage
-    from oef_protocol.serialization import OEFSerializer, DEFAULT_OEF
-    from ml_data_provider_skill.strategy import Strategy
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
+from packages.skills.ml_data_provider.strategy import Strategy
 
 logger = logging.getLogger("aea.ml_data_provider")
 

--- a/packages/skills/ml_data_provider/handlers.py
+++ b/packages/skills/ml_data_provider/handlers.py
@@ -19,20 +19,13 @@
 
 """This module contains the handler for the 'ml_data_provider' skill."""
 import logging
-import sys
-from typing import cast, TYPE_CHECKING
+from typing import cast
 
 from aea.protocols.base import Message
 from aea.skills.base import Handler
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.ml_trade.message import MLTradeMessage
-    from packages.protocols.ml_trade.serialization import MLTradeSerializer
-    from packages.skills.ml_data_provider.strategy import Strategy
-else:
-    from ml_trade_protocol.message import MLTradeMessage
-    from ml_trade_protocol.serialization import MLTradeSerializer
-    from ml_data_provider_skill.strategy import Strategy
+from packages.protocols.ml_trade.message import MLTradeMessage
+from packages.protocols.ml_trade.serialization import MLTradeSerializer
+from packages.skills.ml_data_provider.strategy import Strategy
 
 logger = logging.getLogger("aea.ml_data_provider")
 

--- a/packages/skills/ml_train/behaviours.py
+++ b/packages/skills/ml_train/behaviours.py
@@ -20,21 +20,14 @@
 """This package contains a the behaviours."""
 
 import logging
-import sys
-from typing import cast, TYPE_CHECKING
+from typing import cast
 
 from aea.crypto.ethereum import ETHEREUM
 from aea.crypto.fetchai import FETCHAI
 from aea.skills.behaviours import TickerBehaviour
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
-    from packages.skills.ml_train.strategy import Strategy
-else:
-    from oef_protocol.message import OEFMessage
-    from oef_protocol.serialization import OEFSerializer, DEFAULT_OEF
-    from ml_train_skill.strategy import Strategy
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
+from packages.skills.ml_train.strategy import Strategy
 
 logger = logging.getLogger("aea.ml_train_skill")
 

--- a/packages/skills/ml_train/handlers.py
+++ b/packages/skills/ml_train/handlers.py
@@ -19,28 +19,18 @@
 
 """This module contains the handler for the 'ml_train' skill."""
 import logging
-import sys
-from typing import cast, TYPE_CHECKING, Optional, List
+from typing import cast, Optional, List
 
 from aea.configurations.base import ProtocolId
 from aea.decision_maker.messages.transaction import TransactionMessage
 from aea.helpers.search.models import Description
 from aea.protocols.base import Message
 from aea.skills.base import Handler
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.ml_trade.message import MLTradeMessage
-    from packages.protocols.ml_trade.serialization import MLTradeSerializer
-    from packages.skills.ml_train.strategy import Strategy
-    from packages.skills.ml_train.tasks import MLTrainTask
-    # from packages.skills.ml_train.tasks import MLTask
-else:
-    from oef_protocol.message import OEFMessage
-    from ml_trade_protocol.message import MLTradeMessage
-    from ml_trade_protocol.serialization import MLTradeSerializer
-    from ml_train_skill.strategy import Strategy
-    from ml_train_skill.tasks import MLTrainTask
+from packages.protocols.ml_trade.message import MLTradeMessage
+from packages.protocols.ml_trade.serialization import MLTradeSerializer
+from packages.protocols.oef.message import OEFMessage
+from packages.skills.ml_train.strategy import Strategy
+from packages.skills.ml_train.tasks import MLTrainTask
 
 logger = logging.getLogger("aea.ml_train_skill")
 

--- a/packages/skills/ml_train/tasks.py
+++ b/packages/skills/ml_train/tasks.py
@@ -23,6 +23,7 @@ from typing import Tuple
 
 import numpy as np
 from tensorflow import keras
+
 from aea.skills.base import Task
 
 logger = logging.getLogger("aea.gym_skill")

--- a/packages/skills/tac_control/behaviours.py
+++ b/packages/skills/tac_control/behaviours.py
@@ -21,26 +21,16 @@
 
 import datetime
 import logging
-import sys
-from typing import cast, Optional, TYPE_CHECKING
+from typing import cast, Optional
 
 from aea.helpers.search.models import Description, DataModel, Attribute
 from aea.skills.base import Behaviour
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
-    from packages.protocols.tac.message import TACMessage
-    from packages.protocols.tac.serialization import TACSerializer
-    from packages.skills.tac_control.game import Game, Phase
-    from packages.skills.tac_control.parameters import Parameters
-else:
-    from oef_protocol.message import OEFMessage
-    from oef_protocol.serialization import OEFSerializer, DEFAULT_OEF
-    from tac_protocol.message import TACMessage
-    from tac_protocol.serialization import TACSerializer
-    from tac_control_skill.game import Game, Phase
-    from tac_control_skill.parameters import Parameters
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
+from packages.protocols.tac.message import TACMessage
+from packages.protocols.tac.serialization import TACSerializer
+from packages.skills.tac_control.game import Game, Phase
+from packages.skills.tac_control.parameters import Parameters
 
 CONTROLLER_DATAMODEL = DataModel("tac", [
     Attribute("version", str, True, "Version number of the TAC Controller Agent."),

--- a/packages/skills/tac_control/game.py
+++ b/packages/skills/tac_control/game.py
@@ -19,29 +19,22 @@
 
 """This package contains a class representing the game."""
 
-from collections import defaultdict
 import copy
 import datetime
-from enum import Enum
 import pprint
-import sys
-from typing import cast, Dict, List, Optional, TYPE_CHECKING
+from collections import defaultdict
+from enum import Enum
+from typing import cast, Dict, List, Optional
 
 from aea.crypto.ethereum import ETHEREUM
 from aea.helpers.preference_representations.base import logarithmic_utility, linear_utility
 from aea.mail.base import Address
 from aea.skills.base import SharedClass
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.tac.message import TACMessage
-    from packages.skills.tac_control.helpers import generate_good_id_to_name, determine_scaling_factor, \
-        generate_money_endowments, generate_good_endowments, generate_utility_params, generate_equilibrium_prices_and_holdings, tx_hash_from_values
-    from packages.skills.tac_control.parameters import Parameters
-else:
-    from tac_protocol.message import TACMessage
-    from tac_control_skill.helpers import generate_good_id_to_name, determine_scaling_factor, \
-        generate_money_endowments, generate_good_endowments, generate_utility_params, generate_equilibrium_prices_and_holdings, tx_hash_from_values
-    from tac_control_skill.parameters import Parameters
+from packages.protocols.tac.message import TACMessage
+from packages.skills.tac_control.helpers import generate_good_id_to_name, determine_scaling_factor, \
+    generate_money_endowments, generate_good_endowments, generate_utility_params, \
+    generate_equilibrium_prices_and_holdings, tx_hash_from_values
+from packages.skills.tac_control.parameters import Parameters
 
 GoodId = str
 CurrencyId = str

--- a/packages/skills/tac_control/handlers.py
+++ b/packages/skills/tac_control/handlers.py
@@ -20,25 +20,15 @@
 """This package contains the handlers."""
 
 import logging
-import sys
-from typing import cast, TYPE_CHECKING
+from typing import cast
 
 from aea.protocols.base import Message
 from aea.skills.base import Handler
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.tac.message import TACMessage
-    from packages.protocols.tac.serialization import TACSerializer
-    from packages.skills.tac_control.game import Game, Phase, Transaction
-    from packages.skills.tac_control.parameters import Parameters
-else:
-    from oef_protocol.message import OEFMessage
-    from tac_protocol.message import TACMessage
-    from tac_protocol.serialization import TACSerializer
-    from tac_control_skill.game import Game, Phase, Transaction
-    from tac_control_skill.parameters import Parameters
-
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.tac.message import TACMessage
+from packages.protocols.tac.serialization import TACSerializer
+from packages.skills.tac_control.game import Game, Phase, Transaction
+from packages.skills.tac_control.parameters import Parameters
 
 logger = logging.getLogger("aea.tac_control_skill")
 

--- a/packages/skills/tac_negotiation/behaviours.py
+++ b/packages/skills/tac_negotiation/behaviours.py
@@ -19,23 +19,14 @@
 
 """This package contains a scaffold of a behaviour."""
 import logging
-import sys
-from typing import cast, TYPE_CHECKING
+from typing import cast
 
 from aea.skills.base import Behaviour
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
-    from packages.skills.tac_negotiation.registration import Registration
-    from packages.skills.tac_negotiation.search import Search
-    from packages.skills.tac_negotiation.strategy import Strategy
-else:
-    from oef_protocol.message import OEFMessage
-    from oef_protocol.serialization import OEFSerializer, DEFAULT_OEF
-    from tac_negotiation_skill.registration import Registration
-    from tac_negotiation_skill.search import Search
-    from tac_negotiation_skill.strategy import Strategy
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
+from packages.skills.tac_negotiation.registration import Registration
+from packages.skills.tac_negotiation.search import Search
+from packages.skills.tac_negotiation.strategy import Strategy
 
 logger = logging.getLogger("aea.tac_negotiation_skill")
 

--- a/packages/skills/tac_negotiation/dialogues.py
+++ b/packages/skills/tac_negotiation/dialogues.py
@@ -24,15 +24,9 @@ This module contains the classes required for dialogue management.
 - Dialogues: The dialogues class keeps track of all dialogues.
 """
 
-import sys
-from typing import TYPE_CHECKING
-
 from aea.skills.base import SharedClass
 
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.dialogues import FIPADialogues
-else:
-    from fipa_protocol.dialogues import FIPADialogues
+from packages.protocols.fipa.dialogues import FIPADialogues
 
 
 class Dialogues(SharedClass, FIPADialogues):

--- a/packages/skills/tac_negotiation/handlers.py
+++ b/packages/skills/tac_negotiation/handlers.py
@@ -21,38 +21,25 @@
 
 import logging
 import pprint
-import sys
-from typing import Dict, List, Optional, cast, TYPE_CHECKING
+from typing import Dict, List, Optional, cast
 
 from aea.configurations.base import ProtocolId
+from aea.decision_maker.messages.transaction import TransactionMessage
 from aea.helpers.dialogue.base import DialogueLabel
 from aea.helpers.search.models import Query
-from aea.skills.base import Handler
 from aea.protocols.base import Message
 from aea.protocols.default.message import DefaultMessage
 from aea.protocols.default.serialization import DefaultSerializer
-from aea.decision_maker.messages.transaction import TransactionMessage
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.dialogues import FIPADialogue as Dialogue
-    from packages.protocols.fipa.message import FIPAMessage
-    from packages.protocols.fipa.serialization import FIPASerializer
-    from packages.protocols.oef.message import OEFMessage
-    from packages.skills.tac_negotiation.dialogues import Dialogues
-    from packages.skills.tac_negotiation.helpers import SUPPLY_DATAMODEL_NAME
-    from packages.skills.tac_negotiation.search import Search
-    from packages.skills.tac_negotiation.strategy import Strategy
-    from packages.skills.tac_negotiation.transactions import Transactions
-else:
-    from fipa_protocol.dialogues import FIPADialogue as Dialogue
-    from fipa_protocol.message import FIPAMessage
-    from fipa_protocol.serialization import FIPASerializer
-    from oef_protocol.message import OEFMessage
-    from tac_negotiation_skill.dialogues import Dialogues
-    from tac_negotiation_skill.helpers import SUPPLY_DATAMODEL_NAME
-    from tac_negotiation_skill.search import Search
-    from tac_negotiation_skill.strategy import Strategy
-    from tac_negotiation_skill.transactions import Transactions
+from aea.skills.base import Handler
+from packages.protocols.fipa.dialogues import FIPADialogue as Dialogue
+from packages.protocols.fipa.message import FIPAMessage
+from packages.protocols.fipa.serialization import FIPASerializer
+from packages.protocols.oef.message import OEFMessage
+from packages.skills.tac_negotiation.dialogues import Dialogues
+from packages.skills.tac_negotiation.helpers import SUPPLY_DATAMODEL_NAME
+from packages.skills.tac_negotiation.search import Search
+from packages.skills.tac_negotiation.strategy import Strategy
+from packages.skills.tac_negotiation.transactions import Transactions
 
 logger = logging.getLogger("aea.tac_negotiation_skill")
 

--- a/packages/skills/tac_negotiation/strategy.py
+++ b/packages/skills/tac_negotiation/strategy.py
@@ -21,22 +21,16 @@
 """This module contains the abstract class defining an agent's strategy for the TAC."""
 
 import copy
-from enum import Enum
 import logging
 import random
-import sys
-from typing import Dict, Optional, cast, TYPE_CHECKING
+from enum import Enum
+from typing import Dict, Optional, cast
 
-from aea.helpers.search.models import Query, Description
 from aea.decision_maker.messages.transaction import TransactionMessage
+from aea.helpers.search.models import Query, Description
 from aea.skills.base import SharedClass
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.skills.tac_negotiation.helpers import build_goods_description, build_goods_query
-    from packages.skills.tac_negotiation.transactions import Transactions
-else:
-    from tac_negotiation_skill.helpers import build_goods_description, build_goods_query
-    from tac_negotiation_skill.transactions import Transactions
+from packages.skills.tac_negotiation.helpers import build_goods_description, build_goods_query
+from packages.skills.tac_negotiation.transactions import Transactions
 
 logger = logging.getLogger("aea.tac_negotiation_skill")
 

--- a/packages/skills/tac_negotiation/tasks.py
+++ b/packages/skills/tac_negotiation/tasks.py
@@ -19,15 +19,10 @@
 
 """This package contains a scaffold of a task."""
 
-import sys
-from typing import cast, TYPE_CHECKING
+from typing import cast
 
 from aea.skills.base import Task
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.skills.tac_negotiation.transactions import Transactions
-else:
-    from tac_negotiation_skill.transactions import Transactions
+from packages.skills.tac_negotiation.transactions import Transactions
 
 
 class TransactionCleanUpTask(Task):

--- a/packages/skills/tac_negotiation/transactions.py
+++ b/packages/skills/tac_negotiation/transactions.py
@@ -24,8 +24,7 @@ import copy
 import datetime
 import logging
 from collections import defaultdict, deque
-import sys
-from typing import Dict, Tuple, Deque, TYPE_CHECKING
+from typing import Dict, Tuple, Deque
 
 from aea.decision_maker.base import OwnershipState
 from aea.decision_maker.messages.transaction import TransactionMessage, TransactionId, OFF_CHAIN
@@ -33,11 +32,7 @@ from aea.helpers.dialogue.base import DialogueLabel
 from aea.helpers.search.models import Description
 from aea.mail.base import Address
 from aea.skills.base import SharedClass
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.skills.tac_negotiation.helpers import tx_hash_from_values
-else:
-    from tac_negotiation_skill.helpers import tx_hash_from_values
+from packages.skills.tac_negotiation.helpers import tx_hash_from_values
 
 logger = logging.getLogger("aea.tac_negotiation_skill")
 

--- a/packages/skills/tac_participation/behaviours.py
+++ b/packages/skills/tac_participation/behaviours.py
@@ -20,21 +20,13 @@
 """This package contains a tac participation behaviour."""
 
 import logging
-import sys
-from typing import cast, TYPE_CHECKING
+from typing import cast
 
 from aea.skills.base import Behaviour
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
-    from packages.skills.tac_participation.game import Game, Phase
-    from packages.skills.tac_participation.search import Search
-else:
-    from oef_protocol.message import OEFMessage
-    from oef_protocol.serialization import OEFSerializer, DEFAULT_OEF
-    from tac_participation_skill.game import Game, Phase
-    from tac_participation_skill.search import Search
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
+from packages.skills.tac_participation.game import Game, Phase
+from packages.skills.tac_participation.search import Search
 
 logger = logging.getLogger("aea.tac_participation_skill")
 

--- a/packages/skills/tac_participation/game.py
+++ b/packages/skills/tac_participation/game.py
@@ -18,19 +18,14 @@
 # ------------------------------------------------------------------------------
 
 """This package contains a class representing the game."""
-from enum import Enum
 import logging
-import sys
-from typing import Dict, List, Optional, TYPE_CHECKING
+from enum import Enum
+from typing import Dict, List, Optional
 
 from aea.helpers.search.models import Query, Constraint, ConstraintType
-from aea.skills.base import SharedClass
 from aea.mail.base import Address
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.tac.message import TACMessage
-else:
-    from tac_protocol.message import TACMessage
+from aea.skills.base import SharedClass
+from packages.protocols.tac.message import TACMessage
 
 logger = logging.getLogger("aea.tac_participation_skill")
 

--- a/packages/skills/tac_participation/handlers.py
+++ b/packages/skills/tac_participation/handlers.py
@@ -20,29 +20,19 @@
 """This package contains the handlers."""
 
 import logging
-import sys
-from typing import List, Optional, cast, TYPE_CHECKING
+from typing import List, Optional, cast
 
 from aea.configurations.base import ProtocolId
 from aea.decision_maker.messages.state_update import StateUpdateMessage
 from aea.decision_maker.messages.transaction import TransactionMessage
+from aea.mail.base import Address
 from aea.protocols.base import Message
 from aea.skills.base import Handler
-from aea.mail.base import Address
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.tac.message import TACMessage
-    from packages.protocols.tac.serialization import TACSerializer
-    from packages.skills.tac_participation.game import Game, Phase
-    from packages.skills.tac_participation.search import Search
-else:
-    from oef_protocol.message import OEFMessage
-    from tac_protocol.message import TACMessage
-    from tac_protocol.serialization import TACSerializer
-    from tac_participation_skill.game import Game, Phase
-    from tac_participation_skill.search import Search
-
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.tac.message import TACMessage
+from packages.protocols.tac.serialization import TACSerializer
+from packages.skills.tac_participation.game import Game, Phase
+from packages.skills.tac_participation.search import Search
 
 logger = logging.getLogger("aea.tac_participation_skill")
 

--- a/packages/skills/weather_client/behaviours.py
+++ b/packages/skills/weather_client/behaviours.py
@@ -19,19 +19,12 @@
 
 """This package contains a scaffold of a behaviour."""
 import logging
-import sys
-from typing import cast, TYPE_CHECKING
+from typing import cast
 
 from aea.skills.behaviours import TickerBehaviour
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.oef.serialization import DEFAULT_OEF, OEFSerializer
-    from packages.skills.weather_client.strategy import Strategy
-else:
-    from oef_protocol.message import OEFMessage
-    from oef_protocol.serialization import DEFAULT_OEF, OEFSerializer
-    from weather_client_skill.strategy import Strategy
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.oef.serialization import DEFAULT_OEF, OEFSerializer
+from packages.skills.weather_client.strategy import Strategy
 
 logger = logging.getLogger("aea.weather_client_skill")
 

--- a/packages/skills/weather_client/dialogues.py
+++ b/packages/skills/weather_client/dialogues.py
@@ -25,17 +25,12 @@ This module contains the classes required for dialogue management.
 - Dialogues: The dialogues class keeps track of all dialogues.
 """
 
-import sys
-from typing import Optional, TYPE_CHECKING
+from typing import Optional
 
 from aea.helpers.dialogue.base import DialogueLabel
 from aea.helpers.search.models import Description
 from aea.skills.base import SharedClass
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.dialogues import FIPADialogues, FIPADialogue
-else:
-    from fipa_protocol.dialogues import FIPADialogues, FIPADialogue
+from packages.protocols.fipa.dialogues import FIPADialogues, FIPADialogue
 
 
 class Dialogue(FIPADialogue):

--- a/packages/skills/weather_client/handlers.py
+++ b/packages/skills/weather_client/handlers.py
@@ -20,8 +20,7 @@
 """This package contains a scaffold of a handler."""
 import logging
 import pprint
-import sys
-from typing import List, Optional, cast, TYPE_CHECKING
+from typing import List, Optional, cast
 
 from aea.configurations.base import ProtocolId
 from aea.helpers.search.models import Description
@@ -29,19 +28,11 @@ from aea.protocols.base import Message
 from aea.protocols.default.message import DefaultMessage
 from aea.protocols.default.serialization import DefaultSerializer
 from aea.skills.base import Handler
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.message import FIPAMessage
-    from packages.protocols.fipa.serialization import FIPASerializer
-    from packages.protocols.oef.message import OEFMessage
-    from packages.skills.weather_client.dialogues import Dialogue, Dialogues
-    from packages.skills.weather_client.strategy import Strategy
-else:
-    from fipa_protocol.message import FIPAMessage
-    from fipa_protocol.serialization import FIPASerializer
-    from oef_protocol.message import OEFMessage
-    from weather_client_skill.dialogues import Dialogue, Dialogues
-    from weather_client_skill.strategy import Strategy
+from packages.protocols.fipa.message import FIPAMessage
+from packages.protocols.fipa.serialization import FIPASerializer
+from packages.protocols.oef.message import OEFMessage
+from packages.skills.weather_client.dialogues import Dialogue, Dialogues
+from packages.skills.weather_client.strategy import Strategy
 
 logger = logging.getLogger("aea.weather_client_skill")
 

--- a/packages/skills/weather_client_ledger/behaviours.py
+++ b/packages/skills/weather_client_ledger/behaviours.py
@@ -19,21 +19,14 @@
 
 """This package contains a scaffold of a behaviour."""
 import logging
-import sys
-from typing import cast, TYPE_CHECKING
+from typing import cast
 
 from aea.crypto.ethereum import ETHEREUM
 from aea.crypto.fetchai import FETCHAI
 from aea.skills.behaviours import TickerBehaviour
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.oef.serialization import DEFAULT_OEF, OEFSerializer
-    from packages.skills.weather_client_ledger.strategy import Strategy
-else:
-    from oef_protocol.message import OEFMessage
-    from oef_protocol.serialization import DEFAULT_OEF, OEFSerializer
-    from weather_client_ledger_skill.strategy import Strategy
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.oef.serialization import DEFAULT_OEF, OEFSerializer
+from packages.skills.weather_client_ledger.strategy import Strategy
 
 logger = logging.getLogger("aea.weather_client_ledger_skill")
 

--- a/packages/skills/weather_client_ledger/dialogues.py
+++ b/packages/skills/weather_client_ledger/dialogues.py
@@ -25,17 +25,12 @@ This module contains the classes required for dialogue management.
 - Dialogues: The dialogues class keeps track of all dialogues.
 """
 
-import sys
-from typing import Optional, TYPE_CHECKING
+from typing import Optional
 
 from aea.helpers.dialogue.base import DialogueLabel
 from aea.helpers.search.models import Description
 from aea.skills.base import SharedClass
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.dialogues import FIPADialogues, FIPADialogue
-else:
-    from fipa_protocol.dialogues import FIPADialogues, FIPADialogue
+from packages.protocols.fipa.dialogues import FIPADialogues, FIPADialogue
 
 
 class Dialogue(FIPADialogue):

--- a/packages/skills/weather_client_ledger/handlers.py
+++ b/packages/skills/weather_client_ledger/handlers.py
@@ -20,30 +20,21 @@
 """This package contains a scaffold of a handler."""
 import logging
 import pprint
-import sys
-from typing import Any, Dict, List, Optional, cast, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, cast
 
 from aea.configurations.base import ProtocolId
+from aea.decision_maker.messages.transaction import TransactionMessage
 from aea.helpers.dialogue.base import DialogueLabel
 from aea.helpers.search.models import Description
 from aea.protocols.base import Message
 from aea.protocols.default.message import DefaultMessage
 from aea.protocols.default.serialization import DefaultSerializer
 from aea.skills.base import Handler
-from aea.decision_maker.messages.transaction import TransactionMessage
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.message import FIPAMessage
-    from packages.protocols.fipa.serialization import FIPASerializer
-    from packages.protocols.oef.message import OEFMessage
-    from packages.skills.weather_client_ledger.dialogues import Dialogue, Dialogues
-    from packages.skills.weather_client_ledger.strategy import Strategy
-else:
-    from fipa_protocol.message import FIPAMessage
-    from fipa_protocol.serialization import FIPASerializer
-    from oef_protocol.message import OEFMessage
-    from weather_client_ledger_skill.dialogues import Dialogue, Dialogues
-    from weather_client_ledger_skill.strategy import Strategy
+from packages.protocols.fipa.message import FIPAMessage
+from packages.protocols.fipa.serialization import FIPASerializer
+from packages.protocols.oef.message import OEFMessage
+from packages.skills.weather_client_ledger.dialogues import Dialogue, Dialogues
+from packages.skills.weather_client_ledger.strategy import Strategy
 
 logger = logging.getLogger("aea.weather_client_ledger_skill")
 

--- a/packages/skills/weather_station/behaviours.py
+++ b/packages/skills/weather_station/behaviours.py
@@ -20,20 +20,13 @@
 """This package contains a scaffold of a behaviour."""
 
 import logging
-import sys
-from typing import cast, Optional, TYPE_CHECKING
+from typing import cast, Optional
 
 from aea.helpers.search.models import Description
 from aea.skills.behaviours import TickerBehaviour
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
-    from packages.skills.weather_station.strategy import Strategy
-else:
-    from oef_protocol.message import OEFMessage
-    from oef_protocol.serialization import OEFSerializer, DEFAULT_OEF
-    from weather_station_skill.strategy import Strategy
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
+from packages.skills.weather_station.strategy import Strategy
 
 logger = logging.getLogger("aea.weather_station_skill")
 

--- a/packages/skills/weather_station/dialogues.py
+++ b/packages/skills/weather_station/dialogues.py
@@ -25,17 +25,12 @@ This module contains the classes required for dialogue management.
 - Dialogues: The dialogues class keeps track of all dialogues.
 """
 
-import sys
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Dict, Optional
 
 from aea.helpers.dialogue.base import DialogueLabel
 from aea.helpers.search.models import Description
 from aea.skills.base import SharedClass
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.dialogues import FIPADialogues, FIPADialogue
-else:
-    from fipa_protocol.dialogues import FIPADialogues, FIPADialogue
+from packages.protocols.fipa.dialogues import FIPADialogues, FIPADialogue
 
 
 class Dialogue(FIPADialogue):

--- a/packages/skills/weather_station/handlers.py
+++ b/packages/skills/weather_station/handlers.py
@@ -20,8 +20,7 @@
 """This package contains a scaffold of a handler."""
 
 import logging
-import sys
-from typing import Optional, cast, TYPE_CHECKING
+from typing import Optional, cast
 
 from aea.configurations.base import ProtocolId
 from aea.helpers.search.models import Query
@@ -29,17 +28,10 @@ from aea.protocols.base import Message
 from aea.protocols.default.message import DefaultMessage
 from aea.protocols.default.serialization import DefaultSerializer
 from aea.skills.base import Handler
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.message import FIPAMessage
-    from packages.protocols.fipa.serialization import FIPASerializer
-    from packages.skills.weather_station.dialogues import Dialogue, Dialogues
-    from packages.skills.weather_station.strategy import Strategy
-else:
-    from fipa_protocol.message import FIPAMessage
-    from fipa_protocol.serialization import FIPASerializer
-    from weather_station_skill.dialogues import Dialogue, Dialogues
-    from weather_station_skill.strategy import Strategy
+from packages.protocols.fipa.message import FIPAMessage
+from packages.protocols.fipa.serialization import FIPASerializer
+from packages.skills.weather_station.dialogues import Dialogue, Dialogues
+from packages.skills.weather_station.strategy import Strategy
 
 logger = logging.getLogger("aea.weather_station_skill")
 

--- a/packages/skills/weather_station/strategy.py
+++ b/packages/skills/weather_station/strategy.py
@@ -19,18 +19,12 @@
 
 """This module contains the strategy class."""
 import time
-import sys
-from typing import Any, Dict, List, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Tuple
 
 from aea.helpers.search.models import Description, Query
 from aea.skills.base import SharedClass
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.skills.weather_station.db_communication import DBCommunication
-    from packages.skills.weather_station.weather_station_data_model import WEATHER_STATION_DATAMODEL, SCHEME
-else:
-    from weather_station_skill.db_communication import DBCommunication
-    from weather_station_skill.weather_station_data_model import WEATHER_STATION_DATAMODEL, SCHEME
+from packages.skills.weather_station.db_communication import DBCommunication
+from packages.skills.weather_station.weather_station_data_model import WEATHER_STATION_DATAMODEL, SCHEME
 
 DEFAULT_PRICE_PER_ROW = 2
 DEFAULT_SELLER_TX_FEE = 0

--- a/packages/skills/weather_station_ledger/behaviours.py
+++ b/packages/skills/weather_station_ledger/behaviours.py
@@ -20,22 +20,15 @@
 """This package contains a scaffold of a behaviour."""
 
 import logging
-import sys
-from typing import cast, Optional, TYPE_CHECKING
+from typing import cast, Optional
 
 from aea.crypto.ethereum import ETHEREUM
 from aea.crypto.fetchai import FETCHAI
 from aea.helpers.search.models import Description
 from aea.skills.behaviours import TickerBehaviour
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
-    from packages.skills.weather_station_ledger.strategy import Strategy
-else:
-    from weather_station_ledger_skill.strategy import Strategy
-    from oef_protocol.message import OEFMessage
-    from oef_protocol.serialization import OEFSerializer, DEFAULT_OEF
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
+from packages.skills.weather_station_ledger.strategy import Strategy
 
 logger = logging.getLogger("aea.weather_station_ledger_skill")
 

--- a/packages/skills/weather_station_ledger/dialogues.py
+++ b/packages/skills/weather_station_ledger/dialogues.py
@@ -25,17 +25,12 @@ This module contains the classes required for dialogue management.
 - Dialogues: The dialogues class keeps track of all dialogues.
 """
 
-import sys
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Dict, Optional
 
 from aea.helpers.dialogue.base import DialogueLabel
 from aea.helpers.search.models import Description
 from aea.skills.base import SharedClass
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.dialogues import FIPADialogues, FIPADialogue
-else:
-    from fipa_protocol.dialogues import FIPADialogues, FIPADialogue
+from packages.protocols.fipa.dialogues import FIPADialogues, FIPADialogue
 
 
 class Dialogue(FIPADialogue):

--- a/packages/skills/weather_station_ledger/handlers.py
+++ b/packages/skills/weather_station_ledger/handlers.py
@@ -229,9 +229,9 @@ class FIPAHandler(Handler):
             logger.info("[{}]: checking whether transaction={} has been received ...".format(self.context.agent_name,
                                                                                              tx_digest))
             proposal = cast(Description, dialogue.proposal)
-            total_price = cast(int, proposal.values.get("price"))
             ledger_id = cast(str, proposal.values.get("ledger_id"))
-            is_settled = self.context.ledger_apis.is_tx_settled(ledger_id, tx_digest, total_price)
+            is_settled = self.context.ledger_apis.is_tx_settled(ledger_id, tx_digest)
+            # TODO: check the tx_digest references a transaction with the correct terms
             if is_settled:
                 token_balance = self.context.ledger_apis.token_balance(ledger_id,
                                                                        cast(str, self.context.agent_addresses.get(ledger_id)))

--- a/packages/skills/weather_station_ledger/handlers.py
+++ b/packages/skills/weather_station_ledger/handlers.py
@@ -20,8 +20,7 @@
 """This package contains a scaffold of a handler."""
 
 import logging
-import sys
-from typing import Optional, cast, TYPE_CHECKING
+from typing import Optional, cast
 
 from aea.configurations.base import ProtocolId
 from aea.helpers.search.models import Description, Query
@@ -29,17 +28,10 @@ from aea.protocols.base import Message
 from aea.protocols.default.message import DefaultMessage
 from aea.protocols.default.serialization import DefaultSerializer
 from aea.skills.base import Handler
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.message import FIPAMessage
-    from packages.protocols.fipa.serialization import FIPASerializer
-    from packages.skills.weather_station_ledger.dialogues import Dialogue, Dialogues
-    from packages.skills.weather_station_ledger.strategy import Strategy
-else:
-    from fipa_protocol.message import FIPAMessage
-    from fipa_protocol.serialization import FIPASerializer
-    from weather_station_ledger_skill.dialogues import Dialogue, Dialogues
-    from weather_station_ledger_skill.strategy import Strategy
+from packages.protocols.fipa.message import FIPAMessage
+from packages.protocols.fipa.serialization import FIPASerializer
+from packages.skills.weather_station_ledger.dialogues import Dialogue, Dialogues
+from packages.skills.weather_station_ledger.strategy import Strategy
 
 logger = logging.getLogger("aea.weather_station_ledger_skill")
 

--- a/packages/skills/weather_station_ledger/strategy.py
+++ b/packages/skills/weather_station_ledger/strategy.py
@@ -19,19 +19,13 @@
 
 """This module contains the strategy class."""
 
-import sys
 import time
-from typing import Any, Dict, List, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Tuple
 
 from aea.helpers.search.models import Description, Query
 from aea.skills.base import SharedClass
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.skills.weather_station_ledger.db_communication import DBCommunication
-    from packages.skills.weather_station_ledger.weather_station_data_model import WEATHER_STATION_DATAMODEL, SCHEME
-else:
-    from weather_station_ledger_skill.db_communication import DBCommunication
-    from weather_station_ledger_skill.weather_station_data_model import WEATHER_STATION_DATAMODEL, SCHEME
+from packages.skills.weather_station_ledger.db_communication import DBCommunication
+from packages.skills.weather_station_ledger.weather_station_data_model import WEATHER_STATION_DATAMODEL, SCHEME
 
 DEFAULT_PRICE_PER_ROW = 2
 DEFAULT_SELLER_TX_FEE = 0

--- a/tests/data/aea-config.example_w_keys.yaml
+++ b/tests/data/aea-config.example_w_keys.yaml
@@ -33,10 +33,7 @@ logging_config:
 registry_path: ../../packages
 ledger_apis:
    fetchai:
-     args:
-       addr: example.fetch-ai.com
-       port: 8080
+     addr: example.fetch-ai.com
+     port: 8080
    ethereum:
-     args:
-       address: example.ethereum.com
-       chain_id: 8080
+     addr: example.ethereum.com

--- a/tests/data/dummy_aea/connections/local/connection.py
+++ b/tests/data/dummy_aea/connections/local/connection.py
@@ -23,21 +23,15 @@ import asyncio
 import logging
 from asyncio import Queue, AbstractEventLoop
 from collections import defaultdict
-import sys
 from threading import Thread
-from typing import Dict, List, Optional, Set, cast, TYPE_CHECKING
+from typing import Dict, List, Optional, Set, cast
 
 from aea.configurations.base import ConnectionConfig
 from aea.connections.base import Connection
 from aea.helpers.search.models import Description, Query
 from aea.mail.base import Envelope, AEAConnectionError, Address
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.oef.message import OEFMessage
-    from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
-else:
-    from oef_protocol.message import OEFMessage
-    from oef_protocol.serialization import OEFSerializer, DEFAULT_OEF
+from packages.protocols.oef.message import OEFMessage
+from packages.protocols.oef.serialization import OEFSerializer, DEFAULT_OEF
 
 logger = logging.getLogger(__name__)
 

--- a/tests/data/dummy_aea/protocols/fipa/dialogues.py
+++ b/tests/data/dummy_aea/protocols/fipa/dialogues.py
@@ -27,17 +27,12 @@ This module contains the classes required for FIPA dialogue management.
 """
 
 from enum import Enum
-import sys
-from typing import Dict, Tuple, cast, TYPE_CHECKING
+from typing import Dict, Tuple, cast
 
 from aea.helpers.dialogue.base import DialogueLabel, Dialogue, Dialogues
 from aea.mail.base import Address
 from aea.protocols.base import Message
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa.message import FIPAMessage, VALID_PREVIOUS_PERFORMATIVES
-else:
-    from fipa_protocol.message import FIPAMessage, VALID_PREVIOUS_PERFORMATIVES  # pragma: no cover
+from packages.protocols.fipa.message import FIPAMessage, VALID_PREVIOUS_PERFORMATIVES
 
 
 class FIPADialogue(Dialogue):

--- a/tests/data/dummy_aea/protocols/fipa/serialization.py
+++ b/tests/data/dummy_aea/protocols/fipa/serialization.py
@@ -21,19 +21,13 @@
 """Serialization for the FIPA protocol."""
 import json
 import pickle
-import sys
-from typing import cast, TYPE_CHECKING
+from typing import cast
 
 from aea.helpers.search.models import Description, Query
 from aea.protocols.base import Message
 from aea.protocols.base import Serializer
-
-if TYPE_CHECKING or "pytest" in sys.modules:
-    from packages.protocols.fipa import fipa_pb2
-    from packages.protocols.fipa.message import FIPAMessage
-else:
-    import fipa_protocol.fipa_pb2 as fipa_pb2  # pragma: no cover
-    from fipa_protocol.message import FIPAMessage  # pragma: no cover
+from packages.protocols.fipa import fipa_pb2
+from packages.protocols.fipa.message import FIPAMessage
 
 
 class FIPASerializer(Serializer):

--- a/tests/data/gym-connection.yaml
+++ b/tests/data/gym-connection.yaml
@@ -6,8 +6,8 @@ fingerprint: ""
 description: "The gym connection wraps an OpenAI gym."
 url: ""
 class_name: GymConnection
-protocols: ["gym"]
-restricted_to_protocols: ["gym"]
+protocols: ["fetchai/gym:0.1.0"]
+restricted_to_protocols: ["fetchai/gym:0.1.0"]
 excluded_protocols: []
 config:
   env: 'gyms.env.BanditNArmedRandom'

--- a/tests/test_cli/test_run.py
+++ b/tests/test_cli/test_run.py
@@ -287,9 +287,8 @@ def test_run_unknown_ledger(pytestconfig):
     find_text = "ledger_apis: {}"
     replace_text = """ledger_apis:
     unknown:
-        args:
-            address: https://ropsten.infura.io/v3/f00f7b3ba0e848ddbdc8941c527447fe
-            chain_id: 3"""
+        address: https://ropsten.infura.io/v3/f00f7b3ba0e848ddbdc8941c527447fe
+        chain_id: 3"""
 
     whole_file = whole_file.replace(find_text, replace_text)
 
@@ -513,13 +512,11 @@ def test_run_ledger_apis(pytestconfig):
     find_text = "ledger_apis: {}"
     replace_text = """ledger_apis:
     ethereum:
-        args:
-            address: https://ropsten.infura.io/v3/f00f7b3ba0e848ddbdc8941c527447fe
-            chain_id: 3
+        address: https://ropsten.infura.io/v3/f00f7b3ba0e848ddbdc8941c527447fe
+        chain_id: 3
     fetchai:
-        args:
-            address: alpha.fetch-ai.com
-            port: 80"""
+        address: alpha.fetch-ai.com
+        port: 80"""
 
     whole_file = whole_file.replace(find_text, replace_text)
 
@@ -591,9 +588,8 @@ def test_run_fet_ledger_apis(pytestconfig):
     find_text = "ledger_apis: {}"
     replace_text = """ledger_apis:
     fetchai:
-        args:
-            address: alpha.fetch-ai.com
-            port: 80"""
+        address: alpha.fetch-ai.com
+        port: 80"""
 
     whole_file = whole_file.replace(find_text, replace_text)
 

--- a/tests/test_cli/test_search.py
+++ b/tests/test_cli/test_search.py
@@ -18,11 +18,13 @@
 # ------------------------------------------------------------------------------
 
 """This test module contains the tests for the `aea search` sub-command."""
+import json
 import os
 import shutil
 import tempfile
 from pathlib import Path
 from unittest import mock, TestCase
+
 import jsonschema
 from jsonschema import Draft4Validator
 

--- a/tests/test_configurations/test_schema.py
+++ b/tests/test_configurations/test_schema.py
@@ -131,15 +131,16 @@ class TestConnectionsSchema:
 
     @pytest.mark.parametrize("connection_path",
                              [
-                                 os.path.join(ROOT_DIR, "packages", "connections", "local"),
-                                 os.path.join(ROOT_DIR, "packages", "connections", "oef"),
-                                 os.path.join(ROOT_DIR, "aea", "connections", "scaffold"),
-                                 os.path.join(ROOT_DIR, "packages", "connections", "gym"),
-                                 os.path.join(CUR_PATH, "data", "dummy_connection")
+                                 os.path.join(ROOT_DIR, "packages", "connections", "local", DEFAULT_CONNECTION_CONFIG_FILE),
+                                 os.path.join(ROOT_DIR, "packages", "connections", "oef", DEFAULT_CONNECTION_CONFIG_FILE),
+                                 os.path.join(ROOT_DIR, "aea", "connections", "scaffold", DEFAULT_CONNECTION_CONFIG_FILE),
+                                 os.path.join(ROOT_DIR, "packages", "connections", "gym", DEFAULT_CONNECTION_CONFIG_FILE),
+                                 os.path.join(CUR_PATH, "data", "dummy_connection", DEFAULT_CONNECTION_CONFIG_FILE),
+                                 os.path.join(CUR_PATH, "data", "gym-connection.yaml")
                              ])
     def test_validate_connection_config(self, connection_path):
         """Test that the validation of the protocol configuration file in aea/protocols works correctly."""
-        connection_config_file = yaml.safe_load(open(os.path.join(connection_path, DEFAULT_CONNECTION_CONFIG_FILE)))
+        connection_config_file = yaml.safe_load(open(connection_path))
         self.validator.validate(instance=connection_config_file)
 
 

--- a/tests/test_crypto/test_ledger_apis.py
+++ b/tests/test_crypto/test_ledger_apis.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
@@ -28,8 +27,8 @@ import pytest
 from hexbytes import HexBytes
 
 from aea.crypto.ethereum import ETHEREUM, EthereumCrypto
-from aea.crypto.fetchai import FETCHAI, FetchAICrypto
-from aea.crypto.ledger_apis import LedgerApis, DEFAULT_FETCHAI_CONFIG, \
+from aea.crypto.fetchai import FETCHAI, FetchAICrypto, DEFAULT_FETCHAI_CONFIG
+from aea.crypto.ledger_apis import LedgerApis, \
     _try_to_instantiate_fetchai_ledger_api, \
     _try_to_instantiate_ethereum_ledger_api
 from ..conftest import CUR_PATH
@@ -64,12 +63,12 @@ class TestLedgerApis:
                                  FETCHAI: DEFAULT_FETCHAI_CONFIG}, FETCHAI)
 
         api = ledger_apis.apis[ETHEREUM]
-        with mock.patch.object(api.eth, 'getBalance', return_value=10):
+        with mock.patch.object(api.api.eth, 'getBalance', return_value=10):
             balance = ledger_apis.token_balance(ETHEREUM, eth_address)
             assert balance == 10
             assert ledger_apis.last_tx_statuses[ETHEREUM] == 'OK'
 
-        with mock.patch.object(api.eth, 'getBalance', return_value=0, side_effect=Exception):
+        with mock.patch.object(api.api.eth, 'getBalance', return_value=0, side_effect=Exception):
             balance = ledger_apis.token_balance(ETHEREUM, fet_address)
             assert balance == 0, "This must be 0 since the address is wrong"
             assert ledger_apis.last_tx_statuses[ETHEREUM] == 'ERROR'
@@ -88,12 +87,12 @@ class TestLedgerApis:
                                   FETCHAI: DEFAULT_FETCHAI_CONFIG}, FETCHAI)
 
         api = ledger_apis.apis[FETCHAI]
-        with mock.patch.object(api.tokens, 'balance', return_value=10):
+        with mock.patch.object(api.api.tokens, 'balance', return_value=10):
             balance = ledger_apis.token_balance(FETCHAI, fet_address)
             assert balance == 10
             assert ledger_apis.last_tx_statuses[FETCHAI] == 'OK'
 
-        with mock.patch.object(api.tokens, 'balance', return_value=0, side_effect=Exception):
+        with mock.patch.object(api.api.tokens, 'balance', return_value=0, side_effect=Exception):
             balance = ledger_apis.token_balance(FETCHAI, eth_address)
             assert balance == 0, "This must be 0 since the address is wrong"
             assert ledger_apis.last_tx_statuses[FETCHAI] == 'ERROR'
@@ -105,9 +104,9 @@ class TestLedgerApis:
         ledger_apis = LedgerApis({ETHEREUM: DEFAULT_ETHEREUM_CONFIG,
                                   FETCHAI: DEFAULT_FETCHAI_CONFIG}, FETCHAI)
 
-        with mock.patch.object(ledger_apis.apis.get(FETCHAI).tokens, 'transfer',
+        with mock.patch.object(ledger_apis.apis.get(FETCHAI).api.tokens, 'transfer',
                                return_value="97fcacaaf94b62318c4e4bbf53fd2608c15062f17a6d1bffee0ba7af9b710e35"):
-            with mock.patch.object(ledger_apis.apis.get(FETCHAI), 'sync'):
+            with mock.patch.object(ledger_apis.apis.get(FETCHAI).api, 'sync'):
                 tx_digest = ledger_apis.transfer(fet_obj, fet_address, amount=10, tx_fee=10)
                 assert tx_digest is not None
                 assert ledger_apis.last_tx_statuses[FETCHAI] == 'OK'
@@ -119,9 +118,9 @@ class TestLedgerApis:
         ledger_apis = LedgerApis({ETHEREUM: DEFAULT_ETHEREUM_CONFIG,
                                   FETCHAI: DEFAULT_FETCHAI_CONFIG}, FETCHAI)
 
-        with mock.patch.object(ledger_apis.apis.get(FETCHAI).tokens, 'transfer',
+        with mock.patch.object(ledger_apis.apis.get(FETCHAI).api.tokens, 'transfer',
                                return_value="97fcacaaf94b62318c4e4bbf53fd2608c15062f17a6d1bffee0ba7af9b710e35"):
-            with mock.patch.object(ledger_apis.apis.get(FETCHAI), 'sync', side_effect=Exception):
+            with mock.patch.object(ledger_apis.apis.get(FETCHAI).api, 'sync', side_effect=Exception):
                 tx_digest = ledger_apis.transfer(fet_obj, fet_address, amount=10, tx_fee=10)
                 assert tx_digest is None
                 assert ledger_apis.last_tx_statuses[FETCHAI] == 'ERROR'
@@ -132,13 +131,13 @@ class TestLedgerApis:
         eth_obj = EthereumCrypto(private_key_path=private_key_path)
         ledger_apis = LedgerApis({ETHEREUM: DEFAULT_ETHEREUM_CONFIG,
                                   FETCHAI: DEFAULT_FETCHAI_CONFIG}, FETCHAI)
-        with mock.patch.object(ledger_apis.apis.get(ETHEREUM).eth, 'getTransactionCount', return_value=5):
-            with mock.patch.object(ledger_apis.apis.get(ETHEREUM).eth.account, 'signTransaction',
+        with mock.patch.object(ledger_apis.apis.get(ETHEREUM).api.eth, 'getTransactionCount', return_value=5):
+            with mock.patch.object(ledger_apis.apis.get(ETHEREUM).api.eth.account, 'signTransaction',
                                    return_value=mock.Mock()):
                 result = HexBytes('0xf85f808082c35094d898d5e829717c72e7438bad593076686d7d164a80801ba005c2e99ecee98a12fbf28ab9577423f42e9e88f2291b3acc8228de743884c874a077d6bc77a47ad41ec85c96aac2ad27f05a039c4787fca8a1e5ee2d8c7ec1bb6a')
-                with mock.patch.object(ledger_apis.apis.get(ETHEREUM).eth, 'sendRawTransaction',
+                with mock.patch.object(ledger_apis.apis.get(ETHEREUM).api.eth, 'sendRawTransaction',
                                        return_value=result):
-                    with mock.patch.object(ledger_apis.apis.get(ETHEREUM).eth, "getTransactionReceipt",
+                    with mock.patch.object(ledger_apis.apis.get(ETHEREUM).api.eth, "getTransactionReceipt",
                                            return_value=b'0xa13f2f926233bc4638a20deeb8aaa7e8d6a96e487392fa55823f925220f6efed'):
                         tx_digest = ledger_apis.transfer(eth_obj, eth_address, amount=10, tx_fee=200000)
                         assert tx_digest is not None
@@ -150,7 +149,7 @@ class TestLedgerApis:
         eth_obj = EthereumCrypto(private_key_path=private_key_path)
         ledger_apis = LedgerApis({ETHEREUM: DEFAULT_ETHEREUM_CONFIG,
                                   FETCHAI: DEFAULT_FETCHAI_CONFIG}, FETCHAI)
-        with mock.patch.object(ledger_apis.apis.get(ETHEREUM).eth, 'getTransactionCount', return_value=5, side_effect=Exception):
+        with mock.patch.object(ledger_apis.apis.get(ETHEREUM).api.eth, 'getTransactionCount', return_value=5, side_effect=Exception):
             tx_digest = ledger_apis.transfer(eth_obj, eth_address, amount=10, tx_fee=200000)
             assert tx_digest is None
             assert ledger_apis.last_tx_statuses[ETHEREUM] == 'ERROR'
@@ -161,15 +160,15 @@ class TestLedgerApis:
                                   FETCHAI: DEFAULT_FETCHAI_CONFIG}, FETCHAI)
         tx_digest = "97fcacaaf94b62318c4e4bbf53fd2608c15062f17a6d1bffee0ba7af9b710e35"
         with pytest.raises(AssertionError):
-            ledger_apis.is_tx_settled("Unknown", tx_digest=tx_digest, amount=10)
+            ledger_apis.is_tx_settled("Unknown", tx_digest=tx_digest)
 
-        with mock.patch.object(ledger_apis.apis[FETCHAI].tx, "status", return_value='Submitted'):
-            is_successful = ledger_apis.is_tx_settled(FETCHAI, tx_digest=tx_digest, amount=10)
+        with mock.patch.object(ledger_apis.apis[FETCHAI].api.tx, "status", return_value='Submitted'):
+            is_successful = ledger_apis.is_tx_settled(FETCHAI, tx_digest=tx_digest)
             assert is_successful
             assert ledger_apis.last_tx_statuses[FETCHAI] == 'OK'
 
-        with mock.patch.object(ledger_apis.apis[FETCHAI].tx, "status", side_effect=Exception):
-            is_successful = ledger_apis.is_tx_settled(FETCHAI, tx_digest=tx_digest, amount=10)
+        with mock.patch.object(ledger_apis.apis[FETCHAI].api.tx, "status", side_effect=Exception):
+            is_successful = ledger_apis.is_tx_settled(FETCHAI, tx_digest=tx_digest)
             assert not is_successful
             assert ledger_apis.last_tx_statuses[FETCHAI] == 'ERROR'
 
@@ -180,13 +179,13 @@ class TestLedgerApis:
         tx_digest = "97fcacaaf94b62318c4e4bbf53fd2608c15062f17a6d1bffee0ba7af9b710e35"
         result = HexBytes(
             '0xf85f808082c35094d898d5e829717c72e7438bad593076686d7d164a80801ba005c2e99ecee98a12fbf28ab9577423f42e9e88f2291b3acc8228de743884c874a077d6bc77a47ad41ec85c96aac2ad27f05a039c4787fca8a1e5ee2d8c7ec1bb6a')
-        with mock.patch.object(ledger_apis.apis[ETHEREUM].eth, "getTransactionReceipt", return_value=result):
-            is_successful = ledger_apis.is_tx_settled(ETHEREUM, tx_digest=tx_digest, amount=10)
+        with mock.patch.object(ledger_apis.apis[ETHEREUM].api.eth, "getTransactionReceipt", return_value=result):
+            is_successful = ledger_apis.is_tx_settled(ETHEREUM, tx_digest=tx_digest)
             assert is_successful
             assert ledger_apis.last_tx_statuses[ETHEREUM] == 'OK'
 
-        with mock.patch.object(ledger_apis.apis[ETHEREUM].eth, "getTransactionReceipt", side_effect=Exception):
-            is_successful = ledger_apis.is_tx_settled(ETHEREUM, tx_digest=tx_digest, amount=10)
+        with mock.patch.object(ledger_apis.apis[ETHEREUM].api.eth, "getTransactionReceipt", side_effect=Exception):
+            is_successful = ledger_apis.is_tx_settled(ETHEREUM, tx_digest=tx_digest)
             assert not is_successful
             assert ledger_apis.last_tx_statuses[ETHEREUM] == 'ERROR'
 
@@ -200,8 +199,8 @@ class TestLedgerApis:
 
     def test__try_to_instantiate_ethereum_ledger_api(self):
         """Test the instantiation of the ethereum ledger api."""
-        _try_to_instantiate_ethereum_ledger_api(addr="127.0.0.1", chain_id=80)
+        _try_to_instantiate_ethereum_ledger_api(addr="127.0.0.1")
         from web3 import Web3
         with mock.patch.object(Web3, "__init__", side_effect=Exception):
             with pytest.raises(SystemExit):
-                _try_to_instantiate_ethereum_ledger_api(addr="127.0.0.1", chain_id=80)
+                _try_to_instantiate_ethereum_ledger_api(addr="127.0.0.1")

--- a/tests/test_decision_maker/test_base.py
+++ b/tests/test_decision_maker/test_base.py
@@ -27,7 +27,8 @@ import pytest
 
 import aea
 import aea.decision_maker.base
-from aea.crypto.ledger_apis import LedgerApis, DEFAULT_FETCHAI_CONFIG
+from aea.crypto.fetchai import DEFAULT_FETCHAI_CONFIG
+from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet, FETCHAI
 from aea.decision_maker.base import OwnershipState, Preferences, DecisionMaker
 from aea.decision_maker.messages.base import InternalMessage

--- a/tests/test_packages/test_skills/test_carpark.py
+++ b/tests/test_packages/test_skills/test_carpark.py
@@ -89,10 +89,10 @@ class TestCarPark:
         agent_one_dir_path = os.path.join(self.t, self.agent_name_one)
         os.chdir(agent_one_dir_path)
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "oef"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "fetchai/oef:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "carpark_detection"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "fetchai/carpark_detection:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
         result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "install"], standalone_mode=False)
@@ -132,10 +132,10 @@ class TestCarPark:
         agent_two_dir_path = os.path.join(self.t, self.agent_name_two)
         os.chdir(agent_two_dir_path)
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "oef"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "fetchai/oef:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "carpark_client"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "fetchai/carpark_client:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
         result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "install"], standalone_mode=False)
@@ -151,9 +151,8 @@ class TestCarPark:
         find_text = "ledger_apis: {}"
         replace_text = """ledger_apis:
         fetchai:
-            args:
-                address: alpha.fetch-ai.com
-                port: 80"""
+            address: alpha.fetch-ai.com
+            port: 80"""
 
         whole_file = whole_file.replace(find_text, replace_text)
 

--- a/tests/test_packages/test_skills/test_echo.py
+++ b/tests/test_packages/test_skills/test_echo.py
@@ -76,7 +76,7 @@ class TestEchoSkill:
         yaml.safe_dump(aea_config.json, open(aea_config_path, "w"))
 
         # add skills
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "echo"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "fetchai/echo:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
         # run the agent

--- a/tests/test_packages/test_skills/test_gym.py
+++ b/tests/test_packages/test_skills/test_gym.py
@@ -36,7 +36,7 @@ from ...common.click_testing import CliRunner
 
 from aea.cli import cli
 
-from ...conftest import CLI_LOG_OPTION
+from ...conftest import CLI_LOG_OPTION, ROOT_DIR
 
 
 class TestGymSkill:
@@ -67,9 +67,9 @@ class TestGymSkill:
         os.chdir(agent_dir_path)
 
         # add packages and install dependencies
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "gym"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "fetchai/gym:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "gym"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "fetchai/gym:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
         result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "install"], standalone_mode=False)
         assert result.exit_code == 0
@@ -80,7 +80,7 @@ class TestGymSkill:
         shutil.copytree(gyms_src, gyms_dst)
 
         # change config file of gym connection
-        file_src = os.path.join(self.cwd, 'tests', 'test_packages', 'test_skills', 'data', 'connection.yaml')
+        file_src = os.path.join(ROOT_DIR, 'tests', 'data', 'gym-connection.yaml')
         file_dst = os.path.join(self.t, self.agent_name, 'connections', 'gym', 'connection.yaml')
         shutil.copyfile(file_src, file_dst)
 

--- a/tests/test_packages/test_skills/test_ml_skills.py
+++ b/tests/test_packages/test_skills/test_ml_skills.py
@@ -90,10 +90,10 @@ class TestMLSkills:
         agent_one_dir_path = os.path.join(self.t, self.agent_name_one)
         os.chdir(agent_one_dir_path)
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "oef"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "fetchai/oef:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "ml_data_provider"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "fetchai/ml_data_provider:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
         result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "install"], standalone_mode=False)
@@ -117,10 +117,10 @@ class TestMLSkills:
         agent_two_dir_path = os.path.join(self.t, self.agent_name_two)
         os.chdir(agent_two_dir_path)
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "oef"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "fetchai/oef:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "ml_train"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "fetchai/ml_train:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
         result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "install"], standalone_mode=False)

--- a/tests/test_packages/test_skills/test_weather.py
+++ b/tests/test_packages/test_skills/test_weather.py
@@ -71,10 +71,10 @@ class TestWeatherSkills:
         agent_one_dir_path = os.path.join(self.t, self.agent_name_one)
         os.chdir(agent_one_dir_path)
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "oef"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "fetchai/oef:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "weather_station"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "fetchai/weather_station:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
         result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "install"], standalone_mode=False)
@@ -97,10 +97,10 @@ class TestWeatherSkills:
         agent_two_dir_path = os.path.join(self.t, self.agent_name_two)
         os.chdir(agent_two_dir_path)
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "oef"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "fetchai/oef:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "weather_client"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "fetchai/weather_client:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
         result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "install"], standalone_mode=False)

--- a/tests/test_packages/test_skills/test_weather_ledger.py
+++ b/tests/test_packages/test_skills/test_weather_ledger.py
@@ -89,10 +89,10 @@ class TestWeatherSkillsFetchaiLedger:
         agent_one_dir_path = os.path.join(self.t, self.agent_name_one)
         os.chdir(agent_one_dir_path)
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "oef"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "fetchai/oef:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "weather_station_ledger"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "fetchai/weather_station_ledger:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
         result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "install"], standalone_mode=False)
@@ -116,10 +116,10 @@ class TestWeatherSkillsFetchaiLedger:
         agent_two_dir_path = os.path.join(self.t, self.agent_name_two)
         os.chdir(agent_two_dir_path)
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "oef"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "connection", "fetchai/oef:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "weather_client_ledger"], standalone_mode=False)
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "add", "skill", "fetchai/weather_client_ledger:0.1.0"], standalone_mode=False)
         assert result.exit_code == 0
 
         result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "install"], standalone_mode=False)
@@ -135,9 +135,8 @@ class TestWeatherSkillsFetchaiLedger:
         find_text = "ledger_apis: {}"
         replace_text = """ledger_apis:
         fetchai:
-            args:
-                address: alpha.fetch-ai.com
-                port: 80"""
+            address: alpha.fetch-ai.com
+            port: 80"""
 
         whole_file = whole_file.replace(find_text, replace_text)
 

--- a/tests/test_skills/test_base.py
+++ b/tests/test_skills/test_base.py
@@ -41,13 +41,13 @@ def test_agent_context_ledger_apis():
     private_key_pem_path = os.path.join(CUR_PATH, "data", "priv.pem")
     wallet = Wallet({'default': private_key_pem_path})
     connections = [DummyConnection()]
-    ledger_apis = LedgerApis({"fetchai": ('alpha.fetch-ai.com', 80)}, FETCHAI)
+    ledger_apis = LedgerApis({"fetchai": ['alpha.fetch-ai.com', 80]}, FETCHAI)
     my_aea = AEA("Agent0", connections, wallet, ledger_apis, resources=Resources(str(Path(CUR_PATH, "data", "dummy_aea"))))
 
     assert set(my_aea.context.ledger_apis.apis.keys()) == {"fetchai"}
     fetchai_ledger_api_obj = my_aea.context.ledger_apis.apis["fetchai"]
-    assert fetchai_ledger_api_obj.tokens.host == 'alpha.fetch-ai.com'
-    assert fetchai_ledger_api_obj.tokens.port == 80
+    assert fetchai_ledger_api_obj.api.tokens.host == 'alpha.fetch-ai.com'
+    assert fetchai_ledger_api_obj.api.tokens.port == 80
 
 
 class TestSkillContext:
@@ -59,7 +59,7 @@ class TestSkillContext:
         private_key_pem_path = os.path.join(CUR_PATH, "data", "priv.pem")
         private_key_txt_path = os.path.join(CUR_PATH, "data", "fet_private_key.txt")
         cls.wallet = Wallet({'default': private_key_pem_path, FETCHAI: private_key_txt_path})
-        cls.ledger_apis = LedgerApis({FETCHAI: ("alpha.fetch-ai.com", 80)}, FETCHAI)
+        cls.ledger_apis = LedgerApis({FETCHAI: ["alpha.fetch-ai.com", 80]}, FETCHAI)
         cls.connections = [DummyConnection()]
         cls.my_aea = AEA("Agent0", cls.connections, cls.wallet, cls.ledger_apis, resources=Resources(str(Path(CUR_PATH, "data", "dummy_aea"))))
         cls.skill_context = SkillContext(cls.my_aea.context)
@@ -108,8 +108,8 @@ class TestSkillContext:
         """Test the 'ledger_apis' property."""
         assert isinstance(self.skill_context.ledger_apis, LedgerApis)
         assert set(self.skill_context.ledger_apis.apis.keys()) == {'fetchai'}
-        assert self.skill_context.ledger_apis.apis.get("fetchai").tokens.host == "alpha.fetch-ai.com"
-        assert self.skill_context.ledger_apis.apis.get("fetchai").tokens.port == 80
+        assert self.skill_context.ledger_apis.apis.get("fetchai").api.tokens.host == "alpha.fetch-ai.com"
+        assert self.skill_context.ledger_apis.apis.get("fetchai").api.tokens.port == 80
 
     @classmethod
     def teardown(cls):


### PR DESCRIPTION
## Proposed changes

This PR changes the import path for agent components as described in #541 

E.g. in order to import protocol `default`:

- Current state of the framework
```python
from default_protocol.messages import DefaultMessage
```
- after this PR:
```python
from packages.protocols.default.messages import DefaultMessage
```

## Fixes

Fixes #541 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
