### PR TITLE
Make http connection use the already-running asyncio loop

### DIFF
--- a/packages/fetchai/connections/http/connection.py
+++ b/packages/fetchai/connections/http/connection.py
@@ -330,13 +330,13 @@ def HTTPHandlerFactory(channel: HTTPChannel):
             """Respond to a GET request."""
             request = self.build_request("get")
 
-            response = self.channel.loop.run_until_complete(
-                self.channel.process(request)
-            )
-            # future = asyncio.run_coroutine_threadsafe(
-            #     self.channel.process("GET", url, param), self.channel.loop
+            # response = self.channel.loop.run_until_complete(
+            #     self.channel.process(request)
             # )
-            # response_code, response_desc = future.result()
+            future = asyncio.run_coroutine_threadsafe(
+                self.channel.process(request), self.channel.loop
+            )
+            response = future.result()
 
             self.send_response(response.status_code)
             self.send_header("Content-Type", "text/plain; charset=utf-8")

--- a/tests/test_packages/test_connections/test_http/test_http.py
+++ b/tests/test_packages/test_connections/test_http/test_http.py
@@ -27,6 +27,7 @@ import os
 
 # import json
 # from typing import Tuple
+from threading import Thread
 
 import pytest
 
@@ -157,6 +158,9 @@ class TestHTTPConnectionGET:
         assert cls.http_connection.connection_status.is_connected
         assert not cls.http_connection.channel.is_stopped
 
+        cls.t = Thread(target=cls.loop.run_forever)
+        cls.t.start()
+
     @pytest.mark.asyncio
     async def test_get_404(self):
         """Test send connection error."""
@@ -243,6 +247,8 @@ class TestHTTPConnectionGET:
     @classmethod
     def teardown_class(cls):
         """Teardown the class."""
+        cls.loop.call_soon_threadsafe(cls.loop.stop())
+        cls.t.join()
         value = cls.loop.run_until_complete(cls.http_connection.disconnect())
         assert value is None
 


### PR DESCRIPTION
## Proposed changes
the assumption underlying the AEA connections is that the
attribute 'self.loop' is already running, because it is started by
the multiplexer. (notice, 'self.loop' of the connection is the same loop
passed to the http channel).
In the tests, if the multiplexer is not used, the loop must be run in
a thread (or, even better, using the asyncio loop being run by the
pytest-asyncio plugin). That's the reason why the code with
'run_coroutine_threadsafe' didn't work.
Moreover, the approach of 'run_until_complete' won't work with the
multiplexer, because at the time the method is called the loop
is already running:

    RuntimeError: This event loop is already running

Change (only one) test to show the above in code.
## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
