### PR TITLE
Add golang installation to prod image

### DIFF
--- a/deploy-image/Dockerfile
+++ b/deploy-image/Dockerfile
@@ -14,6 +14,9 @@ RUN pip install --upgrade pip
 RUN pip install protobuf colorlog graphviz
 RUN pip install aea[all]
 
+# golang
+RUN apk add --no-cache go
+
 COPY ./packages /home/packages
 WORKDIR home
 


### PR DESCRIPTION
## Proposed changes

One liner to install go on the docker production image, required by `fetchai/connections/p2p_noise` package.