### PR TITLE
Correctly split between semantic versioning and package versioning.

### DIFF
--- a/aea/configurations/schemas/aea-config_schema.json
+++ b/aea/configurations/schemas/aea-config_schema.json
@@ -27,7 +27,7 @@
       "$ref": "definitions.json#/definitions/author"
     },
     "version": {
-      "$ref": "definitions.json#/definitions/version"
+      "$ref": "definitions.json#/definitions/package_version"
     },
     "license": {
       "$ref": "definitions.json#/definitions/license"

--- a/aea/configurations/schemas/connection-config_schema.json
+++ b/aea/configurations/schemas/connection-config_schema.json
@@ -21,7 +21,7 @@
       "$ref": "definitions.json#/definitions/author"
     },
     "version": {
-      "$ref": "definitions.json#/definitions/version"
+      "$ref": "definitions.json#/definitions/package_version"
     },
     "license": {
       "$ref": "definitions.json#/definitions/license"

--- a/aea/configurations/schemas/contract-config_schema.json
+++ b/aea/configurations/schemas/contract-config_schema.json
@@ -18,7 +18,7 @@
       "$ref": "definitions.json#/definitions/author"
     },
     "version": {
-      "$ref": "definitions.json#/definitions/version"
+      "$ref": "definitions.json#/definitions/package_version"
     },
     "license": {
       "$ref": "definitions.json#/definitions/license"

--- a/aea/configurations/schemas/definitions.json
+++ b/aea/configurations/schemas/definitions.json
@@ -25,7 +25,7 @@
               "pattern": "^[A-Za-z0-9/\\.\\-_]+$"
             },
             "version": {
-              "$ref": "#/definitions/version_specifier"
+              "$ref": "#/definitions/version_specifiers"
             }
           }
         }
@@ -51,9 +51,18 @@
       "type": "string",
       "pattern": "[a-zA-Z_][a-zA-Z0-9_]*"
     },
