### PR TITLE
AEA-368 - Add minimal aea install.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,14 @@ def get_all_extras() -> Dict:
 
 all_extras = get_all_extras()
 
+base_deps = [
+   *all_extras.get("crypto", []),
+    "PyYAML",
+    "jsonschema",
+    "protobuf",
+    "watchdog"
+]
+
 here = os.path.abspath(os.path.dirname(__file__))
 about = {}
 with open(os.path.join(here, PACKAGE_NAME, '__version__.py'), 'r') as f:
@@ -122,10 +130,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
-    install_requires=[
-        *all_extras.get("crypto", []),
-        *all_extras.get("cli", []),
-    ],
+    install_requires=base_deps,
     tests_require=["tox"],
     extras_require=all_extras,
     entry_points={


### PR DESCRIPTION
## Proposed changes

This PR defines a minimal installation of the `aea` package, that includes the following dependencies:
```
PyYAML      # to load configuration files
jsonschema      # to validate configuration files
protobuf      # serialization
watchdog      # stub connection
web3==5.2.2      # ethereum integration
eth-account==0.4.0      # ethereum integration
fetchai-ledger-api==1.0.0rc1      # fetchai integration
```
notice that `click`  and `python-dotenv` of `cli` extra have been removed.

To check that, create a temporary virtual environment, install `aea`, and try to run the AEA programmatically: https://fetchai.github.io/agents-aea/build-aea-programmatically

## Fixes

Fixes #736 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
