### PR TITLE
AEA-452 Forward verbosity option in 'aea launch'.

### DIFF
--- a/aea/cli/common.py
+++ b/aea/cli/common.py
@@ -86,7 +86,7 @@ class Context:
 
     agent_config: AgentConfig
 
-    def __init__(self, cwd: str = "."):
+    def __init__(self, cwd: str = ".", verbosity: str = "INFO"):
         """Init the context."""
         self.config = dict()  # type: Dict
         self.agent_loader = ConfigLoader("aea-config_schema.json", AgentConfig)
@@ -98,6 +98,7 @@ class Context:
             "protocol-config_schema.json", ProtocolConfig
         )
         self.cwd = cwd
+        self.verbosity = verbosity
 
     def set_config(self, key, value) -> None:
         """

--- a/aea/cli/core.py
+++ b/aea/cli/core.py
@@ -76,7 +76,8 @@ FUNDS_RELEASE_TIMEOUT = 10
 @click.pass_context
 def cli(ctx) -> None:
     """Command-line tool for setting up an Autonomous Economic Agent."""
-    ctx.obj = Context(cwd=".")
+    verbosity_option = ctx.meta.pop("verbosity")
+    ctx.obj = Context(cwd=".", verbosity=verbosity_option)
 
 
 @cli.command()

--- a/aea/cli/launch.py
+++ b/aea/cli/launch.py
@@ -24,12 +24,12 @@ import sys
 from collections import OrderedDict
 from pathlib import Path
 from subprocess import Popen  # nosec
-from typing import List
+from typing import List, cast
 
 import click
 from click import pass_context
 
-from aea.cli.common import AgentDirectory, logger
+from aea.cli.common import AgentDirectory, Context, logger
 from aea.cli.run import run
 
 
@@ -38,18 +38,20 @@ def _run_agent(click_context, agent_directory: str):
     click_context.invoke(run)
 
 
-def _launch_subprocesses(agents: List[Path]):
+def _launch_subprocesses(click_context: click.Context, agents: List[Path]):
     """
     Launch many agents using subprocesses.
 
     :param agents: list of paths to agent projects.
     :return: None
     """
+    ctx = cast(Context, click_context.obj)
     processes = []
     failed = 0
     for agent_directory in agents:
         process = Popen(  # nosec
-            [sys.executable, "-m", "aea.cli", "run"], cwd=str(agent_directory)
+            [sys.executable, "-m", "aea.cli", "-v", ctx.verbosity, "run"],
+            cwd=str(agent_directory),
         )
         logger.info("Agent {} started...".format(agent_directory.name))
         processes.append(process)
@@ -85,4 +87,4 @@ def _launch_subprocesses(agents: List[Path]):
 def launch(click_context, agents: List[str]):
     """Launch many agents."""
     agents_directories = list(map(Path, list(OrderedDict.fromkeys(agents))))
-    _launch_subprocesses(agents_directories)
+    _launch_subprocesses(click_context, agents_directories)

--- a/aea/cli/loggers.py
+++ b/aea/cli/loggers.py
@@ -74,6 +74,9 @@ def simple_verbosity_option(logger=None, *names, **kwargs):
         def _set_level(ctx, param, value):
             level = logging.getLevelName(value)
             logger.setLevel(level)
+            # save verbosity option so it can be
+            # read in the main CLI entrypoint
+            ctx.meta["verbosity"] = value
 
         return click.option(*names, callback=_set_level, **kwargs)(f)
 


### PR DESCRIPTION
## Proposed changes

Forward verbosity options in `aea launch`.

That is, the command `aea -v DEBUG launch aea_proj_name [aea_proj_name ...]` 
will forward the verbosity option `DEBUG` to every other agents.

## Fixes

Fixes #951 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
N/A