### PR TITLE
Fix OEF Connection teardown

### DIFF
--- a/aea/agent.py
+++ b/aea/agent.py
@@ -171,7 +171,7 @@ class Agent(ABC):
 
         :return: None
         """
-        if not self.is_debug and not self.multiplexer.connection_status.is_connected:
+        if not self.is_debug:
             self.multiplexer.connect()
 
         logger.debug("[{}]: Calling setup method...".format(self.name))

--- a/aea/agent.py
+++ b/aea/agent.py
@@ -206,8 +206,7 @@ class Agent(ABC):
         self.teardown()
 
         logger.debug("[{}]: Stopping message processing...".format(self.name))
-        if self.multiplexer.connection_status.is_connected:
-            self.multiplexer.disconnect()
+        self.multiplexer.disconnect()
 
     @abstractmethod
     def setup(self) -> None:

--- a/aea/connections/base.py
+++ b/aea/connections/base.py
@@ -32,12 +32,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# TODO refactoring: this should be an enum
+#      but beware of backward-compatibility.
 class ConnectionStatus:
     """The connection status class."""
 
     def __init__(self):
         """Initialize the connection status."""
-        self.is_connected = False
+        self.is_connected = False  # type: bool
+        self.is_connecting = False  # type: bool
 
 
 class Connection(ABC):

--- a/aea/decision_maker/base.py
+++ b/aea/decision_maker/base.py
@@ -529,7 +529,8 @@ class DecisionMaker:
         with self._lock:
             self._stopped = True
             self.message_in_queue.put(None)
-            self._thread.join()
+            if self._thread is not None:
+                self._thread.join()
             logger.debug("Decision Maker stopped.")
             self._thread = None
 

--- a/aea/mail/base.py
+++ b/aea/mail/base.py
@@ -22,9 +22,8 @@
 import asyncio
 import logging
 import queue
-import time
 from abc import ABC, abstractmethod
-from asyncio import AbstractEventLoop, CancelledError, Task
+from asyncio import AbstractEventLoop, CancelledError
 from concurrent.futures import Future
 from threading import Lock, Thread
 from typing import Dict, List, Optional, Sequence, Tuple, cast
@@ -490,9 +489,14 @@ class Multiplexer:
         if self._disconnect_all_task is not None:
             self._disconnect_all_task.cancel()
 
-        for connection in [c for c in self.connections
-                           if c.connection_status.is_connected or c.connection_status.is_connecting]:
-            asyncio.run_coroutine_threadsafe(connection.disconnect(), self._loop).result()
+        for connection in [
+            c
+            for c in self.connections
+            if c.connection_status.is_connected or c.connection_status.is_connecting
+        ]:
+            asyncio.run_coroutine_threadsafe(
+                connection.disconnect(), self._loop
+            ).result()
 
         if self._loop.is_running() and not self._thread.is_alive():
             self._loop.call_soon_threadsafe(self._loop.stop)

--- a/packages/fetchai/connections/oef/connection.py
+++ b/packages/fetchai/connections/oef/connection.py
@@ -22,7 +22,7 @@
 import asyncio
 import logging
 import pickle  # nosec
-from asyncio import AbstractEventLoop, CancelledError, Task
+from asyncio import AbstractEventLoop, CancelledError
 from typing import List, Optional, Set, cast
 
 import oef

--- a/packages/fetchai/connections/oef/connection.py
+++ b/packages/fetchai/connections/oef/connection.py
@@ -120,7 +120,7 @@ class OEFObjectTranslator:
 
     @classmethod
     def to_oef_constraint_expr(
-            cls, constraint_expr: ConstraintExpr
+        cls, constraint_expr: ConstraintExpr
     ) -> OEFConstraintExpr:
         """From our constraint expression to the OEF constraint expression."""
         if isinstance(constraint_expr, And):
@@ -143,7 +143,7 @@ class OEFObjectTranslator:
 
     @classmethod
     def to_oef_constraint_type(
-            cls, constraint_type: ConstraintType
+        cls, constraint_type: ConstraintType
     ) -> OEFConstraintType:
         """From our constraint type to OEF constraint type."""
         value = constraint_type.value
@@ -210,7 +210,7 @@ class OEFObjectTranslator:
 
     @classmethod
     def from_oef_constraint_expr(
-            cls, oef_constraint_expr: OEFConstraintExpr
+        cls, oef_constraint_expr: OEFConstraintExpr
     ) -> ConstraintExpr:
         """From our query to OEF query."""
         if isinstance(oef_constraint_expr, OEFAnd):
@@ -239,7 +239,7 @@ class OEFObjectTranslator:
 
     @classmethod
     def from_oef_constraint_type(
-            cls, constraint_type: OEFConstraintType
+        cls, constraint_type: OEFConstraintType
     ) -> ConstraintType:
         """From OEF constraint type to our constraint type."""
         if isinstance(constraint_type, Eq):
@@ -270,12 +270,12 @@ class OEFChannel(OEFAgent):
     """The OEFChannel connects the OEF Agent with the connection."""
 
     def __init__(
-            self,
-            address: Address,
-            oef_addr: str,
-            oef_port: int,
-            core: AsyncioCore,
-            excluded_protocols: Optional[Set[str]] = None,
+        self,
+        address: Address,
+        oef_addr: str,
+        oef_port: int,
+        core: AsyncioCore,
+        excluded_protocols: Optional[Set[str]] = None,
     ):
         """
         Initialize.
