### PR TITLE
Add AEAException and use it in exceptions of AEABuilder.add_component

### DIFF
--- a/aea/exceptions.py
+++ b/aea/exceptions.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2020 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+
+class AEAException(Exception):
+    """User-defined exception for the AEA framework."""

--- a/tests/test_aea.py
+++ b/tests/test_aea.py
@@ -101,6 +101,9 @@ def test_react():
         builder = AEABuilder()
         builder.set_name(agent_name)
         builder.add_private_key(FETCHAI, private_key_path)
+        builder.add_protocol(
+            Path(ROOT_DIR, "packages", "fetchai", "protocols", "oef_search")
+        )
         builder.add_connection(
             Path(ROOT_DIR, "packages", "fetchai", "connections", "local")
         )
@@ -159,6 +162,9 @@ async def test_handle():
         builder = AEABuilder()
         builder.set_name(agent_name)
         builder.add_private_key(FETCHAI, private_key_path)
+        builder.add_protocol(
+            Path(ROOT_DIR, "packages", "fetchai", "protocols", "oef_search")
+        )
         builder.add_connection(
             Path(ROOT_DIR, "packages", "fetchai", "connections", "local")
         )
@@ -252,6 +258,9 @@ class TestInitializeAEAProgrammaticallyFromResourcesDir:
         builder = AEABuilder()
         builder.set_name(agent_name)
         builder.add_private_key(FETCHAI, private_key_path)
+        builder.add_protocol(
+            Path(ROOT_DIR, "packages", "fetchai", "protocols", "oef_search")
+        )
         builder.add_connection(
             Path(ROOT_DIR, "packages", "fetchai", "connections", "local")
         )

--- a/tests/test_aeabuilder.py
+++ b/tests/test_aeabuilder.py
@@ -18,13 +18,19 @@
 # ------------------------------------------------------------------------------
 """ This module contains tests for aea/aea_builder.py """
 import os
+import re
+from pathlib import Path
+
+import pytest
 
 from aea.aea_builder import AEABuilder
+from aea.configurations.base import ComponentType
 from aea.crypto.fetchai import FETCHAI
+from aea.exceptions import AEAException
 
 from tests.common.utils import timeit_context
 
-from .conftest import CUR_PATH
+from .conftest import CUR_PATH, ROOT_DIR
 
 
 def test_default_timeout_for_agent():
@@ -79,4 +85,43 @@ def test_default_timeout_for_agent():
     assert time_result.time_passed > builder.DEFAULT_AGENT_LOOP_TIMEOUT
     time_0 = time_result.time_passed
 
-    assert time_0 < time_0_001 and time_0_001 < time_0_05
+    assert time_0 < time_0_001 < time_0_05
+
+
+def test_add_package_already_existing():
+    """
+    Test the case when we try to add a package (already added) to the AEA builder.
+
+    It should fail because the package is already present into the builder.
+    """
+    builder = AEABuilder()
+    fipa_package_path = Path(ROOT_DIR) / "packages" / "fetchai" / "protocols" / "fipa"
+    builder.add_component(
+        ComponentType.PROTOCOL,
+        fipa_package_path
+    )
+
+    expected_message = re.escape(
+        "Component 'fetchai/fipa:0.1.0' of type 'protocol' already added."
+    )
+    with pytest.raises(AEAException, match=expected_message):
+        builder.add_component(ComponentType.PROTOCOL, fipa_package_path)
+
+
+def test_when_package_has_missing_dependency():
+    """
+    Test the case when the builder tries to load the packages,
+    but fails because of a missing dependency.
+    """
+    builder = AEABuilder()
+    expected_message = re.escape(
+        "Package 'fetchai/oef:0.2.0' of type 'connection' cannot be added. "
+        "Missing dependencies: ['(protocol, fetchai/fipa:0.1.0)', '(protocol, fetchai/oef_search:0.1.0)']"
+    )
+    with pytest.raises(AEAException, match=expected_message):
+        # connection "fetchai/oef:0.1.0" requires
+        # "fetchai/oef_search:0.1.0" and "fetchai/fipa:0.1.0" protocols.
+        builder.add_component(
+            ComponentType.CONNECTION,
+            Path(ROOT_DIR) / "packages" / "fetchai" / "connections" / "oef",
+        )

