### PR TITLE
Boost cli aea install timeout

### DIFF
--- a/aea/cli/install.py
+++ b/aea/cli/install.py
@@ -67,7 +67,7 @@ def _try_install(install_command: List[str]) -> int:
     """
     try:
         subp = subprocess.Popen(install_command)  # nosec
-        subp.wait(60.0)
+        subp.wait(120.0)
         return_code = subp.returncode
     finally:
         poll = subp.poll()


### PR DESCRIPTION
## Proposed changes

One liner to allow for `aea install` with `fetchai/p2p_noise:0.1.0` dependencies (`pynacl` in particular) to finish
