### PR TITLE
AEA-258 make Decision Maker run in its own thread.

### DIFF
--- a/aea/aea.py
+++ b/aea/aea.py
@@ -144,6 +144,7 @@ class AEA(Agent):
             self.resources.load(self.context)
         self.resources.setup()
         self.task_manager.start()
+        self.decision_maker.start()
 
     def act(self) -> None:
         """
@@ -219,7 +220,6 @@ class AEA(Agent):
         # TODO: task should be submitted by the behaviours and handlers
         for task in self.filter.get_active_tasks():
             task.execute()
-        self.decision_maker.execute()
         self.filter.handle_internal_messages()
 
     def teardown(self) -> None:
@@ -228,6 +228,7 @@ class AEA(Agent):
 
         :return: None
         """
+        self.decision_maker.stop()
         self.task_manager.stop()
         if self._resources is not None:
             self._resources.teardown()

--- a/aea/decision_maker/base.py
+++ b/aea/decision_maker/base.py
@@ -22,8 +22,10 @@
 import copy
 import logging
 import math
+import threading
 from enum import Enum
 from queue import Queue
+from threading import Thread
 from typing import Dict, List, Optional, cast
 
 from aea.crypto.ethereum import ETHEREUM
@@ -464,6 +466,10 @@ class DecisionMaker:
         self._preferences = Preferences()
         self._goal_pursuit_readiness = GoalPursuitReadiness()
 
+        self._thread = None  # type: Optional[Thread]
+        self._lock = threading.Lock()
+        self._stopped = True
+
     @property
     def message_in_queue(self) -> Queue:
         """Get (in) queue."""
@@ -504,25 +510,49 @@ class DecisionMaker:
         """Get readiness of agent to pursuit its goals."""
         return self._goal_pursuit_readiness
 
+    def start(self):
+        """Start the decision maker."""
+        with self._lock:
+            if not self._stopped:
+                logger.debug("Decision maker already started.")
+                return
+
+            self._stopped = False
+            self._thread = Thread(target=self.execute)
+            self._thread.start()
+
+    def stop(self):
+        with self._lock:
+            self._stopped = True
+            self.message_in_queue.put(None)
+            self._thread.join()
+            logger.debug("Decision Maker stopped.")
+            self._thread = None
+
     def execute(self) -> None:
         """
         Execute the decision maker.
 
         :return: None
         """
-        while not self.message_in_queue.empty():
-            message = (
-                self.message_in_queue.get_nowait()
+        while not self._stopped:
+            message = self.message_in_queue.get(
+                block=True
             )  # type: Optional[InternalMessage]
-            if message is not None:
-                if message.protocol_id == INTERNAL_PROTOCOL_ID:
-                    self.handle(message)
-                else:
-                    logger.warning(
-                        "[{}]: Message received by the decision maker is not of protocol_id=internal.".format(
-                            self._agent_name
-                        )
+            if message is None:
+                logger.debug(
+                    "Decision Maker: Received empty message. Quitting the processing loop..."
+                )
+                continue
+
+            if message.protocol_id == INTERNAL_PROTOCOL_ID:
+                self.handle(message)
+            else:
+                logger.warning(
+                    "[{}]: Message received by the decision maker is not of protocol_id=internal.".format(
+                        self._agent_name
                     )
+                )
 
     def handle(self, message: InternalMessage) -> None:
         """

--- a/tests/test_decision_maker/test_base.py
+++ b/tests/test_decision_maker/test_base.py
@@ -19,6 +19,7 @@
 
 """This module contains tests for decision_maker."""
 import os
+import time
 from queue import Queue
 from unittest import mock
 
@@ -475,6 +476,8 @@ class TestDecisionMaker:
         cls.info = {"some_info_key": "some_info_value"}
         cls.ledger_id = "fetchai"
 
+        cls.decision_maker.start()
+
     def test_properties(self):
         """Test the properties of the decision maker."""
         assert self.decision_maker.outbox.empty()
@@ -500,8 +503,8 @@ class TestDecisionMaker:
         )
 
         self.decision_maker.message_in_queue.put_nowait(tx_message)
-        with mock.patch.object(self.decision_maker, "handle"):
-            self.decision_maker.execute()
+        # test that after a while the queue has been consumed.
+        time.sleep(0.5)
         assert self.decision_maker.message_in_queue.empty()
 
     def test_decision_maker_handle_state_update_initialize(self):
@@ -735,8 +738,7 @@ class TestDecisionMaker:
         )
 
         self.decision_maker.message_in_queue.put_nowait(default_message)
-        self.decision_maker.execute()
-
+        time.sleep(0.5)
         self.mocked_logger_warning.assert_called_with(
             "[{}]: Message received by the decision maker is not of protocol_id=internal.".format(
                 self.agent_name
@@ -937,6 +939,7 @@ class TestDecisionMaker:
         """Tear the tests down."""
         cls._unpatch_logger()
         cls.multiplexer.disconnect()
+        cls.decision_maker.stop()
 
 
 class TestLedgerStateProxy:


### PR DESCRIPTION
## Proposed changes

This PR makes the Decision Maker run in its own thread.

## Fixes

Fixes #584 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
