### PR TITLE
Wrap built-in __import__ for better error messages.

### DIFF
--- a/aea/__init__.py
+++ b/aea/__init__.py
@@ -24,5 +24,9 @@ import os
 
 from aea.__version__ import __title__, __description__, __url__, __version__
 from aea.__version__ import __author__, __license__, __copyright__
+from aea.helpers._import_wrapper import ImportWrapper
 
 AEA_DIR = os.path.dirname(inspect.getfile(inspect.currentframe()))  # type: ignore
+
+# enable the import wrapper
+ImportWrapper.wrap()

--- a/aea/helpers/_import_wrapper.py
+++ b/aea/helpers/_import_wrapper.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Import patcher."""
+
+import builtins
+
+
+class ImportWrapper:
+    """This class patches the built-in __import__ function."""
+
+    _builtin_import = builtins.__import__
+
+    @staticmethod
+    def wrapped_import(name: str, globals=None, locals=None, fromlist=(), level=0):
+        """
+        The patched __import__ function.
+
+        It acts as a wrapper to the built-in __import__ function.
+
+        It only gets activated if the first part of the import path
+        is equal to "packages". Otherwise, it forwards the call to
+        the builtins.__import__ function.
+
+        For documentation on the parameters,
+        please look at https://docs.python.org/3/library/functions.html#__import__.
+        """
+        kwargs = dict(globals=globals, locals=locals, fromlist=fromlist, level=level)
+        # print(name, globals, locals, fromlist, level)
+        parts = name.split(".")
+        root = parts[0]
+        if root == "packages" and level == 0:
+            return ImportWrapper.handle_package_import(name, **kwargs)
+        else:
+            return ImportWrapper._builtin_import(name, **kwargs)
+
+    @classmethod
+    def handle_package_import(
+        cls, name: str, globals=None, locals=None, fromlist=(), level=0
+    ):
+        """
+        Handle the import for an AEA import path (i.e. with the leading 'packages.').
+
+        The parameters of this function are the same of the builtins.__import__ function.
+        """
+        parts = name.split(".")
+        root = parts[0]
+        assert root == "packages"
+
+        try:
+            return ImportWrapper._builtin_import(
+                name, globals=globals, locals=locals, fromlist=fromlist, level=level
+            )
+        except ModuleNotFoundError as e:
+            cls.handle_module_not_found_error(
+                e, name, globals=globals, locals=locals, fromlist=fromlist, level=level
+            )
+
+    @classmethod
+    def wrap(cls):
+        builtins.__import__ = cls.wrapped_import
+
+    @classmethod
+    def unwrap(cls):
+        builtins.__import__ = cls._builtin_import
+
+    @classmethod
+    def handle_module_not_found_error(
+        cls, e, fullname, globals, locals, fromlist, level
+    ):
+        """
+        This method handles a 'ModuleNotFoundError' raised from wrong AEA package import.
+
+        It will re-raise the exception with a more meaningful error message (when possible).
+
+        :param e is the exception object. The other parameters are the arguments to the
+        function __import__.
+        """
+        parts = fullname.split(".")
+        nb_parts = len(parts)
+        if nb_parts == 2:
+            author = parts[1]
+            raise ModuleNotFoundError(
+                "No AEA package found with author name {}. The import of {} failed.".format(
+                    author, fullname
+                )
+            )
+        elif nb_parts == 3:
+            author = parts[1]
+            pkg_type = parts[2]
+            raise ModuleNotFoundError(
+                "No AEA package found with author name {} and type {}. The import of {} failed.".format(
+                    author, pkg_type, fullname
+                )
+            )
+        elif nb_parts >= 4:
+            author = parts[1]
+            pkg_type = parts[2]
+            pkg_name = parts[3]
+            raise ModuleNotFoundError(
+                "No AEA package found with author name {}, type {}, and name {}. The import of {} failed.".format(
+                    author, pkg_type, pkg_name, fullname
+                )
+            )
+        else:
+            raise e

--- a/aea/helpers/base.py
+++ b/aea/helpers/base.py
@@ -220,6 +220,7 @@ def import_aea_module(dotted_path: str, module_obj) -> None:
     :param module_obj: the module object. It is assumed it has been already executed.
     :return: None
     """
+
     def add_namespace_to_sys_modules_if_not_present(dotted_path: str):
         if dotted_path not in sys.modules:
             sys.modules[dotted_path] = types.ModuleType(dotted_path)

--- a/aea/helpers/base.py
+++ b/aea/helpers/base.py
@@ -201,21 +201,40 @@ def load_module(dotted_path: str, filepath: Path) -> types.ModuleType:
     return module
 
 
