### PR TITLE
Preventing from publishing with private_key_paths implemented AEA-535

### DIFF
--- a/aea/cli/publish.py
+++ b/aea/cli/publish.py
@@ -33,7 +33,7 @@ from aea.cli.common import (
     check_aea_project,
 )
 from aea.cli.registry.publish import publish_agent
-from aea.configurations.base import PublicId
+from aea.configurations.base import CRUDCollection, PublicId
 from aea.configurations.constants import (
     DEFAULT_CONNECTION,
     DEFAULT_PROTOCOL,
@@ -56,7 +56,15 @@ def publish(click_context, local):
         publish_agent(ctx)
 
 
-def _validate_pkp(private_key_paths):
+def _validate_pkp(private_key_paths: CRUDCollection) -> None:
+    """
+    Prevent to publish agents with non-empty private_key_paths.
+
+    :param private_key_paths: private_key_paths from agent config.
+    :raises: ClickException if private_key_paths is not empty.
+
+    :return: None.
+    """
     if private_key_paths.read_all():
         raise click.ClickException(
             "You are not allowed to publish agents with non-empty private_key_paths."

--- a/aea/cli/publish.py
+++ b/aea/cli/publish.py
@@ -65,7 +65,7 @@ def _validate_pkp(private_key_paths: CRUDCollection) -> None:
 
     :return: None.
     """
-    if private_key_paths.read_all():
+    if private_key_paths.read_all() != []:
         raise click.ClickException(
             "You are not allowed to publish agents with non-empty private_key_paths."
         )

--- a/aea/cli/publish.py
+++ b/aea/cli/publish.py
@@ -48,11 +48,19 @@ from aea.configurations.constants import (
 def publish(click_context, local):
     """Publish Agent to Registry."""
     ctx = cast(Context, click_context.obj)
+    _validate_pkp(ctx.agent_config.private_key_paths)
     if local:
         _save_agent_locally(ctx)
     else:
         # TODO: check agent dependencies are available in local packages dir.
         publish_agent(ctx)
+
+
+def _validate_pkp(private_key_paths):
+    if private_key_paths.read_all():
+        raise click.ClickException(
+            "You are not allowed to publish agents with non-empty private_key_paths."
+        )
 
 
 def _check_is_item_in_local_registry(public_id, item_type_plural, registry_path):

--- a/tests/test_cli/test_publish.py
+++ b/tests/test_cli/test_publish.py
@@ -24,7 +24,11 @@ from click import ClickException
 from click.testing import CliRunner
 
 from aea.cli import cli
-from aea.cli.publish import _check_is_item_in_local_registry, _save_agent_locally
+from aea.cli.publish import (
+    _check_is_item_in_local_registry,
+    _save_agent_locally,
+    _validate_pkp,
+)
 
 from tests.conftest import CLI_LOG_OPTION
 from tests.test_cli.tools_for_testing import (
@@ -86,6 +90,7 @@ class CheckIsItemInLocalRegistryTestCase(TestCase):
 @mock.patch("aea.cli.common.try_to_load_agent_config")
 @mock.patch("aea.cli.publish._save_agent_locally")
 @mock.patch("aea.cli.publish.publish_agent")
+@mock.patch("aea.cli.publish._validate_pkp")
 class PublishCommandTestCase(TestCase):
     """Test case for CLI publish command."""
 
@@ -101,3 +106,22 @@ class PublishCommandTestCase(TestCase):
         self.runner.invoke(
             cli, [*CLI_LOG_OPTION, "publish", "--local"], standalone_mode=False,
         )
+
+
+class ValidatePkpTestCase(TestCase):
+    """Test case for _validate_pkp method."""
+
+    def test__validate_pkp_positive(self):
+        """Test _validate_pkp for positive result."""
+        private_key_paths = mock.Mock()
+        private_key_paths.read_all = mock.Mock(return_value=[])
+        _validate_pkp(private_key_paths)
+        private_key_paths.read_all.assert_called_once()
+
+    def test__validate_pkp_negative(self):
+        """Test _validate_pkp for negative result."""
+        private_key_paths = mock.Mock()
+        private_key_paths.read_all = mock.Mock(return_value=[1, 2])
+        with self.assertRaises(ClickException):
+            _validate_pkp(private_key_paths)
+        private_key_paths.read_all.assert_called_once()


### PR DESCRIPTION
…+ tests.
#1066 

## Proposed changes

Preventing from publishing agents with private_key_paths implemented

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