-    "version": {
+    "package_version": {
+      "$ref": "definitions.json#/definitions/semantic_version"
+    },
+    "semantic_version": {
       "type": "string",
+      "description": "A semantic version number. See https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+    },
+    "pep440_version": {
+      "type": "string",
+      "description": "Version number that matches PEP 440 version schemes. Differently from 'version_specifiers', this type matches only one version number, without comparison operators. See: https://www.python.org/dev/peps/pep-0440/#examples-of-compliant-version-schemes",
+      "pattern": "^(([1-9][0-9]*!)?(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\\.post(0|[1-9][0-9]*))?(\\.dev(0|[1-9][0-9]*))?)(, *(( *(~=|==|>=|<=|!=|<|>) *)([1-9][0-9]*!)?(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\\.post(0|[1-9][0-9]*))?(\\.dev(0|[1-9][0-9]*))?))*$"
     },
     "fingerprint": {
       "oneOf": [
@@ -65,15 +74,17 @@
       "type": "string",
       "pattern": "^[a-zA-Z0-9_]*/[a-zA-Z_][a-zA-Z0-9_]*:(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
     },
-    "version_specifier": {
+    "version_specifiers": {
       "type": "string",
+      "description": "A comma-separated list of PEP 440 version specifiers. See https://www.python.org/dev/peps/pep-0440/#version-specifiers",
       "pattern": "^(( *(~=|==|>=|<=|!=|<|>) *)([1-9][0-9]*!)?(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\\.post(0|[1-9][0-9]*))?(\\.dev(0|[1-9][0-9]*))?)(, *(( *(~=|==|>=|<=|!=|<|>) *)([1-9][0-9]*!)?(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\\.post(0|[1-9][0-9]*))?(\\.dev(0|[1-9][0-9]*))?))*$"
     },
     "aea_version": {
       "type": "string",
+      "description": "The version of AEA framework to use. It can be either a list of version specifiers (e.g. >0.2.0,<=0.2.3), or just a version number interpreted with the equality operator (e.g. 0.2.0, interpreted as ==0.2.0) (according to PEP 440).",
       "oneOf": [
-        {"$ref":  "#/definitions/version_specifier"},
-        {"$ref":  "#/definitions/version"}
+        {"$ref":  "#/definitions/version_specifiers"},
+        {"$ref":  "#/definitions/pep440_version"}
       ]
     }
   }

--- a/aea/configurations/schemas/protocol-config_schema.json
+++ b/aea/configurations/schemas/protocol-config_schema.json
@@ -18,7 +18,7 @@
       "$ref": "definitions.json#/definitions/author"
     },
     "version": {
-      "$ref": "definitions.json#/definitions/version"
+      "$ref": "definitions.json#/definitions/package_version"
     },
     "license": {
       "$ref": "definitions.json#/definitions/license"

--- a/aea/configurations/schemas/protocol-specification_schema.json
+++ b/aea/configurations/schemas/protocol-specification_schema.json
@@ -19,7 +19,7 @@
       "$ref": "definitions.json#/definitions/author"
     },
     "version": {
-      "$ref": "definitions.json#/definitions/version"
+      "$ref": "definitions.json#/definitions/package_version"
     },
     "license": {
       "$ref": "definitions.json#/definitions/license"

--- a/aea/configurations/schemas/skill-config_schema.json
+++ b/aea/configurations/schemas/skill-config_schema.json
@@ -19,7 +19,7 @@
       "$ref": "definitions.json#/definitions/author"
     },
     "version": {
-      "$ref": "definitions.json#/definitions/version"
+      "$ref": "definitions.json#/definitions/package_version"
     },
     "license": {
       "$ref": "definitions.json#/definitions/license"

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,9 @@ ignore_missing_imports = True
 [mypy-watchdog.*]
 ignore_missing_imports = True
 
+[mypy-semver.*]
+ignore_missing_imports = True
+
 [mypy-dotenv]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ base_deps = [
     "base58>=1.0.3",
     "jsonschema>=3.0.0",
     "packaging>=20.3",
-    "semver",
+    "semver>=2.9.1",
     "protobuf",
     "pyyaml>=4.2b1",
     "watchdog",

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ base_deps = [
     "base58>=1.0.3",
     "jsonschema>=3.0.0",
     "packaging>=20.3",
+    "semver",
     "protobuf",
     "pyyaml>=4.2b1",
     "watchdog",

--- a/tests/test_configurations/test_base.py
+++ b/tests/test_configurations/test_base.py
@@ -212,24 +212,24 @@ class PublicIdTestCase(TestCase):
 
     def test_public_id_from_json_positive(self):
         """Test case for from_json method positive result."""
-        obj = {"author": AUTHOR, "name": "name", "version": "version"}
+        obj = {"author": AUTHOR, "name": "name", "version": "0.1.0"}
         PublicId.from_json(obj)
 
     def test_public_id_json_positive(self):
         """Test case for json property positive result."""
-        obj = PublicId(AUTHOR, "name", "version")
+        obj = PublicId(AUTHOR, "name", "0.1.0")
         obj.json
 
     def test_public_id_eq_positive(self):
         """Test case for json __eq__ method positive result."""
-        obj1 = PublicId(AUTHOR, "name", "version")
-        obj2 = PublicId(AUTHOR, "name", "version")
+        obj1 = PublicId(AUTHOR, "name", "0.1.0")
+        obj2 = PublicId(AUTHOR, "name", "0.1.0")
         self.assertTrue(obj1 == obj2)
 
     def test_public_id_lt_positive(self):
         """Test case for json __lt__ method positive result."""
-        obj1 = PublicId(AUTHOR, "name", "1")
-        obj2 = PublicId(AUTHOR, "name", "2")
+        obj1 = PublicId(AUTHOR, "name", "1.0.0")
+        obj2 = PublicId(AUTHOR, "name", "2.0.0")
         self.assertTrue(obj1 < obj2)
 
 
@@ -293,7 +293,7 @@ class ProtocolSpecificationTestCase(TestCase):
         json_disc = {
             "name": "name",
             "author": AUTHOR,
-            "version": "version",
+            "version": "0.1.0",
             "license": "license",
             "description": "description",
             "speech_acts": {"arg1": "arg1", "arg2": "arg2"},


### PR DESCRIPTION
## Proposed changes

Both at JSON schema level and code level, now we have a clear separation of the version numbers.
In particular:
- dependencies.version is compliant with PEP 440 version specifiers
- aea_version is compliant either with PEP 440 version specifiers or one version number (as recommended by PEP 440)
- version is compliant with the SemVer format, since an AEA package is not coupled with Python.

## Fixes

Fixes  #931

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
N/A