-def import_module(dotted_path: str, module_obj) -> None:
+def import_aea_module(dotted_path: str, module_obj) -> None:
     """
-    Add module to sys.modules.
+    Add an AEA module to sys.modules.
+
+    The parameter dotted_path has the form:
+
+        packages.<author_name>.<package_type>.<package_name>
+
+    If the closed-prefix packages are not present, add them to sys.modules.
+    This is done in order to emulate the behaviour of the true Python import system,
+    which in fact imports the packages recursively, for every prefix.
+
+    E.g. see https://docs.python.org/3/library/importlib.html#approximating-importlib-import-module
+    for an explanation on how the 'import' built-in function works.
 
     :param dotted_path: the dotted path to be used in the imports.
     :param module_obj: the module object. It is assumed it has been already executed.
     :return: None
     """
-    # if path is nested, and the root package is not present, add it to sys.modules
-    split = dotted_path.split(".")
-    if len(split) > 1 and split[0] not in sys.modules:
-        root = split[0]
-        sys.modules[root] = types.ModuleType(root)
+    def add_namespace_to_sys_modules_if_not_present(dotted_path: str):
+        if dotted_path not in sys.modules:
+            sys.modules[dotted_path] = types.ModuleType(dotted_path)
 
-    # add the module at the specified path.
+    # add all prefixes as 'namespaces', since they are not actual packages.
+    split = dotted_path.split(".")
+    assert len(split) > 3
+    root = split[0]
+    till_author = root + "." + split[1]
+    till_item_type = till_author + "." + split[2]
+    add_namespace_to_sys_modules_if_not_present(root)
+    add_namespace_to_sys_modules_if_not_present(till_author)
+    add_namespace_to_sys_modules_if_not_present(till_item_type)
+
+    # finally, add the module at the specified path.
     sys.modules[dotted_path] = module_obj
 
 
@@ -247,7 +266,7 @@ def add_modules_to_sys_modules(
     :return: None
     """
     for import_path, module_obj in modules_by_import_path.items():
-        import_module(import_path, module_obj)
+        import_aea_module(import_path, module_obj)
 
 
 def load_env_file(env_file: str):


### PR DESCRIPTION
## Proposed changes

(continuation of #1111)

This PR adds a wrapper to the built-in `__import__` function. It is automatically installed as soon as the framework is used.

It intercepts import statements whose import path start with `packages.`. Also, it filters out imports whose _level_ (see https://docs.python.org/3/library/functions.html#__import__) is `0`.

The right _level_ value has been found empirically. Unfortunately, it's not very reliable. And I couldn't find a better way to discriminate between proper AEA import statements and other import attempts e.g. `packages.six.moves.http_client` (`urllib3`), `packages.ssl_match_hostname` (`urllib3`), `packages.six.moves` etc.

An idea would be to add a 'blacklist' and to filter out import attempts whose `__package__` attribute in `globals`/`locals` is known. But still, there will always be corner cases for this.

## How to test the changes

From the repository root, execute these commands:
![image](https://user-images.githubusercontent.com/9467617/79517242-e7eb0e00-804d-11ea-877c-69fa20e10ca3.png)

in the screenshot, I added a wrong import statement in `vendor/fetchai/protocols/fipa/serialization.py` (see line `31`):
![image](https://user-images.githubusercontent.com/9467617/79517275-03eeaf80-804e-11ea-8651-b58f71e31315.png)

## Fixes

Fixes #890 and #1062, but in my opinion, the changes increase instability and unpredictability. 
I suggest implementing a custom importer by relying on the `importlib` standard package (in particular, on [`importlib.machinery`](https://docs.python.org/3/library/importlib.html#module-importlib.machinery) and path hooks to be installed in `sys.path_hooks`).

Also the [Python docs on `__import__`](https://docs.python.org/3/library/functions.html#__import__) discourage patching the built-in `__import__`:

> It can be replaced (by importing the builtins module and assigning to builtins.__import__) in order to change the semantics of the import statement, but doing so is strongly discouraged as it is usually simpler to use import hooks (see PEP 302) to attain the same goals and does not cause issues with code which assumes the default import implementation is in use.


## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

Despite my bad recommendation on this PR, it has been useful to understand the limits of this approach. I'm investigating the use of `sys.meta_path` and `sys.path_hooks`, although it won't be trivial, as clearly explained [here](https://stackoverflow.com/questions/41990169/how-to-use-sys-path-hooks-for-customized-loading-of-modules).

Nevertheless, the PR addresses the issues, with a relatively small impact on the codebase..