### PR TITLE
Replaces references of owner with author

### DIFF
--- a/aea/cli/add.py
+++ b/aea/cli/add.py
@@ -70,9 +70,9 @@ def _find_connection_locally(ctx, connection_public_id, click_context):
         sys.exit(1)
 
     version = connection_configuration.version
-    owner = connection_configuration.author
-    if connection_public_id.owner != owner or connection_public_id.version != version:
-        logger.error("Cannot find connection with owner and version specified.")
+    author = connection_configuration.author
+    if connection_public_id.author != author or connection_public_id.version != version:
+        logger.error("Cannot find connection with author and version specified.")
         sys.exit(1)
 
     # copy the connection package into the agent's supported connections.
@@ -151,9 +151,9 @@ def _find_protocol_locally(ctx, protocol_public_id):
         sys.exit(1)
 
     version = protocol_configuration.version
-    owner = protocol_configuration.author
-    if protocol_public_id.owner != owner or protocol_public_id.version != version:
-        logger.error("Cannot find protocol with owner and version specified.")
+    author = protocol_configuration.author
+    if protocol_public_id.author != author or protocol_public_id.version != version:
+        logger.error("Cannot find protocol with author and version specified.")
         sys.exit(1)
 
     # copy the protocol package into the agent's supported connections.
@@ -224,9 +224,9 @@ def _find_skill_locally(ctx, skill_public_id, click_context):
         sys.exit(1)
 
     version = skill_configuration.version
-    owner = skill_configuration.author
-    if skill_public_id.owner != owner or skill_public_id.version != version:
-        logger.error("Cannot find skill with owner and version specified.")
+    author = skill_configuration.author
+    if skill_public_id.author != author or skill_public_id.version != version:
+        logger.error("Cannot find skill with author and version specified.")
         sys.exit(1)
 
     # copy the skill package into the agent's supported skills.

--- a/aea/cli/registry/fetch.py
+++ b/aea/cli/registry/fetch.py
@@ -42,8 +42,8 @@ def fetch_agent(public_id: Union[PublicId, str]) -> None:
     """
     if isinstance(public_id, str):
         public_id = PublicId.from_string(public_id)
-    owner, name, version = public_id.owner, public_id.name, public_id.version
-    api_path = '/agents/{}/{}/{}'.format(owner, name, version)
+    author, name, version = public_id.author, public_id.name, public_id.version
+    api_path = '/agents/{}/{}/{}'.format(author, name, version)
     resp = request_api('GET', api_path)
     file_url = resp['file']
 

--- a/aea/cli/registry/push.py
+++ b/aea/cli/registry/push.py
@@ -109,7 +109,7 @@ def _check_package_public_id(source_path, item_type, item_id):
     item_author = config.get("author", "")
     item_name = config.get("name", "")
     item_version = config.get("version", "")
-    if item_id.name != item_name or item_id.owner != item_author or item_id.version != item_version:
+    if item_id.name != item_name or item_id.author != item_author or item_id.version != item_version:
         raise click.ClickException(
             "Version or author do not match. Expected '{}', found '{}'"
             .format(item_id, item_author + "/" + item_name + ":" + item_version)

--- a/aea/cli/registry/utils.py
+++ b/aea/cli/registry/utils.py
@@ -165,10 +165,10 @@ def fetch_package(obj_type: str, public_id: PublicId, cwd: str) -> None:
         public_id=public_id,
         obj_type=obj_type
     ))
-    owner, name, version = public_id.owner, public_id.name, public_id.version
+    author, name, version = public_id.author, public_id.name, public_id.version
     plural_obj_type = obj_type + 's'  # used for API and folder paths
 
-    api_path = '/{}/{}/{}/{}'.format(plural_obj_type, owner, name, version)
+    api_path = '/{}/{}/{}/{}'.format(plural_obj_type, author, name, version)
     resp = request_api('GET', api_path)
     file_url = resp['file']
 

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -125,38 +125,38 @@ class PublicId(object):
     """This class implement a public identifier.
 
     A public identifier is composed of three elements:
-    - owner
+    - author
     - name
     - version
 
     The concatenation of those three elements gives the public identifier:
 
-        owner/name:version
+        author/name:version
 
-    >>> public_id = PublicId("owner", "my_package", "0.1.0")
-    >>> assert public_id.owner == "owner"
+    >>> public_id = PublicId("author", "my_package", "0.1.0")
+    >>> assert public_id.author == "author"
     >>> assert public_id.name == "my_package"
     >>> assert public_id.version == "0.1.0"