@@ -298,7 +298,7 @@ class OEFChannel(OEFAgent):
         self.excluded_protocols = excluded_protocols
 
     def on_message(
-            self, msg_id: int, dialogue_id: int, origin: Address, content: bytes
+        self, msg_id: int, dialogue_id: int, origin: Address, content: bytes
     ) -> None:
         """
         On message event handler.
@@ -319,12 +319,12 @@ class OEFChannel(OEFAgent):
         ).result()
 
     def on_cfp(
-            self,
-            msg_id: int,
-            dialogue_id: int,
-            origin: Address,
-            target: int,
-            query: CFP_TYPES,
+        self,
+        msg_id: int,
+        dialogue_id: int,
+        origin: Address,
+        target: int,
+        query: CFP_TYPES,
     ) -> None:
         """
         On cfp event handler.
@@ -370,12 +370,12 @@ class OEFChannel(OEFAgent):
         ).result()
 
     def on_propose(
-            self,
-            msg_id: int,
-            dialogue_id: int,
-            origin: Address,
-            target: int,
-            b_proposals: PROPOSE_TYPES,
+        self,
+        msg_id: int,
+        dialogue_id: int,
+        origin: Address,
+        target: int,
+        b_proposals: PROPOSE_TYPES,
     ) -> None:
         """
         On propose event handler.
@@ -396,7 +396,7 @@ class OEFChannel(OEFAgent):
         )
 
     def on_accept(
-            self, msg_id: int, dialogue_id: int, origin: Address, target: int
+        self, msg_id: int, dialogue_id: int, origin: Address, target: int
     ) -> None:
         """
         On accept event handler.
@@ -416,7 +416,7 @@ class OEFChannel(OEFAgent):
         )
 
     def on_decline(
-            self, msg_id: int, dialogue_id: int, origin: Address, target: int
+        self, msg_id: int, dialogue_id: int, origin: Address, target: int
     ) -> None:
         """
         On decline event handler.
@@ -460,7 +460,7 @@ class OEFChannel(OEFAgent):
         ).result()
 
     def on_oef_error(
-            self, answer_id: int, operation: oef.messages.OEFErrorOperation
+        self, answer_id: int, operation: oef.messages.OEFErrorOperation
     ) -> None:
         """
         On oef error event handler.
@@ -491,7 +491,7 @@ class OEFChannel(OEFAgent):
         ).result()
 
     def on_dialogue_error(
-            self, answer_id: int, dialogue_id: int, origin: Address
+        self, answer_id: int, dialogue_id: int, origin: Address
     ) -> None:
         """
         On dialogue error event handler.
@@ -587,7 +587,7 @@ class OEFConnection(Connection):
     """The OEFConnection connects the to the mailbox."""
 
     def __init__(
-            self, address: Address, oef_addr: str, oef_port: int = 10000, *args, **kwargs
+        self, address: Address, oef_addr: str, oef_port: int = 10000, *args, **kwargs
     ):
         """
         Initialize.
@@ -608,7 +608,7 @@ class OEFConnection(Connection):
             address, oef_addr, oef_port, core=self._core,
         )  # type: ignore
 
-        self._connection_check_task = None  # type: Optional[Task]
+        self._connection_check_task = None  # type: Optional[asyncio.Future]
 
     async def connect(self) -> None:
         """
@@ -629,7 +629,9 @@ class OEFConnection(Connection):
             self.connection_status.is_connected = True
             self.channel.loop = loop
             self.channel.in_queue = self.in_queue
-            self._connection_check_task = asyncio.ensure_future(self._connection_check(), loop=self._loop)
+            self._connection_check_task = asyncio.ensure_future(
+                self._connection_check(), loop=self._loop
+            )
         except (CancelledError, Exception) as e:  # pragma: no cover
             self._core.stop()
             self.connection_status.is_connected = False
@@ -676,7 +678,7 @@ class OEFConnection(Connection):
         :return: None
         """
         assert (
-                self._connection_check_task is not None
+            self.connection_status.is_connected or self.connection_status.is_connecting
         ), "Call connect before disconnect."
         assert self.in_queue is not None
         self.connection_status.is_connected = False
@@ -721,7 +723,7 @@ class OEFConnection(Connection):
 
     @classmethod
     def from_config(
-            cls, address: Address, connection_configuration: ConnectionConfig
+        cls, address: Address, connection_configuration: ConnectionConfig
     ) -> "Connection":
         """
         Get the OEF connection from the connection configuration.

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -244,8 +244,10 @@ async def test_multiplexer_disconnect_one_raises_error_many_connections():
         with unittest.mock.patch.object(
             connection_3, "disconnect", side_effect=Exception
         ):
-            # with pytest.raises(AEAConnectionError, match="Failed to disconnect the multiplexer."):
-            multiplexer.disconnect()
+            with pytest.raises(
+                AEAConnectionError, match="Failed to disconnect the multiplexer."
+            ):
+                multiplexer.disconnect()
 
         assert not connection_1.connection_status.is_connected
         assert not connection_2.connection_status.is_connected


### PR DESCRIPTION
## Proposed changes

The OEF connection teardown had problems in the following cases:
- the OEF is down, we try to connect, and then we stop
- the OEF was up, we were connected, the OEF goes down and then we stop

to solve that, the `Multiplexer.disconnect` now calls the `Connection.disconnect`
of all the connection that are "connected" or "connecting".

## Fixes

Fixes #841 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
