### PR TITLE
fix import of agent components.

### DIFF
--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -35,7 +35,7 @@ from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, AgentConfig, SkillC
     DEFAULT_PROTOCOL_CONFIG_FILE, DEFAULT_CONNECTION_CONFIG_FILE, DEFAULT_SKILL_CONFIG_FILE, Dependencies, PublicId
 from aea.configurations.loader import ConfigLoader
 from aea.crypto.fetchai import FETCHAI
-from aea.helpers.base import load_module, add_agent_component_module_to_sys_modules
+from aea.helpers.base import add_agent_component_module_to_sys_modules, load_agent_component_package
 
 logger = logging.getLogger("aea")
 logger = default_logging_config(logger)
@@ -126,7 +126,7 @@ def _try_to_load_protocols(ctx: Context):
             sys.exit(1)
 
         try:
-            protocol_package = load_module(protocol_name, Path("protocols", protocol_name, "__init__.py"))
+            protocol_package = load_agent_component_package("protocol", protocol_name)
             add_agent_component_module_to_sys_modules("protocol", protocol_name, protocol_package)
         except Exception:
             logger.error("A problem occurred while processing protocol {}.".format(protocol_public_id))

--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -126,7 +126,7 @@ def _try_to_load_protocols(ctx: Context):
             sys.exit(1)
 
         try:
-            protocol_package = load_agent_component_package("protocol", protocol_name)
+            protocol_package = load_agent_component_package("protocol", protocol_name, Path("protocols", protocol_name))
             add_agent_component_module_to_sys_modules("protocol", protocol_name, protocol_package)
         except Exception:
             logger.error("A problem occurred while processing protocol {}.".format(protocol_public_id))

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -44,7 +44,7 @@ from aea.crypto.helpers import _create_default_private_key, _create_fetchai_priv
 from aea.crypto.ledger_apis import LedgerApis, _try_to_instantiate_fetchai_ledger_api, \
     _try_to_instantiate_ethereum_ledger_api, SUPPORTED_LEDGER_APIS
 from aea.crypto.wallet import Wallet, DEFAULT, SUPPORTED_CRYPTOS
-from aea.helpers.base import load_module, add_agent_component_module_to_sys_modules
+from aea.helpers.base import load_module, add_agent_component_module_to_sys_modules, load_agent_component_package
 from aea.registries.base import Resources
 
 
@@ -155,11 +155,12 @@ def _setup_connection(connection_name: str, address: str, ctx: Context) -> Conne
         raise AEAConfigException("Connection config for '{}' not found.".format(connection_name))
 
     try:
-        connection_module = load_module(connection_name, Path("connections", connection_name, "connection.py"))
-        add_agent_component_module_to_sys_modules("connection", connection_name, connection_module)
+        connection_package = load_agent_component_package("connection", connection_name)
+        add_agent_component_module_to_sys_modules("connection", connection_name, connection_package)
     except FileNotFoundError:
         raise AEAConfigException("Connection '{}' not found.".format(connection_name))
 
+    connection_module = load_module("connection_module", Path("connections", connection_name, "connection.py"))
     classes = inspect.getmembers(connection_module, inspect.isclass)
     connection_classes = list(filter(lambda x: re.match("\\w+Connection", x[0]), classes))
     name_to_class = dict(connection_classes)

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -154,13 +154,13 @@ def _setup_connection(connection_name: str, address: str, ctx: Context) -> Conne
     except FileNotFoundError:
         raise AEAConfigException("Connection config for '{}' not found.".format(connection_name))
 
+    connection_package = load_agent_component_package("connection", connection_name, Path("connections", connection_name))
+    add_agent_component_module_to_sys_modules("connection", connection_name, connection_package)
     try:
-        connection_package = load_agent_component_package("connection", connection_name)
-        add_agent_component_module_to_sys_modules("connection", connection_name, connection_package)
+        connection_module = load_module("connection_module", Path("connections", connection_name, "connection.py"))
     except FileNotFoundError:
         raise AEAConfigException("Connection '{}' not found.".format(connection_name))
 