-    >>> another_public_id = PublicId("owner", "my_package", "0.1.0")
+    >>> another_public_id = PublicId("author", "my_package", "0.1.0")
     >>> assert hash(public_id) == hash(another_public_id)
     >>> assert public_id == another_public_id
     """
 
-    OWNER_REGEX = r"[a-zA-Z0-9_]*"
+    AUTHOR_REGEX = r"[a-zA-Z0-9_]*"
     PACKAGE_NAME_REGEX = r"[a-zA-Z_][a-zA-Z0-9_]*"
     VERSION_REGEX = r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
-    PUBLIC_ID_REGEX = r"^({})/({}):({})$".format(OWNER_REGEX, PACKAGE_NAME_REGEX, VERSION_REGEX)
+    PUBLIC_ID_REGEX = r"^({})/({}):({})$".format(AUTHOR_REGEX, PACKAGE_NAME_REGEX, VERSION_REGEX)
 
-    def __init__(self, owner: str, name: str, version: str):
+    def __init__(self, author: str, name: str, version: str):
         """Initialize the public identifier."""
-        self._owner = owner
+        self._author = author
         self._name = name
         self._version = version
 
     @property
-    def owner(self):
-        """Get the owner."""
-        return self._owner
+    def author(self):
+        """Get the author."""
+        return self._author
 
     @property
     def name(self):
@@ -173,8 +173,8 @@ class PublicId(object):
         """
         Initialize the public id from the string.
 
-        >>> str(PublicId.from_string("owner/package_name:0.1.0"))
-        'owner/package_name:0.1.0'
+        >>> str(PublicId.from_string("author/package_name:0.1.0"))
+        'author/package_name:0.1.0'
 
         A bad formatted input raises value error:
         >>> PublicId.from_string("bad/formatted:input")
@@ -194,16 +194,16 @@ class PublicId(object):
 
     def __hash__(self):
         """Get the hash."""
-        return hash((self.owner, self.name, self.version))
+        return hash((self.author, self.name, self.version))
 
     def __str__(self):
         """Get the string representation."""
-        return "{owner}/{name}:{version}"\
-            .format(owner=self.owner, name=self.name, version=self.version)
+        return "{author}/{name}:{version}"\
+            .format(author=self.author, name=self.name, version=self.version)
 
     def __eq__(self, other):
         """Compare with another object."""
-        return isinstance(other, PublicId) and self.owner == other.owner and self.name == other.name \
+        return isinstance(other, PublicId) and self.author == other.author and self.name == other.name \
             and self.version == other.version
 
     def __lt__(self, other):

--- a/tests/test_cli/test_add/test_connection.py
+++ b/tests/test_cli/test_add/test_connection.py
@@ -67,7 +67,7 @@ class TestAddConnectionFailsWhenConnectionAlreadyExists:
         self, fetch_package_mock
     ):
         """Test add from registry positive result."""
-        public_id = aea.configurations.base.PublicId("owner", "name", "0.1.0")
+        public_id = aea.configurations.base.PublicId("author", "name", "0.1.0")
         obj_type = 'connection'
         result = self.runner.invoke(
             cli,
@@ -111,7 +111,7 @@ class TestAddConnectionFailsWhenConnectionNotInRegistry:
         cls.agent_name = "myagent"
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
-        cls.connection_id = "owner/unknown_connection:0.1.0"
+        cls.connection_id = "author/unknown_connection:0.1.0"
         cls.connection_name = "unknown_connection"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
         cls.mocked_logger_error = cls.patch.__enter__()
@@ -157,7 +157,7 @@ class TestAddConnectionFailsWhenDifferentPublicId:
         cls.agent_name = "myagent"
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
-        cls.connection_id = "different_owner/local:0.1.0"
+        cls.connection_id = "different_author/local:0.1.0"
         cls.connection_name = "unknown_connection"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
         cls.mocked_logger_error = cls.patch.__enter__()
@@ -177,7 +177,7 @@ class TestAddConnectionFailsWhenDifferentPublicId:
 
     def test_error_message_connection_wrong_public_id(self):
         """Test that the log error message is fixed."""
-        s = "Cannot find connection with owner and version specified."
+        s = "Cannot find connection with author and version specified."
         self.mocked_logger_error.assert_called_once_with(s)
 
     @classmethod
@@ -200,7 +200,7 @@ class TestAddConnectionFailsWhenConfigFileIsNotCompliant:
         cls.agent_name = "myagent"
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
-        cls.connection_id = "owner/local:0.1.0"
+        cls.connection_id = "author/local:0.1.0"
         cls.connection_name = "local"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
         cls.mocked_logger_error = cls.patch.__enter__()

--- a/tests/test_cli/test_add/test_protocol.py
+++ b/tests/test_cli/test_add/test_protocol.py
@@ -76,7 +76,7 @@ class TestAddProtocolFailsWhenProtocolAlreadyExists:
         self, fetch_package_mock
     ):
         """Test add from registry positive result."""
