### PR TITLE
AEA-503 improve the import_module function in helpers.

### DIFF
--- a/aea/helpers/base.py
+++ b/aea/helpers/base.py
@@ -227,7 +227,9 @@ def import_aea_module(dotted_path: str, module_obj) -> None:
 
     # add all prefixes as 'namespaces', since they are not actual packages.
     split = dotted_path.split(".")
-    assert len(split) > 3
+    assert (
+        len(split) > 3
+    ), "Import path has not the form 'packages.<author_name>.<package_type>.<package_name>'"
     root = split[0]
     till_author = root + "." + split[1]
     till_item_type = till_author + "." + split[2]


### PR DESCRIPTION
## Proposed changes

This PR changes the `aea.helpers.base.import_module` helper function, called by `aea.helpers.base.add_modules_to_sys_modules`, which in turn is called by many `aea.aea_builder.load_and_add_<package_type>`.
Now it adds all the prefixes of the import path as namespace namespaces in `sys.modules`.

Also, rename the function to `import_aea_module` since it used to handle only import statements for an AEA package (i.e. of the form `packages.<author_name>.<package_type_plural>.<package_name>...`).

## Fixes

Fix (partially) #1062 and  #890

... why? 

Because now, when trying to import, say, `packages.fetchai but on what follows: skills.generic_seller.non_existing_module` (see #890), assuming `packages.fetchai but on what follows: skills.generic_seller` is loaded correctly, instead of:

    error: An error occurred while loading ...: No module named 'packages.fetchai'; 'packages' is not a package

It would likely give an error:

    error: An error occurred while loading ...: No module named 'packages.fetchai.skills.generic_seller.non_existing_module

Which is more explicative.

However, this is not a complete solution. If the module of an AEA package tries to import from another package that does not exists, e.g.

    import packages.fetchai.skills.non_existing_package

The output will be:

    No module named 'packages.fetchai.skills.non_existing_package'; 'packages.fetchai.skills' is not a package

which is quite cryptic, because `packages.fetchai.skills` is not a package but a namespace, and the error message is not very clear (it's that `non_existing_package` is not found).

Nevertheless, for some cases, the changes proposed in this PR are still helpful, and they don't harm.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

