### PR TITLE
AEA-267 fix programmatic guide, add programmatic mode flag to aea/agent

### DIFF
--- a/aea/aea.py
+++ b/aea/aea.py
@@ -48,7 +48,7 @@ class AEA(Agent):
                  loop: Optional[AbstractEventLoop] = None,
                  timeout: float = 0.0,
                  debug: bool = False,
-                 programmatic: bool = False,
+                 programmatic: bool = True,
                  max_reactions: int = 20,
                  executor: Optional[Executor] = None) -> None:
         """

--- a/aea/aea.py
+++ b/aea/aea.py
@@ -48,6 +48,7 @@ class AEA(Agent):
                  loop: Optional[AbstractEventLoop] = None,
                  timeout: float = 0.0,
                  debug: bool = False,
+                 programmatic: bool = False,
                  max_reactions: int = 20,
                  executor: Optional[Executor] = None) -> None:
         """
@@ -61,12 +62,13 @@ class AEA(Agent):
         :param resources: the resources of the agent.
         :param timeout: the time in (fractions of) seconds to time out an agent between act and react
         :param debug: if True, run the agent in debug mode.
+        :param programmatic: if True, run the agent in programmatic mode (skips loading of resources from directory).
         :param max_reactions: the processing rate of messages per iteration.
         :param executor: executor for asynchronous execution of tasks.
 
         :return: None
         """
-        super().__init__(name=name, wallet=wallet, connections=connections, loop=loop, timeout=timeout, debug=debug)
+        super().__init__(name=name, wallet=wallet, connections=connections, loop=loop, timeout=timeout, debug=debug, programmatic=programmatic)
 
         self.max_reactions = max_reactions
         self._task_manager = TaskManager(executor)
@@ -125,7 +127,8 @@ class AEA(Agent):
 
         :return: None
         """
-        self.resources.load(self.context)
+        if not self.programmatic:
+            self.resources.load(self.context)
         self.resources.setup()
         self.task_manager.start()
 

--- a/aea/agent.py
+++ b/aea/agent.py
@@ -63,7 +63,8 @@ class Agent(ABC):
                  wallet: Wallet,
                  loop: Optional[AbstractEventLoop] = None,
                  timeout: float = 1.0,
-                 debug: bool = False) -> None:
+                 debug: bool = False,
+                 programmatic: bool = False) -> None:
         """
         Instantiate the agent.
 
@@ -73,6 +74,7 @@ class Agent(ABC):
         :param loop: the event loop to run the connections.
         :param timeout: the time in (fractions of) seconds to time out an agent between act and react
         :param debug: if True, run the agent in debug mode.
+        :param programmatic: if True, run the agent in programmatic mode (skips loading of resources from directory).
 
         :return: None
         """
@@ -87,6 +89,7 @@ class Agent(ABC):
         self._timeout = timeout
 
         self.debug = debug
+        self.programmatic = programmatic
 
     @property
     def multiplexer(self) -> Multiplexer:

--- a/aea/agent.py
+++ b/aea/agent.py
@@ -64,7 +64,7 @@ class Agent(ABC):
                  loop: Optional[AbstractEventLoop] = None,
                  timeout: float = 1.0,
                  debug: bool = False,
