### PR TITLE
AEA-500 Add agent context namespace.

### DIFF
--- a/aea/aea.py
+++ b/aea/aea.py
@@ -55,6 +55,7 @@ class AEA(Agent):
         timeout: float = 0.0,
         is_debug: bool = False,
         max_reactions: int = 20,
+        **kwargs
     ) -> None:
         """
         Instantiate the agent.
@@ -68,6 +69,7 @@ class AEA(Agent):
         :param timeout: the time in (fractions of) seconds to time out an agent between act and react
         :param is_debug: if True, run the agent in debug mode (does not connect the multiplexer).
         :param max_reactions: the processing rate of envelopes per tick (i.e. single loop).
+        :param kwargs: keyword arguments to be attached in the agent context namespace.
 
         :return: None
         """
@@ -92,6 +94,7 @@ class AEA(Agent):
             self.decision_maker.preferences,
             self.decision_maker.goal_pursuit_readiness,
             self.task_manager,
+            **kwargs
         )
         self._resources = resources
         self._filter = Filter(self.resources, self.decision_maker.message_out_queue)

--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -244,7 +244,7 @@ class AEABuilder:
             "fetchai"  # set by the user, or instantiate a default one.
         )
         self._default_connection = PublicId("fetchai", "stub", "0.1.0")
-        self.context_namespace = {}  # type: Dict[str, Any]
+        self._context_namespace = {}  # type: Dict[str, Any]
 
         self._package_dependency_manager = _DependenciesManager()
 
@@ -395,6 +395,10 @@ class AEABuilder:
         configuration._directory = directory
 
         return self
+
+    def set_context_namespace(self, context_namespace: Dict[str, Any]) -> None:
+        """Set the context namespace."""
+        self._context_namespace = context_namespace
 
     def _add_component_to_resources(self, component: Component) -> None:
         """Add component to the resources."""
@@ -599,7 +603,7 @@ class AEABuilder:
             timeout=0.0,
             is_debug=False,
             max_reactions=20,
-            **self.context_namespace
+            **self._context_namespace
         )
         self._load_and_add_skills(aea.context)
         return aea

--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -24,7 +24,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import Collection, Dict, List, Optional, Set, Tuple, Union, cast
+from typing import Any, Collection, Dict, List, Optional, Set, Tuple, Union, cast
 
 import jsonschema
 
@@ -244,6 +244,7 @@ class AEABuilder:
             "fetchai"  # set by the user, or instantiate a default one.
         )
         self._default_connection = PublicId("fetchai", "stub", "0.1.0")
+        self.context_namespace = {}  # type: Dict[str, Any]
 
         self._package_dependency_manager = _DependenciesManager()
 
@@ -598,6 +599,7 @@ class AEABuilder:
             timeout=0.0,
             is_debug=False,
             max_reactions=20,
+            **self.context_namespace
         )
         self._load_and_add_skills(aea.context)
         return aea

--- a/aea/context/base.py
+++ b/aea/context/base.py
@@ -20,6 +20,7 @@
 """This module contains the agent context class."""
 
 from queue import Queue
+from types import SimpleNamespace
 from typing import Any, Dict
 
 from aea.connections.base import ConnectionStatus
@@ -46,6 +47,7 @@ class AgentContext:
         preferences: Preferences,
         goal_pursuit_readiness: GoalPursuitReadiness,
         task_manager: TaskManager,
+        **kwargs
     ):
         """
         Initialize an agent context.
@@ -59,6 +61,7 @@ class AgentContext:
         :param preferences: the preferences of the agent
         :param goal_pursuit_readiness: if True, the agent is ready to pursuit its goals
         :param task_manager: the task manager
+        :param kwargs: keyword arguments to be attached in the agent context namespace.
         """
         self._shared_state = {}  # type: Dict[str, Any]
         self._identity = identity
@@ -73,6 +76,8 @@ class AgentContext:
         self._search_service_address = (
             DEFAULT_OEF  # TODO: make this configurable via aea-config.yaml
         )
