### PR TITLE
[AEA-552] TaskManager: lazy pool creation option

### DIFF
--- a/aea/skills/tasks.py
+++ b/aea/skills/tasks.py
@@ -121,7 +121,7 @@ def init_worker() -> None:
 class TaskManager:
     """A Task manager."""
 
-    def __init__(self, nb_workers: int = 5, is_lazy_pool_start: bool = True):
+    def __init__(self, nb_workers: int = 1, is_lazy_pool_start: bool = True):
         """
         Initialize the task manager.
 


### PR DESCRIPTION
## Proposed changes
TaskManager by default uses a lazy way to init workers pool on first enqueue instead of on start.
Can be controlled by TaskManager init argument: is_lazy_pool_start

default pool workers amount set to 1 instead of 5.

refers to https://github.com/fetchai/agents-aea/issues/1136
## Fixes
Saves some resources on agent start.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
