### PR TITLE
AEA-531 fix for default agent loop timeout on contruction with AEABuild

### DIFF
--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -229,6 +229,8 @@ class AEABuilder:
     returns the instance of the builder itself.
     """
 
+    DEFAULT_AGENT_LOOP_TIMEOUT = 0.05
+
     def __init__(self, with_default_packages: bool = True):
         """
         Initialize the builder.
@@ -595,12 +597,15 @@ class AEABuilder:
             LedgerApis(self.ledger_apis_config, self._default_ledger),
             self._resources,
             loop=None,
-            timeout=0.0,
+            timeout=self._get_agent_loop_timeout(),
             is_debug=False,
             max_reactions=20,
         )
         self._load_and_add_skills(aea.context)
         return aea
+
+    def _get_agent_loop_timeout(self) -> float:
+        return self.DEFAULT_AGENT_LOOP_TIMEOUT
 
     def _check_configuration_not_already_added(self, configuration) -> None:
         if (

--- a/aea/agent.py
+++ b/aea/agent.py
@@ -199,6 +199,18 @@ class Agent(ABC):
 
         :return: None
         """
+        self._start_setup()
+        self._run_main_loop()
+
+    def _start_setup(self) -> None:
+        """
+        setup Agent on start:
+        - up multiplexer
+        - call agent.setup
+        - set started
+
+        :return: None
+        """
         if not self.is_debug:
             self.multiplexer.connect()
 
@@ -206,7 +218,6 @@ class Agent(ABC):
         self.setup()
 
         self.liveness.start()
-        self._run_main_loop()
 
     def _run_main_loop(self) -> None:
         """
@@ -217,11 +228,19 @@ class Agent(ABC):
         logger.debug("[{}]: Start processing messages...".format(self.name))
         while not self.liveness.is_stopped:
             self._tick += 1
-            self.act()
-            time.sleep(self._timeout)
-            self.react()
-            self.update()
+            self._spin_main_loop()
         logger.debug("[{}]: Exiting main loop...".format(self.name))
+
+    def _spin_main_loop(self) -> None:
+        """
+        Run one cycle of agent's main loop
+
+        :return: None
+        """
+        self.act()
+        time.sleep(self._timeout)
+        self.react()
+        self.update()
 
     def stop(self) -> None:
         """

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""This module contains some utils for testing purposes"""
+
+import time
+from contextlib import contextmanager
+
+
+class TimeItResult:
+    """ class to store execution time for timeit_context """
+
+    def __init__(self):
+        self.time_passed = -1
+
+
+@contextmanager
+def timeit_context():
+    """
+    context manager to measure execution time of code in context
+
+    :return TimeItResult
+
+    example:
+    with timeit_context() as result:
+        do_long_code()
+    print("Long code takes ", result.time_passed)
+    """
+
+    result = TimeItResult()
+    started_time = time.time()
+    try:
+        yield result
+    finally:
+        result.time_passed = time.time() - started_time

--- a/tests/test_aeabuilder.py
+++ b/tests/test_aeabuilder.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+""" This module contains tests for aea/aea_builder.py """
+import os
+
+from aea.aea_builder import AEABuilder
+from aea.crypto.fetchai import FETCHAI
+
+from tests.common.utils import timeit_context
+
+from .conftest import CUR_PATH
+
+
+def test_default_timeout_for_agent():
+    """
+    Tests agents loop sleep timeout
+    set by AEABuilder.DEFAULT_AGENT_LOOP_TIMEOUT
+    """
+    agent_name = "MyAgent"
+    private_key_path = os.path.join(CUR_PATH, "data", "fet_private_key.txt")
+    builder = AEABuilder()
+    builder.set_name(agent_name)
+    builder.add_private_key(FETCHAI, private_key_path)
+    builder.DEFAULT_AGENT_LOOP_TIMEOUT = 0.05
+
+    """ Default timeout == 0.05 """
+    agent = builder.build()
+    assert agent._timeout == builder.DEFAULT_AGENT_LOOP_TIMEOUT
+
+    with timeit_context() as time_result:
+        agent._spin_main_loop()
+
+    assert time_result.time_passed > builder.DEFAULT_AGENT_LOOP_TIMEOUT
+    time_0_05 = time_result.time_passed
+
+    """ Timeout == 0.001 """
+    builder = AEABuilder()
+    builder.set_name(agent_name)
+    builder.add_private_key(FETCHAI, private_key_path)
+    builder.DEFAULT_AGENT_LOOP_TIMEOUT = 0.001
+
+    agent = builder.build()
+    assert agent._timeout == builder.DEFAULT_AGENT_LOOP_TIMEOUT
+
+    with timeit_context() as time_result:
+        agent._spin_main_loop()
+
+    assert time_result.time_passed > builder.DEFAULT_AGENT_LOOP_TIMEOUT
+    time_0_001 = time_result.time_passed
+
+    """ Timeout == 0.0 """
+    builder = AEABuilder()
+    builder.set_name(agent_name)
+    builder.add_private_key(FETCHAI, private_key_path)
+    builder.DEFAULT_AGENT_LOOP_TIMEOUT = 0.0
+
+    agent = builder.build()
+    assert agent._timeout == builder.DEFAULT_AGENT_LOOP_TIMEOUT
+
+    with timeit_context() as time_result:
+        agent._spin_main_loop()
+
+    assert time_result.time_passed > builder.DEFAULT_AGENT_LOOP_TIMEOUT
+    time_0 = time_result.time_passed
+
+    assert time_0 < time_0_001 and time_0_001 < time_0_05


### PR DESCRIPTION
## Proposed changes
small refactoring over Agent to make tests easier: now it's possible to spin agents main loop manually

## Fixes

set default agent sleep timeout in AEABuilder to reduce cpu utilization

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that code coverage does not decrease.
- [X] I have checked that the documentation about the `aea cli` tool works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