+
+        self._namespace = SimpleNamespace(**kwargs)
 
     @property
     def shared_state(self) -> Dict[str, Any]:
@@ -149,3 +154,8 @@ class AgentContext:
     def search_service_address(self) -> Address:
         """Get the address of the search service."""
         return self._search_service_address
+
+    @property
+    def namespace(self) -> SimpleNamespace:
+        """Get the agent context namespace."""
+        return self._namespace

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -213,6 +213,11 @@ class SkillContext:
         assert self._skill is not None, "Skill not initialized."
         return SimpleNamespace(**self._skill.contracts)
 
+    @property
+    def namespace(self) -> SimpleNamespace:
+        """Get the agent context namespace."""
+        return self._get_agent_context().namespace
+
     def __getattr__(self, item) -> Any:
         """Get attribute."""
         return super().__getattribute__(item)  # pragma: no cover

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -16,6 +16,8 @@ This means it is possible to, at any point, grab the `context` and have access t
 
 For example, in the `ErrorHandler(Handler)` class, the code often grabs a reference to its context and by doing so can access initialised and running framework objects such as an `OutBox` for putting messages into.
 
+Moreover, you can read/write to the _agent context namespace_ by accessing the attribute `SkillContext.namespace`.
+
 ``` python
 self.context.outbox.put_message(to=recipient, sender=self.context.agent_address, protocol_id=DefaultMessage.protocol_id, message=DefaultSerializer().encode(reply))
 ``` 

--- a/tests/test_aea.py
+++ b/tests/test_aea.py
@@ -436,8 +436,6 @@ class TestAddBehaviourDynamically:
         resources = Resources()
         resources.add_component(Skill.from_dir(Path(CUR_PATH, "data", "dummy_skill")))
         identity = Identity(agent_name, address=wallet.addresses[FETCHAI])
-        cls.input_file = tempfile.mkstemp()[1]
-        cls.output_file = tempfile.mkstemp()[1]
         cls.agent = AEA(
             identity,
             [_make_local_connection(identity.address, LocalNode())],
@@ -470,5 +468,41 @@ class TestAddBehaviourDynamically:
         """Tear the class down."""
         cls.agent.stop()
         cls.t.join()
-        Path(cls.input_file).unlink()
-        Path(cls.output_file).unlink()
+
+
+class TestContextNamespace:
+    """
+    Test that the keyword arguments to AEA constructor
+    can be accessible from the skill context.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        agent_name = "my_agent"
+        private_key_path = os.path.join(CUR_PATH, "data", "fet_private_key.txt")
+        wallet = Wallet({FETCHAI: private_key_path})
+        ledger_apis = LedgerApis({}, FETCHAI)
+        resources = Resources()
+        resources.add_component(Skill.from_dir(Path(CUR_PATH, "data", "dummy_skill")))
+        identity = Identity(agent_name, address=wallet.addresses[FETCHAI])
+        cls.context_namespace = {"key1": 1, "key2": 2}
+        cls.agent = AEA(
+            identity,
+            [_make_local_connection(identity.address, LocalNode())],
+            wallet,
+            ledger_apis,
+            resources,
+            **cls.context_namespace
+        )
+        for skill in resources.get_all_skills():
+            skill.skill_context.set_agent_context(cls.agent.context)
+
+    def test_access_context_namespace(self):
+        """Test that we can access the context namespace."""
+        assert self.agent.context.namespace.key1 == 1
+        assert self.agent.context.namespace.key2 == 2
+
+        for skill in self.agent.resources.get_all_skills():
+            assert skill.skill_context.namespace.key1 == 1
+            assert skill.skill_context.namespace.key2 == 2


### PR DESCRIPTION

## Proposed changes

The agent context namespace is populated via either AgentContext constructor or AEA constructor through keyword arguments.

It can be accessed with
- agent_context.namespace.attribute_name
- skill_context.namespace.attribute_name


## Fixes

Fixes #1008 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
