### PR TITLE
change what connections are used by default

### DIFF
--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -224,9 +224,9 @@ def _build_aea(ctx: Context, connection_ids: List[PublicId]) -> AEA:
         ctx.agent_config.ledger_apis_dict, ctx.agent_config.default_ledger
     )
 
-    default_connection_id = PublicId.from_str(ctx.agent_config.default_connection)
+    all_connection_ids = ctx.agent_config.connections
     connection_ids = (
-        [default_connection_id] if connection_ids is None else connection_ids
+        all_connection_ids if connection_ids is None else connection_ids
     )
     connections = []
     try:

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -225,9 +225,7 @@ def _build_aea(ctx: Context, connection_ids: List[PublicId]) -> AEA:
     )
 
     all_connection_ids = ctx.agent_config.connections
-    connection_ids = (
-        all_connection_ids if connection_ids is None else connection_ids
-    )
+    connection_ids = all_connection_ids if connection_ids is None else connection_ids
     connections = []
     try:
         for connection_id in connection_ids:


### PR DESCRIPTION
## Proposed changes

This PR changes which connections are used by default.

If the user does not provide `--connections` then all connections are used. This makes more sense than the previous implementation as it aligns it to how we load protocols and skills.

Also, previously `default_connection` was misused. The `default_connection` specifies the connection which should be used for routing envelopes by default. It should not specify which connections are actually run.

## Fixes

- #952 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

-