-    connection_module = load_module("connection_module", Path("connections", connection_name, "connection.py"))
     classes = inspect.getmembers(connection_module, inspect.isclass)
     connection_classes = list(filter(lambda x: re.match("\\w+Connection", x[0]), classes))
     name_to_class = dict(connection_classes)

--- a/aea/helpers/base.py
+++ b/aea/helpers/base.py
@@ -96,24 +96,25 @@ def add_module_to_sys_modules(dotted_path: str, module_obj) -> None:
     :param dotted_path: the dotted path to be used in the imports.
     :param module_obj: the module object. It is assumed it has been already executed.
     :return: None
-    :raises ValueError: if the dotted path is already used.
+    :raises ValueError: if the dotted path is already used. # TODO this cannot be done atm.
     """
-    if dotted_path in sys.modules:
-        raise ValueError("The dotted path {} is already used.".format(dotted_path))
+    # if dotted_path in sys.modules:
+    #     raise ValueError("The dotted path {} is already used.".format(dotted_path))
     sys.modules[dotted_path] = module_obj
 
 
-def load_agent_component_package(item_type: str, item_name: str):
+def load_agent_component_package(item_type: str, item_name: str, directory: os.PathLike):
     """
     Load a Python package associated to .
 
     :param item_type: the type of the item. One of "protocol", "connection", "skill"
     :param item_name: the name of the item to load
+    :param directory: the component directory.
     :return: the module associated to the Python package of the component.
     """
     item_type_plural = item_type + "s"
     dotted_path = "packages.{}.{}".format(item_type_plural, item_name)
-    filepath = Path(item_type_plural, item_name, "__init__.py")
+    filepath = Path(directory) / "__init__.py"
     return load_module(dotted_path, filepath)
 
 

--- a/aea/helpers/base.py
+++ b/aea/helpers/base.py
@@ -24,6 +24,7 @@ import importlib.util
 import logging
 import os
 import sys
+from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -72,27 +73,62 @@ def locate(path):
     return object
 
 
-def load_module(name: str, filepath: os.PathLike):
+def load_module(dotted_path: str, filepath: os.PathLike):
     """
     Load a module.
 
-    :param name: the name of the package/module.
+    :param dotted_path: the dotted path of the package/module.
     :param filepath: the file to the package/module.
     :return: None
     :raises ValueError: if the filepath provided is not a module.
     :raises Exception: if the execution of the module raises exception.
     """
-    spec = importlib.util.spec_from_file_location(name, filepath)
+    spec = importlib.util.spec_from_file_location(dotted_path, filepath)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)  # type: ignore
     return module
 
 
-def add_agent_component_module_to_sys_modules(item_type: str, item_name: str, module_obj):
-    """Add an agent component module to sys.modules."""
+def add_module_to_sys_modules(dotted_path: str, module_obj) -> None:
+    """
+    Add module to sys.modules.
+
+    :param dotted_path: the dotted path to be used in the imports.
+    :param module_obj: the module object. It is assumed it has been already executed.
+    :return: None
+    :raises ValueError: if the dotted path is already used.
+    """
+    if dotted_path in sys.modules:
+        raise ValueError("The dotted path {} is already used.".format(dotted_path))
+    sys.modules[dotted_path] = module_obj
+
+
+def load_agent_component_package(item_type: str, item_name: str):
+    """
+    Load a Python package associated to .
+
+    :param item_type: the type of the item. One of "protocol", "connection", "skill"
+    :param item_name: the name of the item to load
+    :return: the module associated to the Python package of the component.
+    """
     item_type_plural = item_type + "s"
     dotted_path = "packages.{}.{}".format(item_type_plural, item_name)
-    sys.modules[dotted_path] = module_obj
+    filepath = Path(item_type_plural, item_name, "__init__.py")
+    return load_module(dotted_path, filepath)
+
+
+def add_agent_component_module_to_sys_modules(item_type: str, item_name: str, module_obj) -> None:
+    """
+    Add an agent component module to sys.modules.
+
+    :param item_type: the type of the item. One of "protocol", "connection", "skill"
+    :param item_name: the name of the item to load
+    :param module_obj: the module object. It is assumed it has been already executed.
+    :return:
+    """
+    item_type_plural = item_type + "s"
+    dotted_path = "packages.{}.{}".format(item_type_plural, item_name)
+    add_module_to_sys_modules(dotted_path, module_obj)
 
 
 def generate_fingerprint(author: str, package_name: str, version: str, nonce: Optional[int] = None) -> str:

--- a/aea/helpers/base.py
+++ b/aea/helpers/base.py
@@ -96,10 +96,7 @@ def add_module_to_sys_modules(dotted_path: str, module_obj) -> None:
     :param dotted_path: the dotted path to be used in the imports.
     :param module_obj: the module object. It is assumed it has been already executed.
     :return: None
-    :raises ValueError: if the dotted path is already used. # TODO this cannot be done atm.
     """
