### PR TITLE
Fix tx_nonce generator

### DIFF
--- a/aea/crypto/ledger_apis.py
+++ b/aea/crypto/ledger_apis.py
@@ -248,7 +248,7 @@ class LedgerApis(object):
                 )
                 tx_nonce = ""
         else:
-            logger.warning(" You didn't specify a ledger so the tx_nonce will be Empty.")
+            logger.warning("You didn't specify a ledger so the tx_nonce will be Empty.")
             tx_nonce = ""
         return tx_nonce
 

--- a/aea/crypto/ledger_apis.py
+++ b/aea/crypto/ledger_apis.py
@@ -238,14 +238,17 @@ class LedgerApis(object):
         :param client: the address of the client.
         :return: return the hash in hex.
         """
-        try:
-            assert identifier in self.apis.keys()
-            api = self.apis[identifier]
-            tx_nonce = api.generate_tx_nonce(seller=seller, client=client)
-        except Exception:
-            logger.warning(
-                "An error occurred while attempting to generate the tx_nonce. You didn't specify a ledger so the tx_nonce will be Empty."
-            )
+        if identifier in self.apis.keys():
+            try:
+                api = self.apis[identifier]
+                tx_nonce = api.generate_tx_nonce(seller=seller, client=client)
+            except Exception:
+                logger.warning(
+                    "An error occurred while attempting to generate the tx_nonce."
+                )
+                tx_nonce = ""
+        else:
+            logger.warning(" You didn't specify a ledger so the tx_nonce will be Empty.")
             tx_nonce = ""
         return tx_nonce
 

--- a/aea/crypto/ledger_apis.py
+++ b/aea/crypto/ledger_apis.py
@@ -238,13 +238,13 @@ class LedgerApis(object):
         :param client: the address of the client.
         :return: return the hash in hex.
         """
-        assert identifier in self.apis.keys()
-        api = self.apis[identifier]
         try:
+            assert identifier in self.apis.keys()
+            api = self.apis[identifier]
             tx_nonce = api.generate_tx_nonce(seller=seller, client=client)
         except Exception:
             logger.warning(
-                "An error occurred while attempting to generate the tx_nonce"
+                "An error occurred while attempting to generate the tx_nonce. You didn't specify a ledger so the tx_nonce will be Empty."
             )
             tx_nonce = ""
         return tx_nonce


### PR DESCRIPTION
## Proposed changes

The way we generating the transaction nonce it asserts if the identifier exists in the `ledger_apis.keys()`. But when we don't want to transact with a ledger we cannot generate a `tx_nonce` because we implemented this functionality inside the `LedgerApi` of each token. I added the assertion inside the try/catch block so it will return an empty tx_nonce.

## Fixes

#788

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules