### PR TITLE
AEA-354 add identity object to agent and aea

### DIFF
--- a/aea/aea.py
+++ b/aea/aea.py
@@ -22,7 +22,7 @@ import logging
 from asyncio import AbstractEventLoop
 from typing import List, Optional, cast
 
-from aea.agent import Agent
+from aea.agent import Agent, Identity
 from aea.connections.base import Connection
 from aea.context.base import AgentContext
 from aea.crypto.ledger_apis import LedgerApis
@@ -43,7 +43,7 @@ class AEA(Agent):
 
     def __init__(
         self,
-        name: str,
+        identity: Identity,
         connections: List[Connection],
         wallet: Wallet,
         ledger_apis: LedgerApis,
@@ -57,7 +57,7 @@ class AEA(Agent):
         """
         Instantiate the agent.
 
-        :param name: the name of the agent
+        :param identity: the identity of the agent
         :param connections: the list of connections of the agent.
         :param loop: the event loop to run the connections.
         :param wallet: the wallet of the agent.
@@ -71,7 +71,7 @@ class AEA(Agent):
         :return: None
         """
         super().__init__(
-            name=name,
+            identity=identity,
             connections=connections,
             loop=loop,
             timeout=timeout,
@@ -79,6 +79,8 @@ class AEA(Agent):
             programmatic=programmatic,
         )
 
+        self.identity.public_keys = wallet.public_keys
+        self.identity.addresses = wallet.addresses
         self._wallet = wallet
         self.max_reactions = max_reactions
         self._task_manager = TaskManager()
@@ -87,8 +89,8 @@ class AEA(Agent):
         )
         self._context = AgentContext(
             self.name,
-            self.wallet.public_keys,
-            self.wallet.addresses,
+            self.identity.public_keys,
+            self.identity.addresses,
             ledger_apis,
             self.multiplexer.connection_status,
             self.outbox,

--- a/aea/aea.py
+++ b/aea/aea.py
@@ -22,12 +22,13 @@ import logging
 from asyncio import AbstractEventLoop
 from typing import List, Optional, cast
 
-from aea.agent import Agent, Identity
+from aea.agent import Agent
 from aea.connections.base import Connection
 from aea.context.base import AgentContext
 from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet
 from aea.decision_maker.base import DecisionMaker
+from aea.identity.base import Identity
 from aea.mail.base import Envelope
 from aea.protocols.default.message import DefaultMessage
 from aea.registries.base import Filter, Resources
@@ -79,18 +80,13 @@ class AEA(Agent):
             programmatic=programmatic,
         )
 
-        self.identity.public_keys = wallet.public_keys
-        self.identity.addresses = wallet.addresses
-        self._wallet = wallet
         self.max_reactions = max_reactions
         self._task_manager = TaskManager()
         self._decision_maker = DecisionMaker(
-            self.name, self.max_reactions, self.outbox, self.wallet, ledger_apis
+            self.name, self.max_reactions, self.outbox, wallet, ledger_apis
         )
         self._context = AgentContext(
-            self.name,
-            self.identity.public_keys,
-            self.identity.addresses,
+            self.identity,
             ledger_apis,
             self.multiplexer.connection_status,
             self.outbox,
@@ -102,11 +98,6 @@ class AEA(Agent):
         )
         self._resources = resources
         self._filter = Filter(self.resources, self.decision_maker.message_out_queue)
-
-    @property
-    def wallet(self) -> Wallet:
-        """Get the wallet."""
-        return self._wallet
 
     @property
     def decision_maker(self) -> DecisionMaker:

--- a/aea/agent.py
+++ b/aea/agent.py
@@ -25,7 +25,7 @@ import time
 from abc import ABC, abstractmethod
 from asyncio import AbstractEventLoop
 from enum import Enum
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from aea.connections.base import Connection
 from aea.mail.base import InBox, Multiplexer, OutBox
@@ -54,12 +54,70 @@ class Liveness:
         return self._is_stopped
 
 
