### PR TITLE
Change author regex and use 'author' as default

### DIFF
--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -59,6 +59,7 @@ logger = logging.getLogger("aea")
 logger = default_logging_config(logger)
 
 DEFAULT_VERSION = "0.1.0"
+DEFAULT_AUTHOR = "author"
 DEFAULT_CONNECTION = PublicId.from_string(
     "fetchai/stub:" + DEFAULT_VERSION
 )  # type: PublicId

--- a/aea/cli/create.py
+++ b/aea/cli/create.py
@@ -33,6 +33,7 @@ import aea
 from aea.cli.add import connection, skill
 from aea.cli.common import (
     Context,
+    DEFAULT_AUTHOR,
     DEFAULT_CONNECTION,
     DEFAULT_LEDGER,
     DEFAULT_REGISTRY_PATH,
@@ -99,7 +100,7 @@ def create(click_context, agent_name):
         agent_config = AgentConfig(
             agent_name=agent_name,
             aea_version=aea.__version__,
-            author="",
+            author=DEFAULT_AUTHOR,
             version=DEFAULT_VERSION,
             license="",
             fingerprint="",

--- a/aea/configurations/schemas/definitions.json
+++ b/aea/configurations/schemas/definitions.json
@@ -57,7 +57,7 @@
     },
     "author": {
       "type": "string",
-      "pattern": "[a-zA-Z0-9_]*"
+      "pattern": "[a-zA-Z_][a-zA-Z0-9_]*"
     },
     "version": {
       "type": "string",

--- a/tests/test_cli/test_create.py
+++ b/tests/test_cli/test_create.py
@@ -118,7 +118,7 @@ class TestCreate:
 
     def test_authors_field_is_empty_string(self):
         """Check that the 'authors' field in the config file is the empty string."""
-        assert self.agent_config["author"] == ""
+        assert self.agent_config["author"] == aea.cli.common.DEFAULT_AUTHOR
 
     def test_connections_contains_only_stub(self):
         """Check that the 'connections' list contains only the 'stub' connection."""

--- a/tests/test_cli/test_search.py
+++ b/tests/test_cli/test_search.py
@@ -157,10 +157,10 @@ class TestSearchAgents:
         assert (
             self.result.output == "Available agents:\n"
             "------------------------------\n"
-            "Public ID: /myagent:0.1.0\n"
+            "Public ID: author/myagent:0.1.0\n"
             "Name: myagent\n"
             "Description: \n"
-            "Author: \n"
+            "Author: author\n"
             "Version: 0.1.0\n"
             "------------------------------\n\n"
         )


### PR DESCRIPTION
## Proposed changes

- use regex `[a-zA-Z_][a-zA-Z0-9_]*` instead of `[a-zA-Z0-9_]*` in particular, the empty string is not allowed anymore, and it can contains digits but not at the beginning
- set 'author' as default author. This should be improved when the CLI will have more user's information.

## Fixes

fixes #552 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
