### PR TITLE
Let skills register new behaviours.

### DIFF
--- a/aea/registries/base.py
+++ b/aea/registries/base.py
@@ -597,6 +597,14 @@ class Resources(object):
         """Get the skill."""
         return self._skills.get(skill_id, None)
 
+    def get_all_skills(self) -> List[Skill]:
+        """
+        Get the list of all the skills.
+
+        :return: the list of skills.
+        """
+        return list(self._skills.values())
+
     def remove_skill(self, skill_id: SkillId):
         """Remove a skill from the set of resources."""
         self._skills.pop(skill_id, None)
@@ -716,6 +724,20 @@ class Filter(object):
                 logger.warning(
                     "Cannot handle a {} message.".format(type(internal_message))
                 )
+
+        # get new behaviours from the agent skills
+        for skill in self.resources.get_all_skills():
+            while not skill.skill_context.new_behaviours.empty():
+                new_behaviour = skill.skill_context.new_behaviours.get()
+                try:
+                    self.resources.behaviour_registry.register(
+                        (skill.skill_context.skill_id, new_behaviour.name),
+                        new_behaviour,
+                    )
+                except ValueError as e:
+                    logger.warning(
+                        "Error when trying to add a new behaviour: {}".format(str(e))
+                    )
 
     def _handle_tx_message(self, tx_message: TransactionMessage):
         """Handle transaction message from the Decision Maker."""

--- a/aea/registries/base.py
+++ b/aea/registries/base.py
@@ -328,7 +328,7 @@ class ComponentRegistry(
 
     def fetch_by_skill(self, skill_id: SkillId) -> List[Item]:
         """Fetch all the items of a given skill."""
-        return list(*self._items.get(skill_id, {}).values())
+        return [*self._items.get(skill_id, {}).values()]
 
     def fetch_all(self) -> List[SkillComponentType]:
         """Fetch all the items."""

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -22,6 +22,7 @@ import importlib.util
 import inspect
 import logging
 import os
+import queue
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -69,6 +70,7 @@ class SkillContext:
         self._skill = None  # type: Optional[Skill]
 
         self._is_active = True  # type: bool
+        self._new_behaviours_queue = queue.Queue()  # type: Queue
 
     @property
     def shared_state(self) -> Dict[str, Any]:
@@ -99,6 +101,18 @@ class SkillContext:
                 self.skill_id, self._is_active
             )
         )
+
+    @property
+    def new_behaviours(self) -> Queue:
+        """
+        The queue for the new behaviours.
+
+        This queue can be used to send messages to the framework
+        to request the registration of a behaviour.
+
+        :return the queue of new behaviours.
+        """
+        return self._new_behaviours_queue
 
     @property
     def agent_public_key(self) -> str:

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -43,6 +43,13 @@ Conceptually, a `Behaviour`  class contains the business logic specific to initi
 
 There can be one or more `Behaviour` classes per skill. The developer must create a subclass from the abstract class `Behaviour` to create a new `Behaviour`.
 
+A behaviour can be registered in two ways:
+
+- By declaring it in the skill configuration file `skill.yaml` (see [below](#skill-config))
+- In any part of the code of the skill, by enqueuing new `Behaviour` instances in the queue `context.new_behaviours`.
+
+
+
 * `act(self)`: is how the framework calls the `Behaviour` code.
 
 !!!	Todo

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -49,12 +49,36 @@ A behaviour can be registered in two ways:
 - In any part of the code of the skill, by enqueuing new `Behaviour` instances in the queue `context.new_behaviours`.
 
 
-
 * `act(self)`: is how the framework calls the `Behaviour` code.
 
-!!!	Todo
-	For example.
+Follows an example of a custom behaviour:
 
+```python
+
+from aea.skills.base import Behaviour
+
+class MyBehaviour(Behaviour):
+            
+    def setup(self):
+        """This method is called once, when the behaviour gets loaded."""
+
+    def act(self): 
+        """This methods is called in every iteration of the agent main loop."""
+
+    def teardown(self): 
+        """This method is called once, when the behaviour is teared down."""
+
+```
+
+If we want to register this behaviour dynamically, in any part of the skill code
+(i.e. wherever the skill context is available), we can write:
+
+```python
+self.context.new_behaviours.put(MyBehaviour())
+```
+
+The framework is then in charge of registering the behaviour and scheduling it 
+for execution.
 
 ### `tasks.py`
 
@@ -64,8 +88,6 @@ There can be one or more `Task` classes per skill. The developer subclasses abst
 
 * `execute(self)`: is how the framework calls a `Task`. 
 
-!!!	Todo
-	For example.
 
 ### Shared classes
 


### PR DESCRIPTION
## Proposed changes

This PR adds a special queue in every skill context instance, called `new_behaviours`, that lets the skill code to request the framework for registration of new behaviours.

## Fixes

Fixes #591 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

