### PR TITLE
Handle exceptions when calling 'teardown' of skill components.

### DIFF
--- a/aea/registries/base.py
+++ b/aea/registries/base.py
@@ -299,10 +299,9 @@ class HandlerRegistry(Registry):
 
         :return: None
         """
-        if self._handlers.values() is not None:
-            for skill_id_to_handler_dict in self._handlers.values():
-                for handler in skill_id_to_handler_dict.values():
-                    handler.setup()
+        for skill_id_to_handler_dict in self._handlers.values():
+            for handler in skill_id_to_handler_dict.values():
+                handler.setup()
 
     def teardown(self) -> None:
         """
@@ -310,10 +309,13 @@ class HandlerRegistry(Registry):
 
         :return: None
         """
-        if self._handlers.values() is not None:
-            for skill_id_to_handler_dict in self._handlers.values():
-                for handler in skill_id_to_handler_dict.values():
+        for skill_id_to_handler_dict in self._handlers.values():
+            for skill_id, handler in skill_id_to_handler_dict.items():
+                try:
                     handler.teardown()
+                except Exception as e:
+                    logger.warning("An error occurred while tearing down handler {}/{}: {}"
+                                   .format(skill_id, type(handler).__name__, str(e)))
         self._handlers = {}
 
 
@@ -378,9 +380,13 @@ class BehaviourRegistry(Registry):
 
         :return: None
         """
-        for behaviours in self._behaviours.values():
+        for skill_id, behaviours in self._behaviours.items():
             for behaviour in behaviours:
-                behaviour.teardown()
+                try:
+                    behaviour.teardown()
+                except Exception as e:
+                    logger.warning("An error occurred while tearing down behaviour {}/{}: {}"
+                                   .format(skill_id, type(behaviour).__name__, str(e)))
         self._behaviours = {}
 
 
@@ -449,9 +455,13 @@ class TaskRegistry(Registry):
 
         :return: None
         """
-        for tasks in self._tasks.values():
+        for skill_id, tasks in self._tasks.items():
             for task in tasks:
-                task.teardown()
+                try:
+                    task.teardown()
+                except Exception as e:
+                    logger.warning("An error occurred while tearing down task {}/{}: {}"
+                                   .format(skill_id, type(task).__name__, str(e)))
         self._tasks = {}
 
 

--- a/aea/skills/tasks.py
+++ b/aea/skills/tasks.py
@@ -80,7 +80,10 @@ class TaskManager:
     def stop(self) -> None:
         """Stop the task manager."""
         with self.lock:
-            logger.debug("Start the task manager.")
+            if self.stopped is True:
+                return
+            logger.debug("Stop the task manager.")
             self.stopped = True
             self.task_queue.put(None)
             self.thread.join()
+            self.thread = Thread(target=self.dispatch)


### PR DESCRIPTION
## Proposed changes

Handle exception when calling the `teardown` of skill components by logging the exception message with warning level.
This should make the interruption of an agent cleaner, avoiding problems such as the process "hanging" because during the agent teardown the framework couldn't stop a skill component.

In the future, such behaviour can be customized. For instance, do not filter out such errors for some critical components where the fails in the teardown cannot be ignored.

## Fixes


## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
