### PR TITLE
Feature/registry test coverage [AEA-328]

### DIFF
--- a/aea/cli/registry/utils.py
+++ b/aea/cli/registry/utils.py
@@ -262,8 +262,8 @@ def read_cli_config() -> Dict:
 def _rm_tarfiles():
     cwd = os.getcwd()
     for filename in os.listdir(cwd):
-        filepath = os.path.join(cwd, filename)
-        if filepath.endswith(".tar.gz"):
+        if filename.endswith(".tar.gz"):
+            filepath = os.path.join(cwd, filename)
             os.remove(filepath)
 
 

--- a/tests/test_cli/test_publish.py
+++ b/tests/test_cli/test_publish.py
@@ -24,7 +24,11 @@ from click import ClickException
 
 from aea.cli.publish import _check_is_item_in_local_registry, _save_agent_locally
 
-from tests.test_cli.tools_for_testing import ContextMock, PublicIdMock
+from tests.test_cli.tools_for_testing import (
+    ContextMock,
+    PublicIdMock,
+    raise_click_exception,
+)
 
 
 @mock.patch("aea.cli.publish._check_is_item_in_local_registry")
@@ -53,10 +57,6 @@ class SaveAgentLocallyTestCase(TestCase):
         copyfile_mock.assert_called_once_with("joined-path", "joined-path")
 
 
-def _raise_click_exception(*args):
-    raise ClickException("Message")
-
-
 class CheckIsItemInLocalRegistryTestCase(TestCase):
     """Test case for _check_is_item_in_local_registry method."""
 
@@ -71,7 +71,7 @@ class CheckIsItemInLocalRegistryTestCase(TestCase):
             registry_path, public_id.author, item_type_plural, public_id.name
         )
 
-    @mock.patch("aea.cli.publish.try_get_item_source_path", _raise_click_exception)
+    @mock.patch("aea.cli.publish.try_get_item_source_path", raise_click_exception)
     def test__check_is_item_in_local_registry_negative(self):
         """Test for _check_is_item_in_local_registry negative result."""
         public_id = PublicIdMock.from_str("author/name:version")

--- a/tests/test_cli/test_registry/test_publish.py
+++ b/tests/test_cli/test_registry/test_publish.py
@@ -22,11 +22,7 @@ from unittest import TestCase, mock
 
 from click import ClickException
 
-from aea.cli.registry.publish import (
-    _compress,
-    _load_agent_config,
-    publish_agent
-)
+from aea.cli.registry.publish import _compress, _load_agent_config, publish_agent
 
 from tests.test_cli.tools_for_testing import ContextMock
 
@@ -109,5 +105,5 @@ class CompressTestCase(TestCase):
         open_mock = mock.MagicMock(return_value=tar_obj_mock)
         tarfile_mock.open = open_mock
 
-        _compress('output_filename', 'file1', 'file2')
-        open_mock.assert_called_once_with('output_filename', 'w:gz')
+        _compress("output_filename", "file1", "file2")
+        open_mock.assert_called_once_with("output_filename", "w:gz")

--- a/tests/test_cli/test_registry/test_publish.py
+++ b/tests/test_cli/test_registry/test_publish.py
@@ -22,7 +22,11 @@ from unittest import TestCase, mock
 
 from click import ClickException
 
-from aea.cli.registry.publish import _load_agent_config, publish_agent
+from aea.cli.registry.publish import (
+    _compress,
+    _load_agent_config,
+    publish_agent
+)
 
 from tests.test_cli.tools_for_testing import ContextMock
 
@@ -93,3 +97,17 @@ class LoadAgentConfigTestCase(TestCase):
             _load_agent_config("path")
 
         load_yaml_mock.assert_not_called()
+
+
+@mock.patch("aea.cli.registry.publish.tarfile")
+class CompressTestCase(TestCase):
+    """Test case for _compress method."""
+
+    def test__compress_positive(self, tarfile_mock):
+        """Test for _compress positive result."""
+        tar_obj_mock = mock.MagicMock()
+        open_mock = mock.MagicMock(return_value=tar_obj_mock)
+        tarfile_mock.open = open_mock
+
+        _compress('output_filename', 'file1', 'file2')
+        open_mock.assert_called_once_with('output_filename', 'w:gz')

--- a/tests/test_cli/test_registry/test_push.py
+++ b/tests/test_cli/test_registry/test_push.py
@@ -126,6 +126,6 @@ class CompressDirTestCase(TestCase):
         open_mock = mock.MagicMock(return_value=tar_obj_mock)
         tarfile_mock.open = open_mock
 
