### PR TITLE
first step towards simplifying protocol loading

### DIFF
--- a/aea/protocols/base.py
+++ b/aea/protocols/base.py
@@ -38,8 +38,7 @@ from aea.configurations.base import (
 )
 from aea.configurations.loader import ConfigLoader
 from aea.helpers.base import (
-    # add_agent_component_module_to_sys_modules,
-    # load_agent_component_package,
+    add_agent_component_module_to_sys_modules,
     load_module,
 )
 from aea.mail.base import Address
@@ -278,12 +277,9 @@ class Protocol(ABC):
             open(os.path.join(directory, DEFAULT_PROTOCOL_CONFIG_FILE))
         )
         protocol_module = load_module("protocols", Path(directory, "serialization.py"))
-        # protocol_module = load_agent_component_package(
-        #     "protocol", protocol_config.name, protocol_config.author, Path(directory)
-        # )
-        # add_agent_component_module_to_sys_modules(
-        #     "protocol", protocol_config.name, protocol_config.author, protocol_module
-        # )
+        add_agent_component_module_to_sys_modules(
+            "protocol", protocol_config.name, protocol_config.author, protocol_module
+        )
         classes = inspect.getmembers(protocol_module, inspect.isclass)
         serializer_classes = list(
             filter(lambda x: re.match("\\w+Serializer", x[0]), classes)
@@ -294,5 +290,5 @@ class Protocol(ABC):
         protocol_id = PublicId(
             protocol_config.author, protocol_config.name, protocol_config.version
         )
-        protocol = Protocol(protocol_id, serializer_class, protocol_config)
+        protocol = Protocol(protocol_id, serializer_class(), protocol_config)
         return protocol

--- a/aea/protocols/base.py
+++ b/aea/protocols/base.py
@@ -19,14 +19,29 @@
 
 """This module contains the base message and serialization definition."""
 
+import inspect
 import json
+import os
+import re
 from abc import ABC, abstractmethod
 from copy import copy
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from google.protobuf.struct_pb2 import Struct
 
-from aea.configurations.base import ProtocolConfig, ProtocolId, PublicId
+from aea.configurations.base import (
+    DEFAULT_PROTOCOL_CONFIG_FILE,
+    ProtocolConfig,
+    ProtocolId,
+    PublicId,
+)
+from aea.configurations.loader import ConfigLoader
+from aea.helpers.base import (
+    # add_agent_component_module_to_sys_modules,
+    # load_agent_component_package,
+    load_module,
+)
 from aea.mail.base import Address
 
 
@@ -246,3 +261,38 @@ class Protocol(ABC):
     def config(self) -> ProtocolConfig:
         """Get the configuration."""
         return self._config
+
+    @classmethod
+    def from_dir(cls, directory: str) -> "Protocol":
+        """
+        Load a protocol from a directory.
+
+        :param directory: the skill directory.
+        :param agent_context: the agent's context
+        :return: the Protocol object.
+        :raises Exception: if the parsing failed.
+        """
+        # check if there is the config file. If not, then return None.
+        protocol_loader = ConfigLoader("protocol-config_schema.json", ProtocolConfig)
+        protocol_config = protocol_loader.load(
+            open(os.path.join(directory, DEFAULT_PROTOCOL_CONFIG_FILE))
+        )
+        protocol_module = load_module("protocols", Path(directory, "serialization.py"))
+        # protocol_module = load_agent_component_package(
+        #     "protocol", protocol_config.name, protocol_config.author, Path(directory)
+        # )
+        # add_agent_component_module_to_sys_modules(
+        #     "protocol", protocol_config.name, protocol_config.author, protocol_module
+        # )
+        classes = inspect.getmembers(protocol_module, inspect.isclass)
+        serializer_classes = list(
+            filter(lambda x: re.match("\\w+Serializer", x[0]), classes)
+        )
+        assert len(serializer_classes) == 1, "Not exactly one serializer detected."
+        serializer_class = serializer_classes[0][1]
+
+        protocol_id = PublicId(
+            protocol_config.author, protocol_config.name, protocol_config.version
+        )
+        protocol = Protocol(protocol_id, serializer_class, protocol_config)
+        return protocol

--- a/aea/registries/base.py
+++ b/aea/registries/base.py
@@ -594,6 +594,10 @@ class Resources(object):
             for model in skill.models.values():
                 self.model_registry.register((skill_id, model.name), model)
 
+    def add_protocol(self, protocol: Protocol):
+        """Add a protocol to the set of resources."""
+        self.protocol_registry.register(protocol.id, protocol)
+
     def get_skill(self, skill_id: SkillId) -> Optional[Skill]:
         """Get the skill."""
         return self._skills.get(skill_id, None)

--- a/docs/build-aea-programmatically.md
+++ b/docs/build-aea-programmatically.md
@@ -14,8 +14,6 @@ First, import the necessary common Python libraries and classes.
 import os
 import time
 from threading import Thread
-
-import yaml
 ```
 
 Then, import the application specific libraries.
@@ -23,7 +21,6 @@ Then, import the application specific libraries.
 ``` python
 from aea import AEA_DIR
 from aea.aea import AEA
-from aea.configurations.base import ProtocolConfig, PublicId
 from aea.connections.stub.connection import StubConnection
 from aea.crypto.fetchai import FETCHAI
 from aea.crypto.helpers import FETCHAI_PRIVATE_KEY_FILE, _create_fetchai_private_key
@@ -31,7 +28,6 @@ from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet
 from aea.identity.base import Identity
 from aea.protocols.base import Protocol
-from aea.protocols.default.serialization import DefaultSerializer
 from aea.registries.base import Resources
 from aea.skills.base import Skill
 ```
@@ -86,19 +82,8 @@ Then we pass all of this into the AEA constructor to create our AEA.
 Create the default protocol and add it to the AEA.
 ``` python
     # Add the default protocol (which is part of the AEA distribution)
-    default_protocol_configuration = ProtocolConfig.from_json(
-        yaml.safe_load(
-            open(os.path.join(AEA_DIR, "protocols", "default", "protocol.yaml"))
-        )
-    )
-    default_protocol = Protocol(
-        PublicId.from_str("fetchai/default:0.1.0"),
-        DefaultSerializer(),
-        default_protocol_configuration,
-    )
-    resources.protocol_registry.register(
-        PublicId.from_str("fetchai/default:0.1.0"), default_protocol
-    )
+    default_protocol = Protocol.from_dir(os.path.join(AEA_DIR, "protocols", "default"))
+    resources.add_protocol(default_protocol)
 ```
 
 Create the error skill (needed by all AEAs) and the echo skill which will bounce our messages back to us, and add them both to the AEA.
@@ -171,11 +156,8 @@ import os
 import time
 from threading import Thread
 
-import yaml
-
 from aea import AEA_DIR
 from aea.aea import AEA
-from aea.configurations.base import ProtocolConfig, PublicId
 from aea.connections.stub.connection import StubConnection
 from aea.crypto.fetchai import FETCHAI
 from aea.crypto.helpers import FETCHAI_PRIVATE_KEY_FILE, _create_fetchai_private_key
@@ -183,7 +165,6 @@ from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet
 from aea.identity.base import Identity
 from aea.protocols.base import Protocol
-from aea.protocols.default.serialization import DefaultSerializer
 from aea.registries.base import Resources
 from aea.skills.base import Skill
 
@@ -220,19 +201,8 @@ def run():
     my_aea = AEA(identity, [stub_connection], wallet, ledger_apis, resources)
 
     # Add the default protocol (which is part of the AEA distribution)
-    default_protocol_configuration = ProtocolConfig.from_json(
-        yaml.safe_load(
-            open(os.path.join(AEA_DIR, "protocols", "default", "protocol.yaml"))
-        )
-    )
-    default_protocol = Protocol(
-        PublicId.from_str("fetchai/default:0.1.0"),
-        DefaultSerializer(),
-        default_protocol_configuration,
-    )
-    resources.protocol_registry.register(
-        PublicId.from_str("fetchai/default:0.1.0"), default_protocol
-    )
+    default_protocol = Protocol.from_dir(os.path.join(AEA_DIR, "protocols", "default"))
+    resources.add_protocol(default_protocol)
 
     # Add the error skill (from the local packages dir) and the echo skill (which is part of the AEA distribution)
     echo_skill = Skill.from_dir(

--- a/docs/cli-vs-programmatic-aeas.md
+++ b/docs/cli-vs-programmatic-aeas.md
@@ -64,24 +64,18 @@ import time
 from threading import Thread
 from typing import cast
 
-import yaml
-
 from aea import AEA_DIR
 from aea.aea import AEA
-from aea.configurations.base import ProtocolConfig, PublicId
 from aea.crypto.fetchai import FETCHAI
 from aea.crypto.helpers import FETCHAI_PRIVATE_KEY_FILE, _create_fetchai_private_key
 from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet
 from aea.identity.base import Identity
 from aea.protocols.base import Protocol
-from aea.protocols.default.serialization import DefaultSerializer
 from aea.registries.base import Resources
 from aea.skills.base import Skill
 
 from packages.fetchai.connections.oef.connection import OEFConnection
-from packages.fetchai.protocols.fipa.serialization import FIPASerializer
-from packages.fetchai.protocols.oef.serialization import OEFSerializer
 from packages.fetchai.skills.weather_client.strategy import Strategy
 
 HOST = "127.0.0.1"
@@ -112,67 +106,32 @@ def run():
     )
 
     # Add the default protocol (which is part of the AEA distribution)
-    default_protocol_configuration = ProtocolConfig.from_json(
-        yaml.safe_load(
-            open(os.path.join(AEA_DIR, "protocols", "default", "protocol.yaml"))
-        )
-    )
-    default_protocol = Protocol(
-        PublicId.from_str("fetchai/default:0.1.0"),
-        DefaultSerializer(),
-        default_protocol_configuration,
-    )
-    resources.protocol_registry.register(
-        PublicId.from_str("fetchai/default:0.1.0"), default_protocol
-    )
+    default_protocol = Protocol.from_dir(os.path.join(AEA_DIR, "protocols", "default"))
+    resources.add_protocol(default_protocol)
 
     # Add the oef protocol (which is a package)
-    oef_protocol_configuration = ProtocolConfig.from_json(
-        yaml.safe_load(
-            open(
+    oef_protocol = Protocol.from_dir(
                 os.path.join(
                     os.getcwd(),
                     "packages",
                     "fetchai",
                     "protocols",
                     "oef",
-                    "protocol.yaml",
                 )
-            )
         )
-    )
-    oef_protocol = Protocol(
-        PublicId.from_str("fetchai/oef:0.1.0"),
-        OEFSerializer(),
-        oef_protocol_configuration,
-    )
-    resources.protocol_registry.register(
-        PublicId.from_str("fetchai/oef:0.1.0"), oef_protocol
-    )
+    resources.add_protocol(oef_protocol)
 
     # Add the fipa protocol (which is a package)
-    fipa_protocol_configuration = ProtocolConfig.from_json(
-        yaml.safe_load(
-            open(
+    fipa_protocol = Protocol.from_dir(
                 os.path.join(
-                    ROOT_DIR,
+                    os.getcwd(),
                     "packages",
                     "fetchai",
                     "protocols",
                     "fipa",
-                    "protocol.yaml",
                 )
-            )
         )
-    )
-    fipa_protocol = Protocol(
-        PublicId.from_str("fetchai/fipa:0.1.0"),
-        FIPASerializer(),
-        fipa_protocol_configuration,
-    )
-    resources.protocol_registry.register(
-        PublicId.from_str("fetchai/fipa:0.1.0"), fipa_protocol
-    )
+    resources.add_protocol(fipa_protocol)
 
     # Add the error and weather_station skills
     error_skill = Skill.from_dir(

--- a/tests/test_docs/test_build_aea_programmatically/programmatic_aea.py
+++ b/tests/test_docs/test_build_aea_programmatically/programmatic_aea.py
@@ -23,11 +23,8 @@ import os
 import time
 from threading import Thread
 
-import yaml
-
 from aea import AEA_DIR
 from aea.aea import AEA
-from aea.configurations.base import ProtocolConfig, PublicId
 from aea.connections.stub.connection import StubConnection
 from aea.crypto.fetchai import FETCHAI
 from aea.crypto.helpers import FETCHAI_PRIVATE_KEY_FILE, _create_fetchai_private_key
@@ -35,7 +32,6 @@ from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet
 from aea.identity.base import Identity
 from aea.protocols.base import Protocol
-from aea.protocols.default.serialization import DefaultSerializer
 from aea.registries.base import Resources
 from aea.skills.base import Skill
 
@@ -72,19 +68,8 @@ def run():
     my_aea = AEA(identity, [stub_connection], wallet, ledger_apis, resources)
 
     # Add the default protocol (which is part of the AEA distribution)
-    default_protocol_configuration = ProtocolConfig.from_json(
-        yaml.safe_load(
-            open(os.path.join(AEA_DIR, "protocols", "default", "protocol.yaml"))
-        )
-    )
-    default_protocol = Protocol(
-        PublicId.from_str("fetchai/default:0.1.0"),
-        DefaultSerializer(),
-        default_protocol_configuration,
-    )
-    resources.protocol_registry.register(
-        PublicId.from_str("fetchai/default:0.1.0"), default_protocol
-    )
+    default_protocol = Protocol.from_dir(os.path.join(AEA_DIR, "protocols", "default"))
+    resources.add_protocol(default_protocol)
 
     # Add the error skill (from the local packages dir) and the echo skill (which is part of the AEA distribution)
     echo_skill = Skill.from_dir(

--- a/tests/test_docs/test_cli_vs_programmatic_aeas/programmatic_aea.py
+++ b/tests/test_docs/test_cli_vs_programmatic_aeas/programmatic_aea.py
@@ -25,24 +25,18 @@ import time
 from threading import Thread
 from typing import cast
 
-import yaml
-
 from aea import AEA_DIR
 from aea.aea import AEA
-from aea.configurations.base import ProtocolConfig, PublicId
 from aea.crypto.fetchai import FETCHAI
 from aea.crypto.helpers import FETCHAI_PRIVATE_KEY_FILE, _create_fetchai_private_key
 from aea.crypto.ledger_apis import LedgerApis
 from aea.crypto.wallet import Wallet
 from aea.identity.base import Identity
 from aea.protocols.base import Protocol
-from aea.protocols.default.serialization import DefaultSerializer
 from aea.registries.base import Resources
 from aea.skills.base import Skill
 
 from packages.fetchai.connections.oef.connection import OEFConnection
-from packages.fetchai.protocols.fipa.serialization import FIPASerializer
-from packages.fetchai.protocols.oef.serialization import OEFSerializer
 from packages.fetchai.skills.weather_client.strategy import Strategy
 
 HOST = "127.0.0.1"
@@ -73,67 +67,20 @@ def run():
     )
 
     # Add the default protocol (which is part of the AEA distribution)
-    default_protocol_configuration = ProtocolConfig.from_json(
-        yaml.safe_load(
-            open(os.path.join(AEA_DIR, "protocols", "default", "protocol.yaml"))
-        )
-    )
-    default_protocol = Protocol(
-        PublicId.from_str("fetchai/default:0.1.0"),
-        DefaultSerializer(),
-        default_protocol_configuration,
-    )
-    resources.protocol_registry.register(
-        PublicId.from_str("fetchai/default:0.1.0"), default_protocol
-    )
+    default_protocol = Protocol.from_dir(os.path.join(AEA_DIR, "protocols", "default"))
+    resources.add_protocol(default_protocol)
 
     # Add the oef protocol (which is a package)
-    oef_protocol_configuration = ProtocolConfig.from_json(
-        yaml.safe_load(
-            open(
-                os.path.join(
-                    os.getcwd(),
-                    "packages",
-                    "fetchai",
-                    "protocols",
-                    "oef",
-                    "protocol.yaml",
-                )
-            )
-        )
+    oef_protocol = Protocol.from_dir(
+        os.path.join(os.getcwd(), "packages", "fetchai", "protocols", "oef",)
     )
-    oef_protocol = Protocol(
-        PublicId.from_str("fetchai/oef:0.1.0"),
-        OEFSerializer(),
-        oef_protocol_configuration,
-    )
-    resources.protocol_registry.register(
-        PublicId.from_str("fetchai/oef:0.1.0"), oef_protocol
-    )
+    resources.add_protocol(oef_protocol)
 
     # Add the fipa protocol (which is a package)
-    fipa_protocol_configuration = ProtocolConfig.from_json(
-        yaml.safe_load(
-            open(
-                os.path.join(
-                    ROOT_DIR,
-                    "packages",
-                    "fetchai",
-                    "protocols",
-                    "fipa",
-                    "protocol.yaml",
-                )
-            )
-        )
+    fipa_protocol = Protocol.from_dir(
+        os.path.join(os.getcwd(), "packages", "fetchai", "protocols", "fipa",)
     )
-    fipa_protocol = Protocol(
-        PublicId.from_str("fetchai/fipa:0.1.0"),
-        FIPASerializer(),
-        fipa_protocol_configuration,
-    )
-    resources.protocol_registry.register(
-        PublicId.from_str("fetchai/fipa:0.1.0"), fipa_protocol
-    )
+    resources.add_protocol(fipa_protocol)
 
     # Add the error and weather_station skills
     error_skill = Skill.from_dir(

--- a/tests/test_protocols/test_base.py
+++ b/tests/test_protocols/test_base.py
@@ -19,8 +19,12 @@
 
 """This module contains the tests of the messages module."""
 
+import os
+import shutil
+import tempfile
 from typing import cast
 
+from aea import AEA_DIR
 from aea.configurations.base import ProtocolConfig, PublicId
 from aea.mail.base import Envelope
 from aea.protocols.base import (
@@ -107,3 +111,32 @@ class TestBaseSerializations:
             config=ProtocolConfig(),
         )
         assert protocol.config is not None
+
+
+class TestProtocolFromDir:
+    """Test the 'Protocol.from_dir' method."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the tests up."""
+        cls.cwd = os.getcwd()
+        cls.t = tempfile.mkdtemp()
+        os.chdir(cls.t)
+
+    def test_protocol_load_positive(self):
+        """Test protocol loaded correctly."""
+        default_protocol = Protocol.from_dir(
+            os.path.join(AEA_DIR, "protocols", "default")
+        )
+        assert (
+            str(default_protocol.id) == "fetchai/default:0.1.0"
+        ), "Protocol not loaded correctly."
+
+    @classmethod
+    def teardown_class(cls):
+        """Tear the tests down."""
+        os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -42,7 +42,7 @@ from aea.protocols.base import Protocol
 from aea.protocols.default.message import DefaultMessage
 from aea.registries.base import ProtocolRegistry, Resources
 
-from .conftest import CUR_PATH, DUMMY_CONNECTION_PUBLIC_ID, DummyConnection
+from .conftest import CUR_PATH, DUMMY_CONNECTION_PUBLIC_ID, DummyConnection, ROOT_DIR
 
 
 class TestProtocolRegistry:
@@ -173,6 +173,11 @@ class TestResources:
             PublicId("fetchai", "error", "0.1.0"),
         }
 
+        cls.expected_protocols = {
+            PublicId("fetchai", "default", "0.1.0"),
+            PublicId("fetchai", "oef", "0.1.0"),
+        }
+
     def test_unregister_handler(self):
         """Test that the unregister of handlers work correctly."""
         assert len(self.resources.handler_registry.fetch_all()) == 3
@@ -226,12 +231,23 @@ class TestResources:
         self.mocked_logger_warning.assert_called_once_with(s)
 
     def test_remove_skill(self):
-        """Test that the 'remove skill' method works correctly."""
+        """Test that the 'remove skill' and 'add skill' method works correctly."""
         error_skill = self.resources.get_skill(self.error_skill_public_id)
         self.resources.remove_skill(self.error_skill_public_id)
         assert self.resources.get_skill(self.error_skill_public_id) is None
         self.resources.add_skill(error_skill)
         assert self.resources.get_skill(self.error_skill_public_id) == error_skill
+
+    def test_add_protocol(self):
+        """Test that the 'add protocol' method works correctly."""
+        oef_protocol = Protocol.from_dir(
+            os.path.join(ROOT_DIR, "packages", "fetchai", "protocols", "oef")
+        )
+        self.resources.add_protocol(oef_protocol)
+        for protocol_id in self.expected_protocols:
+            assert (
+                self.resources.protocol_registry.fetch(protocol_id) is not None
+            ), "Protocol missing!"
 
     def test_register_behaviour_with_already_existing_skill_id(self):
         """Test that registering a behaviour with an already existing skill id behaves as expected."""

--- a/tests/test_skills/test_base.py
+++ b/tests/test_skills/test_base.py
@@ -193,8 +193,11 @@ class TestSkillFromDir:
     def teardown_class(cls):
         """Tear the tests down."""
         cls._unpatch_logger()
-        shutil.rmtree(cls.t)
         os.chdir(cls.cwd)
+        try:
+            shutil.rmtree(cls.t)
+        except (OSError, IOError):
+            pass
 
 
 class SkillContextTestCase(TestCase):


### PR DESCRIPTION
## Proposed changes

This PR introduces functionality for protocols to be loaded directly from a directory in one line via `Protocol.from_dir(protocol_dir_path)`.

## Fixes

- #834

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

-