+class Identity:
+    """
+    An identity are the public elements identifying an agent.
+
+    It can include:
+    - the agent name
+    - the public half of private / public key pairs
+    - the addresses
+    """
+
+    def __init__(self, name: str):
+        """
+        Instantiate the agent.
+
+        :param name: the name of the agent.
+        """
+        self._name = name
+        self._public_keys = None  # type: Optional[Dict[str, str]]
+        self._addresses = None  # type: Optional[Dict[str, str]]
+
+    @property
+    def name(self) -> str:
+        """Get the agent name."""
+        return self._name
+
+    @property
+    def public_keys(self) -> Dict[str, str]:
+        """Get the public_keys."""
+        assert self._public_keys is not None, "The public_keys are not set."
+        return self._public_keys
+
+    @public_keys.setter
+    def public_keys(self, public_keys: Dict[str, str]) -> None:
+        """
+        Set the public keys.
+
+        :param public_keys: the public keys.
+        :return: None
+        """
+        self._public_keys = public_keys
+
+    @property
+    def addresses(self) -> Dict[str, str]:
+        """Get the addresses."""
+        assert self._addresses is not None, "The addresses are not set."
+        return self._addresses
+
+    @addresses.setter
+    def addresses(self, addresses: Dict[str, str]) -> None:
+        """
+        Set the addresses.
+
+        :param addresses: the addresses.
+        :return: None
+        """
+        self._addresses = addresses
+
+
 class Agent(ABC):
     """This class implements a template agent."""
 
     def __init__(
         self,
-        name: str,
+        identity: Identity,
         connections: List[Connection],
         loop: Optional[AbstractEventLoop] = None,
         timeout: float = 1.0,
@@ -69,7 +127,7 @@ class Agent(ABC):
         """
         Instantiate the agent.
 
-        :param name: the name of the agent
+        :param identity: the identity of the agent.
         :param connections: the list of connections of the agent.
         :param loop: the event loop to run the connections.
         :param timeout: the time in (fractions of) seconds to time out an agent between act and react
@@ -78,7 +136,7 @@ class Agent(ABC):
 
         :return: None
         """
-        self._name = name
+        self._identity = identity
         self._connections = connections
 
         self._multiplexer = Multiplexer(self._connections, loop=loop)
@@ -91,6 +149,11 @@ class Agent(ABC):
 
         self.debug = debug
         self.programmatic = programmatic
+
+    @property
+    def identity(self) -> Identity:
+        """Get the identity."""
+        return self._identity
 
     @property
     def multiplexer(self) -> Multiplexer:
@@ -110,7 +173,7 @@ class Agent(ABC):
     @property
     def name(self) -> str:
         """Get the agent name."""
-        return self._name
+        return self.identity.name
 
     @property
     def liveness(self) -> Liveness:

--- a/aea/agent.py
+++ b/aea/agent.py
@@ -25,9 +25,10 @@ import time
 from abc import ABC, abstractmethod
 from asyncio import AbstractEventLoop
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from aea.connections.base import Connection
+from aea.identity.base import Identity
 from aea.mail.base import InBox, Multiplexer, OutBox
 
 logger = logging.getLogger(__name__)
@@ -52,64 +53,6 @@ class Liveness:
     def is_stopped(self) -> bool:
         """Check whether the liveness is stopped."""
         return self._is_stopped
-
-
-class Identity:
-    """
-    An identity are the public elements identifying an agent.
-
-    It can include:
-    - the agent name
-    - the public half of private / public key pairs
-    - the addresses
-    """
-
-    def __init__(self, name: str):
-        """
-        Instantiate the agent.
-
-        :param name: the name of the agent.
-        """
-        self._name = name
-        self._public_keys = None  # type: Optional[Dict[str, str]]
-        self._addresses = None  # type: Optional[Dict[str, str]]
-
-    @property
-    def name(self) -> str:
-        """Get the agent name."""
-        return self._name
-
-    @property
-    def public_keys(self) -> Dict[str, str]:
-        """Get the public_keys."""
-        assert self._public_keys is not None, "The public_keys are not set."
-        return self._public_keys
-
-    @public_keys.setter
-    def public_keys(self, public_keys: Dict[str, str]) -> None:
-        """
-        Set the public keys.
-
-        :param public_keys: the public keys.
-        :return: None
-        """
-        self._public_keys = public_keys
-
-    @property
-    def addresses(self) -> Dict[str, str]:
-        """Get the addresses."""
-        assert self._addresses is not None, "The addresses are not set."
-        return self._addresses
-
-    @addresses.setter
-    def addresses(self, addresses: Dict[str, str]) -> None:
-        """
-        Set the addresses.
-
-        :param addresses: the addresses.
-        :return: None
-        """
-        self._addresses = addresses
 
 
 class Agent(ABC):

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -329,8 +329,8 @@ def run(
         ]
     )
 
-    identity = Identity(agent_name)
     wallet = Wallet(private_key_paths)
+    identity = Identity(agent_name, addresses=wallet.addresses, default_address_key=ctx.agent_config.default_ledger)
     ledger_apis = LedgerApis(ledger_api_configs, ctx.agent_config.default_ledger)
 
     default_connection_id = PublicId.from_str(ctx.agent_config.default_connection)