-        public_id = aea.configurations.base.PublicId("owner", "name", "0.1.0")
+        public_id = aea.configurations.base.PublicId("author", "name", "0.1.0")
         obj_type = 'protocol'
         result = self.runner.invoke(
             cli,
@@ -153,7 +153,7 @@ class TestAddProtocolFailsWhenDifferentPublicId:
         cls.agent_name = "myagent"
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
-        cls.protocol_id = "different_owner/default:0.1.0"
+        cls.protocol_id = "different_author/default:0.1.0"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
         cls.mocked_logger_error = cls.patch.__enter__()
 
@@ -172,7 +172,7 @@ class TestAddProtocolFailsWhenDifferentPublicId:
 
     def test_error_message_protocol_wrong_public_id(self):
         """Test that the log error message is fixed."""
-        s = "Cannot find protocol with owner and version specified."
+        s = "Cannot find protocol with author and version specified."
         self.mocked_logger_error.assert_called_once_with(s)
 
     @classmethod

--- a/tests/test_cli/test_add/test_skill.py
+++ b/tests/test_cli/test_add/test_skill.py
@@ -79,7 +79,7 @@ class TestAddSkillFailsWhenSkillAlreadyExists:
         self, fetch_package_mock
     ):
         """Test add from registry positive result."""
-        public_id = aea.configurations.base.PublicId("owner", "name", "0.1.0")
+        public_id = aea.configurations.base.PublicId("author", "name", "0.1.0")
         obj_type = 'skill'
         result = self.runner.invoke(
             cli,
@@ -111,7 +111,7 @@ class TestAddSkillFailsWhenSkillNotInRegistry:
         cls.agent_name = "myagent"
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
-        cls.skill_id = "owner/unknown_skill:0.1.0"
+        cls.skill_id = "author/unknown_skill:0.1.0"
         cls.skill_name = "unknown_skill"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
         cls.mocked_logger_error = cls.patch.__enter__()
@@ -157,7 +157,7 @@ class TestAddProtocolFailsWhenDifferentPublicId:
         cls.agent_name = "myagent"
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
-        cls.skill_id = "different_owner/error:0.1.0"
+        cls.skill_id = "different_author/error:0.1.0"
         cls.skill_name = "unknown_skill"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, 'error')
         cls.mocked_logger_error = cls.patch.__enter__()
@@ -177,7 +177,7 @@ class TestAddProtocolFailsWhenDifferentPublicId:
 
     def test_error_message_protocol_wrong_public_id(self):
         """Test that the log error message is fixed."""
-        s = "Cannot find skill with owner and version specified."
+        s = "Cannot find skill with author and version specified."
         self.mocked_logger_error.assert_called_once_with(s)
 
     @classmethod

--- a/tests/test_cli/test_common.py
+++ b/tests/test_cli/test_common.py
@@ -30,20 +30,20 @@ class FormatItemsTestCase(TestCase):
         """Test format_items positive result."""
         items = [
             {
-                'public_id': 'owner/name:version',
+                'public_id': 'author/name:version',
                 'name': 'obj-name',
                 'description': 'Some description',
-                'author': 'owner',
+                'author': 'author',
                 'version': '1.0'
             }
         ]
         result = format_items(items)
         expected_result = (
             '------------------------------\n'
-            'Public ID: owner/name:version\n'
+            'Public ID: author/name:version\n'
             'Name: obj-name\n'
             'Description: Some description\n'
-            'Author: owner\n'
+            'Author: author\n'
             'Version: 1.0\n'
             '------------------------------\n'
         )
