### PR TITLE
remove pyyaml and jsonschema from base dependencies.

### DIFF
--- a/aea/registries/base.py
+++ b/aea/registries/base.py
@@ -38,7 +38,6 @@ from aea.configurations.base import (
     PublicId,
     SkillId,
 )
-from aea.configurations.loader import ConfigLoader
 from aea.decision_maker.messages.base import InternalMessage
 from aea.decision_maker.messages.transaction import TransactionMessage
 from aea.protocols.base import Message, Protocol
@@ -250,6 +249,9 @@ class ProtocolRegistry(Registry[PublicId, Protocol]):
         )
         serializer = serializer_class()
 
+        # we import the loader here because the minimal install does not support
+        # loading a skill from a skill directory.
+        from aea.configurations.loader import ConfigLoader
         config_loader = ConfigLoader("protocol-config_schema.json", ProtocolConfig)
         protocol_config = config_loader.load(
             open(protocol_directory / DEFAULT_PROTOCOL_CONFIG_FILE)

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -41,7 +41,6 @@ from aea.configurations.base import (
     PublicId,
     SkillConfig,
 )
-from aea.configurations.loader import ConfigLoader
 from aea.connections.base import ConnectionStatus
 from aea.context.base import AgentContext
 from aea.crypto.ledger_apis import LedgerApis
@@ -524,6 +523,9 @@ class Skill:
         :raises Exception: if the parsing failed.
         """
         # check if there is the config file. If not, then return None.
+        # we import the loader here because the minimal install does not support
+        # loading a skill from a skill directory.
+        from aea.configurations.loader import ConfigLoader
         skill_loader = ConfigLoader("skill-config_schema.json", SkillConfig)
         skill_config = skill_loader.load(
             open(os.path.join(directory, DEFAULT_SKILL_CONFIG_FILE))

--- a/setup.py
+++ b/setup.py
@@ -98,8 +98,6 @@ all_extras = get_all_extras()
 
 base_deps = [
    *all_extras.get("crypto", []),
-    "PyYAML",
-    "jsonschema",
     "protobuf",
     "watchdog"
 ]


### PR DESCRIPTION
## Proposed changes

Remove `PyYAML` and `jsonschema` from base dependencies (although `jsonschema` is still needed for another main dependency).

The imports have been pushed inside the methods that needed those dependencies. 
Although it is not a good practice, sometimes can simplify things and avoid complex refactoring.

## Fixes

Fixes #760 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