@@ -342,7 +342,7 @@ def run(
     try:
         for connection_id in connection_ids:
             connection = _setup_connection(
-                connection_id, wallet.addresses[ctx.agent_config.default_ledger], ctx
+                connection_id, identity.address, ctx
             )
             connections.append(connection)
     except AEAConfigException as e:

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -29,6 +29,7 @@ import click
 from click import pass_context
 
 from aea.aea import AEA
+from aea.agent import Identity
 from aea.cli.common import (
     AEAConfigException,
     ConnectionsOption,
@@ -328,6 +329,7 @@ def run(
         ]
     )
 
+    identity = Identity(agent_name)
     wallet = Wallet(private_key_paths)
     ledger_apis = LedgerApis(ledger_api_configs, ctx.agent_config.default_ledger)
 
@@ -354,7 +356,7 @@ def run(
             click_context.invoke(install)
 
     agent = AEA(
-        agent_name,
+        identity,
         connections,
         wallet,
         ledger_apis,

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -330,7 +330,11 @@ def run(
     )
 
     wallet = Wallet(private_key_paths)
-    identity = Identity(agent_name, addresses=wallet.addresses, default_address_key=ctx.agent_config.default_ledger)
+    identity = Identity(
+        agent_name,
+        addresses=wallet.addresses,
+        default_address_key=ctx.agent_config.default_ledger,
+    )
     ledger_apis = LedgerApis(ledger_api_configs, ctx.agent_config.default_ledger)
 
     default_connection_id = PublicId.from_str(ctx.agent_config.default_connection)
@@ -341,9 +345,7 @@ def run(
     _try_to_load_protocols(ctx)
     try:
         for connection_id in connection_ids:
-            connection = _setup_connection(
-                connection_id, identity.address, ctx
-            )
+            connection = _setup_connection(connection_id, identity.address, ctx)
             connections.append(connection)
     except AEAConfigException as e:
         logger.error(str(e))

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -29,7 +29,6 @@ import click
 from click import pass_context
 
 from aea.aea import AEA
-from aea.agent import Identity
 from aea.cli.common import (
     AEAConfigException,
     ConnectionsOption,
@@ -74,6 +73,7 @@ from aea.helpers.base import (
     load_agent_component_package,
     load_module,
 )
+from aea.identity.base import Identity
 from aea.registries.base import Resources
 
 

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -330,11 +330,16 @@ def run(
     )
 
     wallet = Wallet(private_key_paths)
-    identity = Identity(
-        agent_name,
-        addresses=wallet.addresses,
-        default_address_key=ctx.agent_config.default_ledger,
-    )
+    if len(wallet.addresses) > 1:
+        identity = Identity(
+            agent_name,
+            addresses=wallet.addresses,
+            default_address_key=ctx.agent_config.default_ledger,
+        )
+    else:
+        identity = Identity(
+            agent_name, address=wallet.addresses[ctx.agent_config.default_ledger],
+        )
     ledger_apis = LedgerApis(ledger_api_configs, ctx.agent_config.default_ledger)
 
     default_connection_id = PublicId.from_str(ctx.agent_config.default_connection)

--- a/aea/context/base.py
+++ b/aea/context/base.py
@@ -25,7 +25,8 @@ from typing import Any, Dict
 from aea.connections.base import ConnectionStatus
 from aea.crypto.ledger_apis import LedgerApis
 from aea.decision_maker.base import GoalPursuitReadiness, OwnershipState, Preferences
-from aea.mail.base import OutBox
+from aea.identity.base import Identity
+from aea.mail.base import Address, OutBox
 from aea.skills.tasks import TaskManager
 
 
@@ -34,9 +35,7 @@ class AgentContext:
 
     def __init__(
         self,
-        agent_name: str,
-        public_keys: Dict[str, str],
-        addresses: Dict[str, str],
+        identity: Identity,
         ledger_apis: LedgerApis,
         connection_status: ConnectionStatus,
         outbox: OutBox,
@@ -49,8 +48,7 @@ class AgentContext:
         """
         Initialize an agent context.
 
-        :param agent_name: the agent's name
-        :param public_keys: the public keys of the agent
+        :param identity: the identity object
         :param ledger_apis: the ledger apis
         :param connection_status: the connection status
         :param outbox: the outbox
@@ -61,9 +59,7 @@ class AgentContext:
         :param task_manager: the task manager
         """
         self._shared_state = {}  # type: Dict[str, Any]
-        self._agent_name = agent_name
-        self._public_keys = public_keys
-        self._addresses = addresses
+        self._identity = identity
         self._ledger_apis = ledger_apis
         self._connection_status = connection_status
         self._outbox = outbox
@@ -79,29 +75,23 @@ class AgentContext:
         return self._shared_state
 
     @property
+    def identity(self) -> Identity:
+        return self._identity
+
+    @property
     def agent_name(self) -> str:
         """Get agent name."""
-        return self._agent_name
+        return self.identity.name
 
     @property
-    def public_keys(self) -> Dict[str, str]:
-        """Get public keys."""
-        return self._public_keys
-
-    @property
-    def addresses(self) -> Dict[str, str]:
+    def addresses(self) -> Dict[str, Address]:
         """Get addresses."""
-        return self._addresses
+        return self.identity.addresses
 
     @property
-    def address(self) -> str:
+    def address(self) -> Address:
         """Get the defualt address."""
-        return self._addresses[self.ledger_apis.default_ledger_id]
-
-    @property
-    def public_key(self) -> str:
-        """Get the default public key."""
-        return self._public_keys[self.ledger_apis.default_ledger_id]
+        return self.identity.address
 
     @property
     def connection_status(self) -> ConnectionStatus:

--- a/aea/decision_maker/base.py
+++ b/aea/decision_maker/base.py
@@ -480,6 +480,10 @@ class DecisionMaker:
         return self._message_out_queue
 
     @property
+    def wallet(self) -> Wallet:
+        return self._wallet
+
+    @property
     def ledger_apis(self) -> LedgerApis:
         """Get outbox."""
         return self._ledger_apis
@@ -736,7 +740,7 @@ class DecisionMaker:
             tx_digest = OFF_CHAIN_SETTLEMENT_DIGEST
         else:
             logger.info("[{}]: Settling transaction on chain!".format(self._agent_name))
-            crypto_object = self._wallet.crypto_objects.get(tx_message.ledger_id)
+            crypto_object = self.wallet.crypto_objects.get(tx_message.ledger_id)
             tx_digest = self.ledger_apis.transfer(
                 crypto_object,
                 tx_message.tx_counterparty_addr,
@@ -802,10 +806,10 @@ class DecisionMaker:
         :return: the signature of the signing payload
         """
         if tx_message.ledger_id == OFF_CHAIN:
-            crypto_object = self._wallet.crypto_objects.get(ETHEREUM)
+            crypto_object = self.wallet.crypto_objects.get(ETHEREUM)
             # TODO: replace with default_ledger when recover_hash function is available for FETCHAI
         else:
-            crypto_object = self._wallet.crypto_objects.get(tx_message.ledger_id)
+            crypto_object = self.wallet.crypto_objects.get(tx_message.ledger_id)
         tx_hash = tx_message.signing_payload.get("tx_hash")
         tx_signature = crypto_object.sign_message(tx_hash)
         return tx_signature

--- a/aea/identity/__init__.py
+++ b/aea/identity/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the identity modules."""

--- a/aea/identity/base.py
+++ b/aea/identity/base.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the identity class."""
+
+from typing import Dict, Optional
+
+from aea.mail.base import Address
+
+
+class Identity:
+    """
+    An identity are the public elements identifying an agent.
+
+    It can include:
+    - the agent name
+    - the addresses
+    """
+
+    def __init__(self, name: str, address: Optional[str] = None, addresses: Optional[Dict[str, Address]] = None, default_address_key: Optional[str] = None):
+        """
+        Instantiate the identity.
+
+        :param name: the name of the agent.
+        :param addresses: the addresses of the agent.
+        :param default_address_key: the key for the default address
+        """
+        self._name = name
+        self._address = address
+        self._addresses = addresses
+        self._default_address_key = default_address_key
+        self._check_consistency(address, addresses, default_address_key)
+
+    def _check_consistency(self, address, addresses, default_address_key):
+        is_single = address is not None
+        is_multiple = (addresses is not None and len(addresses) > 1)
+        assert is_single != is_multiple, "Either provide a single address or a dictionary of multiple addresses, not both."
+        if is_multiple:
+            assert default_address_key is not None, "No key set for default address."
+            assert default_address_key in addresses.keys(), "Addresses does not contain default address key."
+
+    @property
+    def name(self) -> str:
+        """Get the agent name."""
+        return self._name
+
+    @property
+    def addresses(self) -> Dict[str, Address]:
+        """Get the addresses."""
+        assert self._addresses is not None, "No addresses assigned."
+        return self._addresses
+
+    @property
+    def address(self) -> Address:
+        """Get the default address."""
+        if self._address is not None:
+            return self._address
+        else:
+            assert self._default_address_key is not None, "No key set for default address."
+            return self.addresses[self._default_address_key]

--- a/aea/identity/base.py
+++ b/aea/identity/base.py
@@ -33,7 +33,13 @@ class Identity:
     - the addresses
     """
 
-    def __init__(self, name: str, address: Optional[str] = None, addresses: Optional[Dict[str, Address]] = None, default_address_key: Optional[str] = None):
+    def __init__(
+        self,
+        name: str,
+        address: Optional[str] = None,
+        addresses: Optional[Dict[str, Address]] = None,
+        default_address_key: Optional[str] = None,
+    ):
         """
         Instantiate the identity.
 
@@ -49,11 +55,15 @@ class Identity:
 
     def _check_consistency(self, address, addresses, default_address_key):
         is_single = address is not None
-        is_multiple = (addresses is not None and len(addresses) > 1)
-        assert is_single != is_multiple, "Either provide a single address or a dictionary of multiple addresses, not both."
+        is_multiple = addresses is not None and len(addresses) > 1
+        assert (
+            is_single != is_multiple
+        ), "Either provide a single address or a dictionary of multiple addresses, not both."
         if is_multiple:
             assert default_address_key is not None, "No key set for default address."
-            assert default_address_key in addresses.keys(), "Addresses does not contain default address key."
+            assert (
+                default_address_key in addresses.keys()
+            ), "Addresses does not contain default address key."
 
     @property
     def name(self) -> str:
@@ -72,5 +82,7 @@ class Identity:
         if self._address is not None:
             return self._address
         else:
-            assert self._default_address_key is not None, "No key set for default address."
+            assert (
+                self._default_address_key is not None
+            ), "No key set for default address."
             return self.addresses[self._default_address_key]

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -115,16 +115,6 @@ class SkillContext:
         return self._new_behaviours_queue
 
     @property
-    def agent_public_key(self) -> str:
-        """Get public key."""
-        return self._agent_context.public_key
-
-    @property
-    def agent_public_keys(self) -> Dict[str, str]:
-        """Get public keys."""
-        return self._agent_context.public_keys
-
-    @property
     def agent_addresses(self) -> Dict[str, str]:
         """Get addresses."""
         return self._agent_context.addresses

--- a/docs/agent-vs-aea.md
+++ b/docs/agent-vs-aea.md
@@ -85,7 +85,7 @@ if os.path.isfile(OUTPUT_FILE):
     os.remove(OUTPUT_FILE)
 
 # Create an addresses identity:
-identity = Identity(name="my_agent", address='some_address')
+identity = Identity(name="my_agent", address="some_address")
 
 # Set up the stub connection
 stub_connection = StubConnection(
@@ -199,7 +199,7 @@ def run():
         os.remove(OUTPUT_FILE)
 
     # Create an addresses identity:
-    identity = Identity(name="my_agent", address='some_address')
+    identity = Identity(name="my_agent", address="some_address")
 
     # Set up the stub connection
     stub_connection = StubConnection(

--- a/docs/agent-vs-aea.md
+++ b/docs/agent-vs-aea.md
@@ -13,9 +13,10 @@ import time
 from threading import Thread
 from typing import List, Optional
 
-from aea.agent import Agent, Identity
+from aea.agent import Agent
 from aea.connections.base import Connection
 from aea.connections.stub.connection import StubConnection
+from aea.identity.base import Identity
 from aea.mail.base import Envelope
 ```
 
@@ -83,13 +84,15 @@ if os.path.isfile(INPUT_FILE):
 if os.path.isfile(OUTPUT_FILE):
     os.remove(OUTPUT_FILE)
 
+# Create an addresses identity:
+identity = Identity(name="my_agent", address='some_address')
+
 # Set up the stub connection
 stub_connection = StubConnection(
     input_file_path=INPUT_FILE, output_file_path=OUTPUT_FILE
 )
 
 # Create our Agent
-identity = Identity("my_agent")
 my_agent = MyAgent(identity, [stub_connection])
 ```
 
@@ -144,9 +147,10 @@ import time
 from threading import Thread
 from typing import List, Optional
 
-from aea.agent import Agent, Identity
+from aea.agent import Agent
 from aea.connections.base import Connection
 from aea.connections.stub.connection import StubConnection
+from aea.identity.base import Identity
 from aea.mail.base import Envelope
 
 
@@ -194,13 +198,15 @@ def run():
     if os.path.isfile(OUTPUT_FILE):
         os.remove(OUTPUT_FILE)
 
+    # Create an addresses identity:
+    identity = Identity(name="my_agent", address='some_address')
+
     # Set up the stub connection
     stub_connection = StubConnection(
         input_file_path=INPUT_FILE, output_file_path=OUTPUT_FILE
     )
 
     # Create our Agent
-    identity = Identity("my_agent")
     my_agent = MyAgent(identity, [stub_connection])
 
     # Set the agent running in a different thread

--- a/docs/agent-vs-aea.md
+++ b/docs/agent-vs-aea.md
@@ -13,7 +13,7 @@ import time
 from threading import Thread
 from typing import List, Optional
 
-from aea.agent import Agent
+from aea.agent import Agent, Identity
 from aea.connections.base import Connection
 from aea.connections.stub.connection import StubConnection
 from aea.mail.base import Envelope
@@ -89,7 +89,8 @@ stub_connection = StubConnection(
 )
 
 # Create our Agent
-my_agent = MyAgent("my_agent", [stub_connection])
+identity = Identity("my_agent")
+my_agent = MyAgent(identity, [stub_connection])
 ```
 
 ## Start the agent
@@ -143,7 +144,7 @@ import time
 from threading import Thread
 from typing import List, Optional
 
-from aea.agent import Agent
+from aea.agent import Agent, Identity
 from aea.connections.base import Connection
 from aea.connections.stub.connection import StubConnection
 from aea.mail.base import Envelope
@@ -199,7 +200,8 @@ def run():
     )
 
     # Create our Agent
-    my_agent = MyAgent("my_agent", [stub_connection])
+    identity = Identity("my_agent")
+    my_agent = MyAgent(identity, [stub_connection])
 
     # Set the agent running in a different thread
     t = Thread(target=my_agent.start)

--- a/docs/build-aea-programmatically.md
+++ b/docs/build-aea-programmatically.md
@@ -23,6 +23,7 @@ Then, import the application specific libraries.
 ``` python
 from aea import AEA_DIR
 from aea.aea import AEA
+from aea.agent import Identity
 from aea.configurations.base import ProtocolConfig, PublicId
 from aea.connections.stub.connection import StubConnection
 from aea.crypto.default import DEFAULT
@@ -73,7 +74,8 @@ ledger_apis = LedgerApis({}, DEFAULT)
 resources = Resources()
 
 # Create our AEA
-my_aea = AEA("my_aea", [stub_connection], wallet, ledger_apis, resources)
+identity = Identity("my_aea")
+my_aea = AEA(identity, [stub_connection], wallet, ledger_apis, resources)
 ```
 
 Create the default protocol and add it to the AEA.
@@ -166,6 +168,7 @@ import yaml
 
 from aea import AEA_DIR
 from aea.aea import AEA
+from aea.agent import Identity
 from aea.configurations.base import ProtocolConfig, PublicId
 from aea.connections.stub.connection import StubConnection
 from aea.crypto.default import DEFAULT
@@ -201,7 +204,8 @@ def run():
     resources = Resources()
 
     # Create our AEA
-    my_aea = AEA("my_aea", [stub_connection], wallet, ledger_apis, resources)
+    identity = Identity("my_aea")
+    my_aea = AEA(identity, [stub_connection], wallet, ledger_apis, resources)
 
     # Add the default protocol (which is part of the AEA distribution)
     default_protocol_configuration = ProtocolConfig.from_json(

--- a/docs/build-aea-programmatically.md
+++ b/docs/build-aea-programmatically.md
@@ -23,13 +23,13 @@ Then, import the application specific libraries.
 ``` python
 from aea import AEA_DIR
 from aea.aea import AEA
-from aea.agent import Identity
 from aea.configurations.base import ProtocolConfig, PublicId
 from aea.connections.stub.connection import StubConnection
 from aea.crypto.default import DEFAULT
 from aea.crypto.helpers import DEFAULT_PRIVATE_KEY_FILE, _create_default_private_key
 from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet
+from aea.identity.base import Identity
 from aea.protocols.base import Protocol
 from aea.protocols.default.serialization import DefaultSerializer
 from aea.registries.base import Resources
@@ -73,8 +73,10 @@ stub_connection = StubConnection(
 ledger_apis = LedgerApis({}, DEFAULT)
 resources = Resources()
 
+# Create an identity
+identity = Identity(name="my_aea", addresses=wallet.addresses, default_address_key=DEFAULT)
+
 # Create our AEA
-identity = Identity("my_aea")
 my_aea = AEA(identity, [stub_connection], wallet, ledger_apis, resources)
 ```
 
@@ -175,6 +177,7 @@ from aea.crypto.default import DEFAULT
 from aea.crypto.helpers import DEFAULT_PRIVATE_KEY_FILE, _create_default_private_key
 from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet
+from aea.identity.base import Identity
 from aea.protocols.base import Protocol
 from aea.protocols.default.serialization import DefaultSerializer
 from aea.registries.base import Resources
@@ -203,8 +206,10 @@ def run():
     ledger_apis = LedgerApis({}, DEFAULT)
     resources = Resources()
 
+    # Create an identity
+    identity = Identity(name="my_aea", addresses=wallet.addresses, default_address_key=DEFAULT)
+
     # Create our AEA
-    identity = Identity("my_aea")
     my_aea = AEA(identity, [stub_connection], wallet, ledger_apis, resources)
 
     # Add the default protocol (which is part of the AEA distribution)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -22,7 +22,7 @@
 import time
 from threading import Thread
 
-from aea.agent import Agent, AgentState
+from aea.agent import Agent, AgentState, Identity
 from aea.configurations.base import PublicId
 from aea.mail.base import InBox, OutBox
 
@@ -61,15 +61,16 @@ def test_run_agent():
     """Test that we can set up and then run the agent."""
     with LocalNode() as node:
         agent_name = "dummyagent"
+        identity = Identity(agent_name)
         agent = DummyAgent(
-            agent_name,
+            identity,
             [
                 OEFLocalConnection(
                     "mypbk", node, connection_id=PublicId("fetchai", "oef", "0.1.0")
                 )
             ],
         )
-        assert agent.name == agent_name
+        assert agent.name == identity.name
         assert (
             agent.agent_state == AgentState.INITIATED
         ), "Agent state must be 'initiated'"

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -61,7 +61,8 @@ def test_run_agent():
     """Test that we can set up and then run the agent."""
     with LocalNode() as node:
         agent_name = "dummyagent"
-        identity = Identity(agent_name)
+        agent_address = "some_address"
+        identity = Identity(agent_name, address=agent_address)
         agent = DummyAgent(
             identity,
             [

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -33,9 +33,11 @@ import aea
 import aea.registries.base
 from aea.aea import AEA
 from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, PublicId
+from aea.crypto.default import DEFAULT
 from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet
 from aea.decision_maker.messages.transaction import TransactionMessage
+from aea.identity.base import Identity
 from aea.protocols.base import Protocol
 from aea.protocols.default.message import DefaultMessage
 from aea.registries.base import ProtocolRegistry, Resources
@@ -152,11 +154,12 @@ class TestResources:
 
         connections = [DummyConnection(connection_id=DUMMY_CONNECTION_PUBLIC_ID)]
         private_key_pem_path = os.path.join(CUR_PATH, "data", "priv.pem")
-        wallet = Wallet({"default": private_key_pem_path})
-        ledger_apis = LedgerApis({}, "default")
+        wallet = Wallet({DEFAULT: private_key_pem_path})
+        ledger_apis = LedgerApis({}, DEFAULT)
         cls.resources = Resources(os.path.join(cls.agent_folder))
+        identity = Identity(cls.agent_name, address=wallet.addresses[DEFAULT])
         cls.aea = AEA(
-            cls.agent_name,
+            identity,
             connections,
             wallet,
             ledger_apis,
@@ -342,10 +345,11 @@ class TestFilter:
 
         connections = [DummyConnection(connection_id=DUMMY_CONNECTION_PUBLIC_ID)]
         private_key_pem_path = os.path.join(CUR_PATH, "data", "priv.pem")
-        wallet = Wallet({"default": private_key_pem_path})
-        ledger_apis = LedgerApis({}, "default")
+        wallet = Wallet({DEFAULT: private_key_pem_path})
+        ledger_apis = LedgerApis({}, DEFAULT)
+        identity = Identity(cls.agent_name, address=wallet.addresses[DEFAULT])
         cls.aea = AEA(
-            cls.agent_name,
+            identity,
             connections,
             wallet,
             ledger_apis,

--- a/tests/test_skills/test_base.py
+++ b/tests/test_skills/test_base.py
@@ -82,10 +82,6 @@ class TestSkillContext:
         """Test the agent's name."""
         assert self.skill_context.agent_name == self.my_aea.name
 
-    def test_agent_public_keys(self):
-        """Test the agent's public keys."""
-        assert self.skill_context.agent_public_keys == self.my_aea.wallet.public_keys
-
     def test_agent_addresses(self):
         """Test the agent's address."""
         assert self.skill_context.agent_addresses == self.my_aea.wallet.addresses

--- a/tests/test_skills/test_base.py
+++ b/tests/test_skills/test_base.py
@@ -71,7 +71,9 @@ class TestSkillContext:
         )
         cls.ledger_apis = LedgerApis({FETCHAI: {"network": "testnet"}}, FETCHAI)
         cls.connections = [DummyConnection(connection_id=DUMMY_CONNECTION_PUBLIC_ID)]
-        cls.identity = Identity("name", addresses=cls.wallet.addresses, default_address_key=FETCHAI)
+        cls.identity = Identity(
+            "name", addresses=cls.wallet.addresses, default_address_key=FETCHAI
+        )
         cls.my_aea = AEA(
             cls.identity,
             cls.connections,

--- a/tests/test_skills/test_base.py
+++ b/tests/test_skills/test_base.py
@@ -28,10 +28,12 @@ from queue import Queue
 import aea.registries.base
 from aea.aea import AEA, Resources
 from aea.connections.base import ConnectionStatus
+from aea.crypto.default import DEFAULT
 from aea.crypto.fetchai import FETCHAI
 from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet
 from aea.decision_maker.base import GoalPursuitReadiness, OwnershipState, Preferences
+from aea.identity.base import Identity
 from aea.skills.base import Skill, SkillContext
 
 from ..conftest import CUR_PATH, DUMMY_CONNECTION_PUBLIC_ID, DummyConnection
@@ -40,11 +42,12 @@ from ..conftest import CUR_PATH, DUMMY_CONNECTION_PUBLIC_ID, DummyConnection
 def test_agent_context_ledger_apis():
     """Test that the ledger apis configurations are loaded correctly."""
     private_key_pem_path = os.path.join(CUR_PATH, "data", "priv.pem")
-    wallet = Wallet({"default": private_key_pem_path})
+    wallet = Wallet({DEFAULT: private_key_pem_path})
     connections = [DummyConnection(connection_id=DUMMY_CONNECTION_PUBLIC_ID)]
     ledger_apis = LedgerApis({"fetchai": {"network": "testnet"}}, FETCHAI)
+    identity = Identity("name", address=wallet.addresses[DEFAULT])
     my_aea = AEA(
-        "Agent0",
+        identity,
         connections,
         wallet,
         ledger_apis,
@@ -64,12 +67,13 @@ class TestSkillContext:
         private_key_pem_path = os.path.join(CUR_PATH, "data", "priv.pem")
         private_key_txt_path = os.path.join(CUR_PATH, "data", "fet_private_key.txt")
         cls.wallet = Wallet(
-            {"default": private_key_pem_path, FETCHAI: private_key_txt_path}
+            {DEFAULT: private_key_pem_path, FETCHAI: private_key_txt_path}
         )
         cls.ledger_apis = LedgerApis({FETCHAI: {"network": "testnet"}}, FETCHAI)
         cls.connections = [DummyConnection(connection_id=DUMMY_CONNECTION_PUBLIC_ID)]
+        cls.identity = Identity("name", addresses=cls.wallet.addresses, default_address_key=FETCHAI)
         cls.my_aea = AEA(
-            "Agent0",
+            cls.identity,
             cls.connections,
             cls.wallet,
             cls.ledger_apis,
@@ -84,11 +88,11 @@ class TestSkillContext:
 
     def test_agent_addresses(self):
         """Test the agent's address."""
-        assert self.skill_context.agent_addresses == self.my_aea.wallet.addresses
+        assert self.skill_context.agent_addresses == self.my_aea.identity.addresses
 
     def test_agent_address(self):
         """Test the default agent's address."""
-        assert self.skill_context.agent_address == self.my_aea.wallet.addresses[FETCHAI]
+        assert self.skill_context.agent_address == self.my_aea.identity.address
 
     def test_connection_status(self):
         """Test the default agent's connection status."""
@@ -152,11 +156,12 @@ class TestSkillFromDir:
         os.chdir(cls.t)
 
         private_key_pem_path = os.path.join(CUR_PATH, "data", "priv.pem")
-        cls.wallet = Wallet({"default": private_key_pem_path})
+        cls.wallet = Wallet({DEFAULT: private_key_pem_path})
         ledger_apis = LedgerApis({}, FETCHAI)
         cls.connections = [DummyConnection(connection_id=DUMMY_CONNECTION_PUBLIC_ID)]
+        cls.identity = Identity("name", address=cls.wallet.addresses[DEFAULT])
         cls.my_aea = AEA(
-            "agent_name",
+            cls.identity,
             cls.connections,
             cls.wallet,
             ledger_apis,

--- a/tests/test_skills/test_error.py
+++ b/tests/test_skills/test_error.py
@@ -27,6 +27,7 @@ from aea.aea import AEA
 from aea.crypto.default import DEFAULT
 from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet
+from aea.identity.base import Identity
 from aea.mail.base import Envelope
 from aea.protocols.default.message import DefaultMessage
 from aea.protocols.default.serialization import DefaultSerializer
@@ -52,15 +53,16 @@ class TestSkillError:
         """Test the initialisation of the AEA."""
         cls.node = LocalNode()
         private_key_pem_path = os.path.join(CUR_PATH, "data", "priv.pem")
-        cls.wallet = Wallet({"default": private_key_pem_path})
+        cls.wallet = Wallet({DEFAULT: private_key_pem_path})
         cls.ledger_apis = LedgerApis({}, DEFAULT)
         cls.agent_name = "Agent0"
-        cls.address = cls.wallet.addresses["default"]
 
         cls.connection = DummyConnection(connection_id=DUMMY_CONNECTION_PUBLIC_ID)
         cls.connections = [cls.connection]
+        cls.identity = Identity(cls.agent_name, address=cls.wallet.addresses[DEFAULT])
+        cls.address = cls.identity.address
         cls.my_aea = AEA(
-            cls.agent_name,
+            cls.identity,
             cls.connections,
             cls.wallet,
             cls.ledger_apis,


### PR DESCRIPTION
## Proposed changes

This PR introduces an `Identity` object. This is used by in the agent `Agent(identity, [connections])` and the AEA `AEA(identity, ...)`.

For now, it just contains the name and public key and address (if set). Later, it will also include other identity claims. It is introduced now to be forward compatible to these changes and not break the AEA and Agent constructor when they are extended.

## Fixes

#699 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

-