@@ -57,7 +57,7 @@ class FormatSkillsTestCase(TestCase):
         """Test format_skills positive result."""
         items = [
             {
-                'public_id': 'owner/name:version',
+                'public_id': 'author/name:version',
                 'name': 'obj-name',
                 'description': 'Some description',
                 'version': '1.0',
@@ -67,7 +67,7 @@ class FormatSkillsTestCase(TestCase):
         result = format_skills(items)
         expected_result = (
             '------------------------------\n'
-            'Public ID: owner/name:version\n'
+            'Public ID: author/name:version\n'
             'Name: obj-name\n'
             'Description: Some description\n'
             'Protocols: p1 | p2 | p3 | \n'

--- a/tests/test_cli/test_registry/test_fetch.py
+++ b/tests/test_cli/test_registry/test_fetch.py
@@ -56,11 +56,11 @@ class TestFetchAgent(TestCase):
         download_file_mock,
     ):
         """Test for fetch_agent method positive result."""
-        public_id = 'owner/name:0.1.0'
+        public_id = 'author/name:0.1.0'
 
         fetch_agent(public_id)
         request_api_mock.assert_called_with(
-            'GET', '/agents/owner/name/0.1.0'
+            'GET', '/agents/author/name/0.1.0'
         )
         download_file_mock.assert_called_once_with('url', 'cwd')
         extract_mock.assert_called_once_with('filepath', 'cwd/name')
@@ -84,11 +84,11 @@ class TestFetchAgent(TestCase):
         download_file_mock,
     ):
         """Test for fetch_agent method with dependencies positive result."""
-        public_id = 'owner/name:0.1.0'
+        public_id = 'author/name:0.1.0'
 
         fetch_agent(public_id)
         request_api_mock.assert_called_with(
-            'GET', '/agents/owner/name/0.1.0'
+            'GET', '/agents/author/name/0.1.0'
         )
         download_file_mock.assert_called_once_with('url', 'cwd')
         extract_mock.assert_called_once_with('filepath', 'cwd/name')
@@ -114,13 +114,13 @@ class TestFetchAgent(TestCase):
         extract_mock,
     ):
         """Test for fetch_agent method positive result."""
-        public_id = 'owner/name:0.1.0'
+        public_id = 'author/name:0.1.0'
 
         with self.assertRaises(ClickException):
             fetch_agent(public_id)
 
         request_api_mock.assert_called_with(
-            'GET', '/agents/owner/name/0.1.0'
+            'GET', '/agents/author/name/0.1.0'
         )
         extract_mock.assert_not_called()
         fetch_package_mock.assert_called_once()
@@ -162,5 +162,5 @@ class FetchAgentLocallyTestCase(TestCase):
         copy_tree
     ):
         """Test for fetch_agent_locally method positive result."""
-        fetch_agent_locally('owner/name:1.0.0')
+        fetch_agent_locally('author/name:1.0.0')
         copy_tree.assert_called_once_with('path', 'joined-path')

--- a/tests/test_cli/test_registry/test_utils.py
+++ b/tests/test_cli/test_registry/test_utils.py
@@ -55,12 +55,12 @@ class TestFetchPackage:
     ):
         """Test for fetch_package method positive result."""
         obj_type = 'connection'
-        public_id = PublicId.from_string('owner/name:0.1.0')
+        public_id = PublicId.from_string('author/name:0.1.0')
         cwd = 'cwd'
 
         fetch_package(obj_type, public_id, cwd)
         request_api_mock.assert_called_with(
-            'GET', '/connections/owner/name/0.1.0'
+            'GET', '/connections/author/name/0.1.0'
         )
         download_file_mock.assert_called_once_with('url', 'cwd')
         extract_mock.assert_called_once_with('filepath', 'cwd/connections')

--- a/tests/test_gui/test_add.py
+++ b/tests/test_gui/test_add.py
@@ -34,7 +34,7 @@ def test_add_item():
     app = create_app()
 
     agent_name = "test_agent_id"
-    connection_id = "owner/test_connection:0.1.0"
+    connection_id = "author/test_connection:0.1.0"
 
     def _dummy_call_aea(param_list, dir):
         assert param_list[0] == sys.executable
@@ -65,7 +65,7 @@ def test_delete_agent_fail():
     app = create_app()
 
     agent_name = "test_agent_id"
-    connection_id = "owner/test_connection:0.1.0"
+    connection_id = "author/test_connection:0.1.0"
 
     def _dummy_call_aea(param_list, dir):
         assert param_list[0] == sys.executable

--- a/tests/test_gui/test_run_agent.py
+++ b/tests/test_gui/test_run_agent.py
@@ -74,7 +74,7 @@ def test_create_and_run_agent():
         response_run = app.post(
             'api/agent/' + agent_id + "/run",
             content_type='application/json',
-            data=json.dumps("owner/non-existent-connection:0.1.0")
+            data=json.dumps("author/non-existent-connection:0.1.0")
         )
         assert response_run.status_code == 400
 


### PR DESCRIPTION
## Proposed changes

This PR fixes some issues around inconsistent `author` vs `owner` usage. It replaces all occurrences of `owner` with `author` in the codebase.

## Fixes

It addresses #568 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

-