-                 programmatic: bool = False) -> None:
+                 programmatic: bool = True) -> None:
         """
         Instantiate the agent.
 

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -216,7 +216,7 @@ def run(click_context, connection_names: List[str], env_file: str, install_deps:
         else:
             click_context.invoke(install)
 
-    agent = AEA(agent_name, connections, wallet, ledger_apis, resources=Resources(str(Path("."))))
+    agent = AEA(agent_name, connections, wallet, ledger_apis, resources=Resources(str(Path("."))), programmatic=False)
     try:
         agent.start()
     except KeyboardInterrupt:

--- a/docs/hacking-an-agent.md
+++ b/docs/hacking-an-agent.md
@@ -33,6 +33,7 @@ from aea.aea import AEA
 from aea import AEA_DIR
 from aea.skills.base import Skill
 from aea.connections.stub.connection import StubConnection
+from aea.crypto.default import DEFAULT
 from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet
 from aea.protocols.default.serialization import DefaultSerializer
@@ -64,28 +65,28 @@ We use the private key file we created to initialise a wallet, we also create th
 Then we pass all of this into the AEA constructor to create our agent.
 ``` python
 # Set up the wallet, stub connection, ledger and (empty) resources
-wallet = Wallet({'default': 'my_key.txt'})
+wallet = Wallet({DEFAULT: 'my_key.txt'})
 stub_connection = StubConnection(input_file_path=input_filename, output_file_path=output_filename)
-ledger_apis = LedgerApis({})
-resources = Resources('')
+ledger_apis = LedgerApis({}, DEFAULT)
+resources = Resources()
 
 # Create our AEA
-my_agent = AEA("my_agent", [stub_connection], wallet, ledger_apis, resources)
+my_agent = AEA("my_agent", [stub_connection], wallet, ledger_apis, resources, programmatic=True)
 ```
 
-Create the default protocol and add it to the agent
+Create the default protocol and add it to the agent.
 ``` python
-# Add the default protocol
+# Add the default protocol (which is part of the AEA distribution)
 default_protocol_configuration = ProtocolConfig.from_json(
     yaml.safe_load(open(os.path.join(AEA_DIR, "protocols", "default", "protocol.yaml"))))
 default_protocol = Protocol("default", DefaultSerializer(), default_protocol_configuration)
 resources.protocol_registry.register(("default", None), default_protocol)
 ```
 
-Create the error skill (needed by all agents) and the echo skill which will bounce our messages back to us
+Create the error skill (needed by all agents) and the echo skill which will bounce our messages back to us, and add them both to the agent.
 ``` python
-# Add the error skill and the echo skill
-echo_skill = Skill.from_dir(os.path.join(root_dir, "packages", "skills", "echo"), my_agent.context)
+# Add the error skill (from the local packages dir) and the echo skill (which is part of the AEA distribution)
+echo_skill = Skill.from_dir(os.path.join(root_dir, "packages", "fetchai", "skills", "echo"), my_agent.context)
 resources.add_skill(echo_skill)
 error_skill = Skill.from_dir(os.path.join(AEA_DIR, "skills", "error"), my_agent.context)
 resources.add_skill(error_skill)
@@ -130,8 +131,6 @@ t.join()
 ## Running the agent
 If you now run this python script file, you should see this output:
 
-    No protocol found.
-    No skill found.
     input message: my_agent,other_agent,default,{"type": "bytes", "content": "aGVsbG8="}
     output message: other_agent,my_agent,default,{"type": "bytes", "content": "aGVsbG8="}
 
@@ -152,6 +151,7 @@ from aea.aea import AEA
 from aea import AEA_DIR
 from aea.skills.base import Skill
 from aea.connections.stub.connection import StubConnection
+from aea.crypto.default import DEFAULT
 from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet
 from aea.protocols.default.serialization import DefaultSerializer
@@ -170,22 +170,22 @@ if os.path.isfile(output_filename):
     os.remove(output_filename)
 
 # set up the Wallet, stub connection, ledger and (empty) resources
-wallet = Wallet({'default': 'my_key.txt'})
+wallet = Wallet({DEFAULT: 'my_key.txt'})
 stub_connection = StubConnection(input_file_path=input_filename, output_file_path=output_filename)
-ledger_apis = LedgerApis({}, 'default')
-resources = Resources('')
+ledger_apis = LedgerApis({}, DEFAULT)
+resources = Resources()
 
 # Create our AEA
-my_agent = AEA("my_agent", [stub_connection], wallet, ledger_apis, resources)
+my_agent = AEA("my_agent", [stub_connection], wallet, ledger_apis, resources, programmatic=True)
 
-# Add the default protocol
+# Add the default protocol (which is part of the AEA distribution)
 default_protocol_configuration = ProtocolConfig.from_json(
     yaml.safe_load(open(os.path.join(AEA_DIR, "protocols", "default", "protocol.yaml"))))
 default_protocol = Protocol("default", DefaultSerializer(), default_protocol_configuration)
 resources.protocol_registry.register(("default", None), default_protocol)
 
-# Add the error skill and the echo skill
-echo_skill = Skill.from_dir(os.path.join(root_dir, "packages", "skills", "echo"), my_agent.context)
+# Add the error skill (from the local packages dir) and the echo skill (which is part of the AEA distribution)
+echo_skill = Skill.from_dir(os.path.join(root_dir, "packages", "fetchai", "skills", "echo"), my_agent.context)
 resources.add_skill(echo_skill)
 error_skill = Skill.from_dir(os.path.join(AEA_DIR, "skills", "error"), my_agent.context)
 resources.add_skill(error_skill)

--- a/docs/hacking-an-agent.md
+++ b/docs/hacking-an-agent.md
@@ -176,7 +176,7 @@ ledger_apis = LedgerApis({}, DEFAULT)
 resources = Resources()
 
 # Create our AEA
-my_agent = AEA("my_agent", [stub_connection], wallet, ledger_apis, resources, programmatic=True)
+my_agent = AEA("my_agent", [stub_connection], wallet, ledger_apis, resources)
 
 # Add the default protocol (which is part of the AEA distribution)
 default_protocol_configuration = ProtocolConfig.from_json(

--- a/docs/hacking-an-agent.md
+++ b/docs/hacking-an-agent.md
@@ -71,7 +71,7 @@ ledger_apis = LedgerApis({}, DEFAULT)
 resources = Resources()
 
 # Create our AEA
-my_agent = AEA("my_agent", [stub_connection], wallet, ledger_apis, resources, programmatic=True)
+my_agent = AEA("my_agent", [stub_connection], wallet, ledger_apis, resources)
 ```
 
 Create the default protocol and add it to the agent.

--- a/tests/test_aea.py
+++ b/tests/test_aea.py
@@ -73,13 +73,15 @@ def test_act():
         ledger_apis = LedgerApis({}, 'default')
         address = wallet.addresses['default']
         connections = [OEFLocalConnection(address, node)]
+        resources = Resources(str(Path(CUR_PATH, "data", "dummy_aea")))
 
         agent = AEA(
             agent_name,
             connections,
             wallet,
             ledger_apis,
-            resources=Resources(str(Path(CUR_PATH, "data", "dummy_aea"))))
+            resources,
+            programmatic=False)
         t = Thread(target=agent.start)
         try:
             t.start()
@@ -102,6 +104,7 @@ def test_react():
         address = wallet.addresses['default']
         connection = OEFLocalConnection(address, node)
         connections = [connection]
+        resources = Resources(str(Path(CUR_PATH, "data", "dummy_aea")))
 
         msg = DefaultMessage(type=DefaultMessage.Type.BYTES, content=b"hello")
         msg.counterparty = address
@@ -118,7 +121,8 @@ def test_react():
             connections,
             wallet,
             ledger_apis,
-            resources=Resources(str(Path(CUR_PATH, "data", "dummy_aea"))))
+            resources,
+            programmatic=False)
         t = Thread(target=agent.start)
         try:
             t.start()
@@ -146,6 +150,7 @@ async def test_handle():
         address = wallet.addresses['default']
         connection = OEFLocalConnection(address, node)
         connections = [connection]
+        resources = Resources(str(Path(CUR_PATH, "data", "dummy_aea")))
 
         msg = DefaultMessage(type=DefaultMessage.Type.BYTES, content=b"hello")
         msg.counterparty = agent_name
@@ -162,7 +167,8 @@ async def test_handle():
             connections,
             wallet,
             ledger_apis,
-            resources=Resources(str(Path(CUR_PATH, "data", "dummy_aea"))))
+            resources,
+            programmatic=False)
         t = Thread(target=agent.start)
         try:
             t.start()
@@ -224,7 +230,7 @@ class TestInitializeAEAProgrammaticallyFromResourcesDir:
         cls.connections = [cls.connection]
 
         cls.resources = Resources(os.path.join(CUR_PATH, "data", "dummy_aea"))
-        cls.aea = AEA(cls.agent_name, cls.connections, cls.wallet, cls.ledger_apis, cls.resources)
+        cls.aea = AEA(cls.agent_name, cls.connections, cls.wallet, cls.ledger_apis, cls.resources, programmatic=False)
 
         cls.expected_message = DefaultMessage(type=DefaultMessage.Type.BYTES, content=b"hello")
         cls.expected_message.counterparty = cls.agent_name
@@ -277,7 +283,7 @@ class TestInitializeAEAProgrammaticallyBuildResources:
 
         cls.temp = tempfile.mkdtemp(prefix="test_aea_resources")
         cls.resources = Resources(cls.temp)
-        cls.aea = AEA(cls.agent_name, cls.connections, cls.wallet, cls.ledger_apis, resources=cls.resources, programmatic=True)
+        cls.aea = AEA(cls.agent_name, cls.connections, cls.wallet, cls.ledger_apis, resources=cls.resources)
 
         cls.default_protocol_configuration = ProtocolConfig.from_json(
             yaml.safe_load(open(Path(AEA_DIR, "protocols", "default", "protocol.yaml"))))

--- a/tests/test_aea.py
+++ b/tests/test_aea.py
@@ -29,6 +29,7 @@ import yaml
 from aea import AEA_DIR
 from aea.aea import AEA
 from aea.configurations.base import ProtocolConfig
+from aea.crypto.default import DEFAULT
 from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet
 from aea.mail.base import Envelope
@@ -217,8 +218,8 @@ class TestInitializeAEAProgrammaticallyFromResourcesDir:
         cls.node.start()
         cls.agent_name = "MyAgent"
         cls.private_key_pem_path = os.path.join(CUR_PATH, "data", "priv.pem")
-        cls.wallet = Wallet({'default': cls.private_key_pem_path})
-        cls.ledger_apis = LedgerApis({}, 'default')
+        cls.wallet = Wallet({DEFAULT: cls.private_key_pem_path})
+        cls.ledger_apis = LedgerApis({}, DEFAULT)
         cls.connection = OEFLocalConnection(cls.agent_name, cls.node)
         cls.connections = [cls.connection]
 
@@ -276,7 +277,7 @@ class TestInitializeAEAProgrammaticallyBuildResources:
 
         cls.temp = tempfile.mkdtemp(prefix="test_aea_resources")
         cls.resources = Resources(cls.temp)
-        cls.aea = AEA(cls.agent_name, cls.connections, cls.wallet, cls.ledger_apis, resources=cls.resources)
+        cls.aea = AEA(cls.agent_name, cls.connections, cls.wallet, cls.ledger_apis, resources=cls.resources, programmatic=True)
 
         cls.default_protocol_configuration = ProtocolConfig.from_json(
             yaml.safe_load(open(Path(AEA_DIR, "protocols", "default", "protocol.yaml"))))

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -138,7 +138,7 @@ class TestResources:
         wallet = Wallet({'default': private_key_pem_path})
         ledger_apis = LedgerApis({}, 'default')
         cls.resources = Resources(os.path.join(cls.agent_folder))
-        cls.aea = AEA(cls.agent_name, connections, wallet, ledger_apis, resources=cls.resources)
+        cls.aea = AEA(cls.agent_name, connections, wallet, ledger_apis, resources=cls.resources, programmatic=False)
         cls.resources.load(cls.aea.context)
 
         cls.expected_skills = {"dummy", "error"}
@@ -302,7 +302,7 @@ class TestFilter:
         private_key_pem_path = os.path.join(CUR_PATH, "data", "priv.pem")
         wallet = Wallet({'default': private_key_pem_path})
         ledger_apis = LedgerApis({}, 'default')
-        cls.aea = AEA(cls.agent_name, connections, wallet, ledger_apis, resources=Resources(cls.agent_folder))
+        cls.aea = AEA(cls.agent_name, connections, wallet, ledger_apis, resources=Resources(cls.agent_folder), programmatic=False)
 
     def test_handle_internal_messages(self):
         """Test that the internal messages are handled."""

--- a/tests/test_skills/test_base.py
+++ b/tests/test_skills/test_base.py
@@ -42,7 +42,7 @@ def test_agent_context_ledger_apis():
     wallet = Wallet({'default': private_key_pem_path})
     connections = [DummyConnection()]
     ledger_apis = LedgerApis({"fetchai": ['alpha.fetch-ai.com', 80]}, FETCHAI)
-    my_aea = AEA("Agent0", connections, wallet, ledger_apis, resources=Resources(str(Path(CUR_PATH, "data", "dummy_aea"))))
+    my_aea = AEA("Agent0", connections, wallet, ledger_apis, resources=Resources(str(Path(CUR_PATH, "data", "dummy_aea"))), programmatic=False)
 
     assert set(my_aea.context.ledger_apis.apis.keys()) == {"fetchai"}
     fetchai_ledger_api_obj = my_aea.context.ledger_apis.apis["fetchai"]
@@ -61,7 +61,7 @@ class TestSkillContext:
         cls.wallet = Wallet({'default': private_key_pem_path, FETCHAI: private_key_txt_path})
         cls.ledger_apis = LedgerApis({FETCHAI: ["alpha.fetch-ai.com", 80]}, FETCHAI)
         cls.connections = [DummyConnection()]
-        cls.my_aea = AEA("Agent0", cls.connections, cls.wallet, cls.ledger_apis, resources=Resources(str(Path(CUR_PATH, "data", "dummy_aea"))))
+        cls.my_aea = AEA("Agent0", cls.connections, cls.wallet, cls.ledger_apis, resources=Resources(str(Path(CUR_PATH, "data", "dummy_aea"))), programmatic=False)
         cls.skill_context = SkillContext(cls.my_aea.context)
 
     def test_agent_name(self):
@@ -143,7 +143,7 @@ class TestSkillFromDir:
         cls.wallet = Wallet({'default': private_key_pem_path})
         ledger_apis = LedgerApis({}, FETCHAI)
         cls.connections = [DummyConnection()]
-        cls.my_aea = AEA("agent_name", cls.connections, cls.wallet, ledger_apis, resources=Resources(str(Path(CUR_PATH, "data", "dummy_aea"))))
+        cls.my_aea = AEA("agent_name", cls.connections, cls.wallet, ledger_apis, resources=Resources(str(Path(CUR_PATH, "data", "dummy_aea"))), programmatic=False)
         cls.agent_context = cls.my_aea.context
 
     def test_missing_handler(self):

--- a/tests/test_skills/test_error.py
+++ b/tests/test_skills/test_error.py
@@ -57,7 +57,7 @@ class TestSkillError:
         cls.connection = DummyConnection()
         cls.connections = [cls.connection]
         cls.my_aea = AEA(cls.agent_name, cls.connections, cls.wallet, cls.ledger_apis, timeout=2.0,
-                         resources=Resources(str(Path(CUR_PATH, "data/dummy_aea"))))
+                         resources=Resources(str(Path(CUR_PATH, "data/dummy_aea"))), programmatic=False)
         cls.t = Thread(target=cls.my_aea.start)
         cls.t.start()
         time.sleep(0.5)


### PR DESCRIPTION
## Proposed changes

This PR fixes the guide to build an agent programmatically. It also adds a flag to an AEA/Agent which lets the developer skip the loading from resource directory stage.

## Fixes

#619 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

-