### PR TITLE
Fix `aea scaffold` when an invalid package name is given as input.

### DIFF
--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -22,6 +22,7 @@
 import logging
 import logging.config
 import os
+import re
 import shutil
 import sys
 from collections import OrderedDict
@@ -343,6 +344,19 @@ class PublicIdParameter(click.ParamType):
             return PublicId.from_str(value)
         except ValueError:
             raise click.BadParameter(value)
+
+
+def validate_package_name(package_name: str):
+    """Check that the package name matches the pattern r"[a-zA-Z_][a-zA-Z0-9_]*".
+
+    >>> validate_package_name("this_is_a_good_package_name")
+    >>> validate_package_name("this-is-not")
+    Traceback (most recent call last):
+    ...
+    click.exceptions.BadParameter: this-is-not is not a valid package name.
+    """
+    if re.fullmatch(PublicId.PACKAGE_NAME_REGEX, package_name) is None:
+        raise click.BadParameter("{} is not a valid package name.".format(package_name))
 
 
 def try_get_item_source_path(

--- a/aea/cli/scaffold.py
+++ b/aea/cli/scaffold.py
@@ -35,6 +35,7 @@ from aea.cli.common import (
     logger,
     pass_ctx,
     try_to_load_agent_config,
+    validate_package_name,
 )
 from aea.configurations.base import DEFAULT_AEA_CONFIG_FILE, PublicId
 from aea.configurations.base import (  # noqa: F401
@@ -77,6 +78,7 @@ def skill(ctx: Context, skill_name: str):
 
 def _scaffold_item(ctx: Context, item_type, item_name):
     """Add an item scaffolding to the configuration file and agent."""
+    validate_package_name(item_name)
     author_name = ctx.agent_config.author
     loader = getattr(ctx, "{}_loader".format(item_type))
     default_config_filename = globals()[


### PR DESCRIPTION
## Proposed changes

This PR fixes an issue of `aea scaffold` when an invalid package name is given as input.

E.g.: the result of the following command
```
aea scaffold protocol hello-world
```
used to fail, making the `aea-config.yaml` file empty.

## Fixes

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that code coverage does not decrease.
- [X] I have checked that the documentation about the `aea cli` tool works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
