### PR TITLE
Update Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ verify_ssl = true
 name = "test-pypi"
 
 [dev-packages]
-aries-cloudagent = "==0.4.5"
 bandit = "==1.6.2"
 black = "==19.10b0"
 bs4 = "==0.0.1"
@@ -39,7 +38,7 @@ pytest = "==5.3.5"
 pytest-asyncio = "==0.10.0"
 pytest-cov = "==2.8.1"
 pytest-randomly = "==3.2.1"
-requests = "==2.23.0"
+requests = ">=2.22.0"
 safety = "==1.8.5"
 tox = "==3.14.5"
 vyper = "==0.1.0b12"


### PR DESCRIPTION
## Proposed changes

Some recently added dependencies caused `pipenv lock` to fail.

- aries-cloudagent==0.4.5 requires markdown~=3.1.1, whereas we require markdown>=3.2.1: https://github.com/hyperledger/aries-cloudagent-python/blob/2f6e50bc1b64c3d43f846be6b9203f636b6165bf/requirements.txt#L7
- fetchai-ledger-api==1.0.3 requires requests==2.22.0 which conflicts with requests==2.23.0

Fix in the following way:
- remove aries-cloudagent dependency (it was used in only one test)
- relax requests version specifier (from ==2.23 to >=2.22)

## Fixes

N/A

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
For the record, I debugged the issue using:

```
pipenv install --dev --verbose
```

Since it printed a lot, I dumped the stderr output to a file by appending ` 2>& temp_file` to the command