### PR TITLE
fix issue #886

### DIFF
--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -308,7 +308,11 @@ class Behaviour(SkillComponent):
         behaviour_module = load_module("behaviours", Path(path))
         classes = inspect.getmembers(behaviour_module, inspect.isclass)
         behaviours_classes = list(
-            filter(lambda x: re.match("\\w+Behaviour", x[0]), classes)
+            filter(
+                lambda x: re.match("\\w+Behaviour", x[0])
+                and not str.startswith(x[1].__module__, "aea."),
+                classes,
+            )
         )
 
         name_to_class = dict(behaviours_classes)
@@ -388,7 +392,13 @@ class Handler(SkillComponent):
         handler_module = importlib.util.module_from_spec(handler_spec)
         handler_spec.loader.exec_module(handler_module)  # type: ignore
         classes = inspect.getmembers(handler_module, inspect.isclass)
-        handler_classes = list(filter(lambda x: re.match("\\w+Handler", x[0]), classes))
+        handler_classes = list(
+            filter(
+                lambda x: re.match("\\w+Handler", x[0])
+                and not str.startswith(x[1].__module__, "aea."),
+                classes,
+            )
+        )
 
         name_to_class = dict(handler_classes)
         _print_warning_message_for_non_declared_skill_components(
@@ -485,7 +495,8 @@ class Model(SkillComponent):
             filtered_classes = list(
                 filter(
                     lambda x: any(re.match(shared, x[0]) for shared in model_names)
-                    and Model in inspect.getmro(x[1]),
+                    and Model in inspect.getmro(x[1])
+                    and not str.startswith(x[1].__module__, "aea."),
                     classes,
                 )
             )


### PR DESCRIPTION
## Proposed changes

The classes now are filtered by the import path. If they start with 'aea.' then they are removed, since they belong to the framework and are not user-defined.

## Fixes

Fixes #886 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