-        _compress_dir('output_filename', 'source_dir')
-        _remove_pycache_mock.assert_called_once_with('source_dir')
-        open_mock.assert_called_once_with('output_filename', 'w:gz')
+        _compress_dir("output_filename", "source_dir")
+        _remove_pycache_mock.assert_called_once_with("source_dir")
+        open_mock.assert_called_once_with("output_filename", "w:gz")

--- a/tests/test_cli/test_registry/test_push.py
+++ b/tests/test_cli/test_registry/test_push.py
@@ -23,7 +23,7 @@ from unittest import TestCase, mock
 
 from click import ClickException
 
-from aea.cli.registry.push import _remove_pycache, push_item
+from aea.cli.registry.push import _compress_dir, _remove_pycache, push_item
 
 from tests.test_cli.tools_for_testing import ContextMock, PublicIdMock
 
@@ -113,3 +113,19 @@ class RemovePycacheTestCase(TestCase):
         source_dir = "somedir"
         _remove_pycache(source_dir)
         rmtree_mock.assert_not_called()
+
+
+@mock.patch("aea.cli.registry.push.tarfile")
+@mock.patch("aea.cli.registry.push._remove_pycache")
+class CompressDirTestCase(TestCase):
+    """Test case for _compress_dir method."""
+
+    def test__compress_dir_positive(self, _remove_pycache_mock, tarfile_mock):
+        """Test for _compress_dir positive result."""
+        tar_obj_mock = mock.MagicMock()
+        open_mock = mock.MagicMock(return_value=tar_obj_mock)
+        tarfile_mock.open = open_mock
+
+        _compress_dir('output_filename', 'source_dir')
+        _remove_pycache_mock.assert_called_once_with('source_dir')
+        open_mock.assert_called_once_with('output_filename', 'w:gz')

--- a/tests/test_cli/test_registry/test_utils.py
+++ b/tests/test_cli/test_registry/test_utils.py
@@ -100,7 +100,7 @@ class RequestAPITestCase(TestCase):
         self.assertEqual(result, expected_result)
 
     def test_request_api_404(self, request_mock):
-        """Test for request_api method 404 sever response."""
+        """Test for request_api method 404 server response."""
         resp_mock = mock.Mock()
         resp_mock.status_code = 404
         request_mock.return_value = resp_mock
@@ -108,7 +108,7 @@ class RequestAPITestCase(TestCase):
             request_api("GET", "/path")
 
     def test_request_api_201(self, request_mock):
-        """Test for request_api method 201 sever response."""
+        """Test for request_api method 201 server response."""
         expected_result = {"correct": "json"}
 
         resp_mock = mock.Mock()
@@ -119,7 +119,7 @@ class RequestAPITestCase(TestCase):
         self.assertEqual(result, expected_result)
 
     def test_request_api_403(self, request_mock):
-        """Test for request_api method not authorized sever response."""
+        """Test for request_api method not authorized server response."""
         resp_mock = mock.Mock()
         resp_mock.status_code = 403
         request_mock.return_value = resp_mock
@@ -127,7 +127,7 @@ class RequestAPITestCase(TestCase):
             request_api("GET", "/path")
 
     def test_request_api_400(self, request_mock):
-        """Test for request_api method 400 code sever response."""
+        """Test for request_api method 400 code server response."""
         resp_mock = mock.Mock()
         resp_mock.status_code = 400
         request_mock.return_value = resp_mock
@@ -135,7 +135,7 @@ class RequestAPITestCase(TestCase):
             request_api("GET", "/path")
 
     def test_request_api_409(self, request_mock):
-        """Test for request_api method conflict sever response."""
+        """Test for request_api method conflict server response."""
         resp_mock = mock.Mock()
         resp_mock.status_code = 409
         resp_mock.json = lambda: {"detail": "some"}
@@ -144,7 +144,7 @@ class RequestAPITestCase(TestCase):
             request_api("GET", "/path")
 
     def test_request_api_unexpected_response(self, request_mock):
-        """Test for request_api method unexpected sever response."""
+        """Test for request_api method unexpected server response."""
         resp_mock = mock.Mock()
         resp_mock.status_code = 500
         request_mock.return_value = resp_mock

--- a/tests/test_cli/tools_for_testing.py
+++ b/tests/test_cli/tools_for_testing.py
@@ -20,7 +20,14 @@
 
 from typing import List
 
+from click import ClickException
+
 from tests.test_cli.constants import DEFAULT_TESTING_VERSION
+
+
+def raise_click_exception(*args):
+    """Raise ClickException."""
+    raise ClickException("Message")
 
 
 class AgentConfigMock:


### PR DESCRIPTION
## Proposed changes

Test coverage of `aea.cli.registry` subpackage.
#684 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
