### PR TITLE
Adding protocold recursively changed to call the method directly

### DIFF
--- a/aea/cli/add.py
+++ b/aea/cli/add.py
@@ -83,7 +83,7 @@ def _add_protocols(click_context, protocols: Collection[PublicId]):
             logger.debug(
                 "Adding protocol '{}' to the agent...".format(protocol_public_id)
             )
-            click_context.invoke(protocol, protocol_public_id=protocol_public_id)
+            _add_item(click_context, "protocol", protocol_public_id)
 
 
 def _add_item(click_context, item_type, item_public_id) -> None:


### PR DESCRIPTION
Adding protocold recursively changed to call the method directly, not invoking the command. For correct error handling.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
