### PR TITLE
Remove the unnecessary msg._check_consistency from tests

### DIFF
--- a/tests/test_decision_maker/test_base.py
+++ b/tests/test_decision_maker/test_base.py
@@ -82,7 +82,6 @@ class TestOwnershipState:
 
         other_msg = InternalMessage(body={"test_key": "test_value"})
         assert msg == other_msg, "Messages should be equal."
-        assert msg.check_consistency(), "It is true."
         assert str(msg) == "InternalMessage(test_key=test_value)"
         assert msg._body is not None
         msg.body = {"Test": "My_test"}

--- a/tests/test_packages/test_protocols/test_ml_message.py
+++ b/tests/test_packages/test_protocols/test_ml_message.py
@@ -20,6 +20,7 @@
 """This module contains the tests of the ml_messages module."""
 
 import logging
+from unittest import mock
 
 import numpy as np
 
@@ -52,6 +53,15 @@ def test_ml_wrong_message_creation():
     """Test the creation of a ml message."""
     with pytest.raises(AssertionError):
         MLTradeMessage(performative=MLTradeMessage.Performative.CFT, query="")
+
+
+def test_ml_messge_consistency():
+    """Test the consistency of the message."""
+    dm = DataModel("ml_datamodel", [Attribute("dataset_id", str, True)])
+    query = Query([Constraint("dataset_id", ConstraintType("==", "fmnist"))], model=dm)
+    msg = MLTradeMessage(performative=MLTradeMessage.Performative.CFT, query=query)
+    with mock.patch.object(MLTradeMessage.Performative, "__eq__", return_value=False):
+        assert not msg._check_consistency()
 
 
 def test_ml_message_creation():

--- a/tests/test_packages/test_protocols/test_oef_message.py
+++ b/tests/test_packages/test_protocols/test_oef_message.py
@@ -18,14 +18,13 @@
 # ------------------------------------------------------------------------------
 
 """This module contains the tests for the OEF protocol."""
+from unittest import mock
+
 
 from aea.helpers.search.models import (
     Attribute,
-    Constraint,
-    ConstraintType,
     DataModel,
     Description,
-    Query,
 )
 
 from packages.fetchai.protocols.oef.message import OEFMessage
@@ -63,15 +62,39 @@ def test_oef_type_string_value():
     ), "The string representation must be search_result"
 
 
+def test_oef_error_operation():
+    """Test the string value of the error operation."""
+    assert (
+        str(OEFMessage.OEFErrorOperation.REGISTER_SERVICE) == "0"
+    ), "The string representation must be 0"
+    assert (
+        str(OEFMessage.OEFErrorOperation.UNREGISTER_SERVICE) == "1"
+    ), "The string representation must be 1"
+    assert (
+        str(OEFMessage.OEFErrorOperation.SEARCH_SERVICES) == "2"
+    ), "The string representation must be 2"
+    assert (
+        str(OEFMessage.OEFErrorOperation.SEARCH_SERVICES_WIDE) == "3"
+    ), "The string representation must be 3"
+    assert (
+        str(OEFMessage.OEFErrorOperation.SEARCH_AGENTS) == "4"
+    ), "The string representation must be 4"
+    assert (
+        str(OEFMessage.OEFErrorOperation.SEND_MESSAGE) == "5"
+    ), "The string representation must be 5"
+    assert (
+        str(OEFMessage.OEFErrorOperation.REGISTER_AGENT) == "6"
+    ), "The string representation must be 6"
+    assert (
+        str(OEFMessage.OEFErrorOperation.UNREGISTER_AGENT) == "7"
+    ), "The string representation must be 7"
+    assert (
+        str(OEFMessage.OEFErrorOperation.OTHER) == "10000"
+    ), "The string representation must be 10000"
+
+
 def test_oef_message_consistency():
     """Tests the consistency of an OEFMessage."""
-    foo_datamodel = DataModel("foo", [Attribute("bar", int, True, "A bar attribute.")])
-    msg = OEFMessage(
-        type=OEFMessage.Type.SEARCH_AGENTS,
-        id=2,
-        query=Query([Constraint("bar", ConstraintType("==", 1))], model=foo_datamodel),
-    )
-    assert msg._check_consistency(), "We expect the consistency to return TRUE"
 
     attribute_foo = Attribute("foo", int, True, "a foo attribute.")
     attribute_bar = Attribute("bar", str, True, "a bar attribute.")
@@ -87,16 +110,9 @@ def test_oef_message_consistency():
         agent_description=description_foobar,
         agent_id="address",
     )
-    assert msg._check_consistency()
 
-    msg = OEFMessage(
-        type=OEFMessage.Type.UNREGISTER_AGENT,
-        id=0,
-        agent_description=description_foobar,
-        agent_id="address",
-    )
-
-    assert msg._check_consistency()
+    with mock.patch.object(OEFMessage.Type, "__eq__", return_value=False):
+        assert not msg._check_consistency()
 
 
 def test_oef_message_oef_error():

--- a/tests/test_protocols/test_base.py
+++ b/tests/test_protocols/test_base.py
@@ -111,7 +111,3 @@ class TestBaseSerializations:
             config=ProtocolConfig(),
         )
         assert protocol.config is not None
-
-    def test_check_consistency_returns_true(self):
-        """Test that the check consistency method returns True."""
-        assert self.message._check_consistency()


### PR DESCRIPTION
## Proposed changes

Removed any unnecessary check_consistency from tests. I left though the checks that look like this : 
```
  with mock.patch.object(OEFMessage.Type, "__eq__", return_value=False):
        assert not msg._check_consistency()
```

## Fixes

#643 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules