### PR TITLE
Update pipfile due to dependency conflicts

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ verify_ssl = true
 name = "test-pypi"
 
 [dev-packages]
-aiohttp = ">=3.5"
+aiohttp = "==3.6.2"
 bandit = "==1.6.2"
 black = "==19.10b0"
 bs4 = "==0.0.1"

--- a/Pipfile
+++ b/Pipfile
@@ -9,8 +9,7 @@ verify_ssl = true
 name = "test-pypi"
 
 [dev-packages]
-aiohttp = "==3.6.2"
-aries-cloudagent = "==0.4.5"
+aiohttp = ">=3.5"
 bandit = "==1.6.2"
 black = "==19.10b0"
 bs4 = "==0.0.1"


### PR DESCRIPTION
## Proposed changes

`aiohttp` and `markdown` versions caused issues in `pipenv lock`ing.

this is the screen after  `pipenv install --dev 2> output_file && vim output_file`

![image](https://user-images.githubusercontent.com/9467617/80620781-b8bd9f00-8a46-11ea-8677-3fde5419e078.png)
as you can see, `aries-cloud-agent caused the problem

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