--- a/tests/test_aeabuilder.py
+++ b/tests/test_aeabuilder.py
@@ -96,10 +96,7 @@ def test_add_package_already_existing():
     """
     builder = AEABuilder()
     fipa_package_path = Path(ROOT_DIR) / "packages" / "fetchai" / "protocols" / "fipa"
-    builder.add_component(
-        ComponentType.PROTOCOL,
-        fipa_package_path
-    )
+    builder.add_component(ComponentType.PROTOCOL, fipa_package_path)
 
     expected_message = re.escape(
         "Component 'fetchai/fipa:0.1.0' of type 'protocol' already added."

--- a/tests/test_docs/test_agent_vs_aea/test_agent_vs_aea.py
+++ b/tests/test_docs/test_agent_vs_aea/test_agent_vs_aea.py
@@ -65,7 +65,6 @@ class TestAgentVsAEA:
 
         run()
         assert os.path.exists(Path(self.t, "input.txt"))
-        assert os.path.exists(Path(self.t, "input.txt"))
 
         message_text = (
             "other_agent,my_agent,fetchai/default:0.1.0,\x08\x01*\x07\n\x05hello,"

--- a/tests/test_protocols/test_generator.py
+++ b/tests/test_protocols/test_generator.py
@@ -262,6 +262,12 @@ class TestEndToEndGenerator:
         builder_1.add_private_key(FETCHAI, FETCHAI_PRIVATE_KEY_FILE)
         builder_1.set_default_ledger(FETCHAI)
         builder_1.set_default_connection(PublicId.from_str("fetchai/oef:0.2.0"))
+        builder_1.add_protocol(
+            Path(ROOT_DIR, "packages", "fetchai", "protocols", "fipa")
+        )
+        builder_1.add_protocol(
+            Path(ROOT_DIR, "packages", "fetchai", "protocols", "oef_search")
+        )
         builder_1.add_component(
             ComponentType.PROTOCOL,
             Path(ROOT_DIR, "tests", "data", "generator", "t_protocol"),
@@ -275,6 +281,12 @@ class TestEndToEndGenerator:
         builder_2.set_name("my_aea_2")
         builder_2.add_private_key(FETCHAI, FETCHAI_PRIVATE_KEY_FILE)
         builder_2.set_default_ledger(FETCHAI)
+        builder_2.add_protocol(
+            Path(ROOT_DIR, "packages", "fetchai", "protocols", "fipa")
+        )
+        builder_2.add_protocol(
+            Path(ROOT_DIR, "packages", "fetchai", "protocols", "oef_search")
+        )
         builder_2.set_default_connection(PublicId.from_str("fetchai/oef:0.2.0"))
         builder_2.add_component(
             ComponentType.PROTOCOL,


### PR DESCRIPTION
## Proposed changes

This PR does the following:
- adds an user-defined `AEAException`. 
- improves the `AEABuilder.add_component` so it raises `AEAException`s in specific circumstances.

The `AEAException` class is supposed to be used whenever we need to describe exceptions at framework level.

For instance, trying to add a package in the AEABuilder class (`AEABuilder.add_component(type, path)`) might fail for many reasons:

1. the path to the package does not exist
2. the directory exists, but there isn't the expected configuration file.
3. the package already exists in the AEABuilder
4. there are some missing package dependencies
...

Despite we can't foresee all the exceptions, for some of them we can. For instance, case (3) and (4) are exceptions at framework level, so we can raise the right exception to the client of the class.

Needless to say, AEABuilder.add_component' is just one example. The same idea can be applied to other framework classes/functions.


## Fixes

First step toward fixing #1062 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also, you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
N/A