-    # if dotted_path in sys.modules:
-    #     raise ValueError("The dotted path {} is already used.".format(dotted_path))
     sys.modules[dotted_path] = module_obj
 
 

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -35,7 +35,7 @@ from aea.connections.base import ConnectionStatus
 from aea.context.base import AgentContext
 from aea.crypto.ledger_apis import LedgerApis
 from aea.decision_maker.base import OwnershipState, Preferences, GoalPursuitReadiness
-from aea.helpers.base import load_module, add_agent_component_module_to_sys_modules
+from aea.helpers.base import load_module, add_agent_component_module_to_sys_modules, load_agent_component_package
 from aea.mail.base import OutBox
 from aea.protocols.base import Message
 
@@ -521,7 +521,7 @@ class Skill:
         # check if there is the config file. If not, then return None.
         skill_loader = ConfigLoader("skill-config_schema.json", SkillConfig)
         skill_config = skill_loader.load(open(os.path.join(directory, DEFAULT_SKILL_CONFIG_FILE)))
-        skill_module = load_module(skill_config.name, Path(os.path.join(directory, "__init__.py")))
+        skill_module = load_agent_component_package("skill", skill_config.name)
         add_agent_component_module_to_sys_modules("skill", skill_config.name, skill_module)
         loader_contents = [path.name for path in Path(directory).iterdir()]
         skills_packages = list(filter(lambda x: not x.startswith("__"), loader_contents))  # type: ignore

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -513,7 +513,7 @@ class Skill:
         """
         Load a skill from a directory.
 
-        :param directory: the skill
+        :param directory: the skill directory.
         :param agent_context: the agent's context
         :return: the Skill object.
         :raises Exception: if the parsing failed.
@@ -521,7 +521,7 @@ class Skill:
         # check if there is the config file. If not, then return None.
         skill_loader = ConfigLoader("skill-config_schema.json", SkillConfig)
         skill_config = skill_loader.load(open(os.path.join(directory, DEFAULT_SKILL_CONFIG_FILE)))
-        skill_module = load_agent_component_package("skill", skill_config.name)
+        skill_module = load_agent_component_package("skill", skill_config.name, Path(directory))
         add_agent_component_module_to_sys_modules("skill", skill_config.name, skill_module)
         loader_contents = [path.name for path in Path(directory).iterdir()]
         skills_packages = list(filter(lambda x: not x.startswith("__"), loader_contents))  # type: ignore


### PR DESCRIPTION
## Proposed changes

This PR fixes some issues of the import system for agent components.
In particular:
- uses the right dotted path (e.g. `packages.protocols.fipa`) for imports.
- make the framework to import the whole connection package, and not only the `connection.py` module.

## Fixes

None

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
