### PR TITLE
fixes requirements for name and author in configs

### DIFF
--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -56,7 +56,8 @@ DEFAULT_SKILL_CONFIG_FILE = "skill.yaml"
 DEFAULT_CONNECTION_CONFIG_FILE = "connection.yaml"
 DEFAULT_CONTRACT_CONFIG_FILE = "contract.yaml"
 DEFAULT_PROTOCOL_CONFIG_FILE = "protocol.yaml"
-DEFAULT_PRIVATE_KEY_PATHS = {"fetchai": "", "ethereum": ""}
+DEFAULT_REGISTRY_PATH = str(Path("./", "packages"))
+DEFAULT_LICENSE = "Apache-2.0"
 
 DEFAULT_FINGERPRINT_IGNORE_PATTERNS = [
     ".DS_Store",
@@ -617,8 +618,8 @@ class PackageConfiguration(Configuration, ABC):
         self,
         name: str,
         author: str,
-        version: str,
-        license: str,
+        version: str = "",
+        license: str = "",
         aea_version: str = "",
         fingerprint: Optional[Dict[str, str]] = None,
         fingerprint_ignore_patterns: Optional[Sequence[str]] = None,
@@ -638,10 +639,13 @@ class PackageConfiguration(Configuration, ABC):
         :param fingerprint_ignore_patterns: a list of file patterns to ignore files to fingerprint.
         """
         super().__init__()
+        assert (
+            name is not None and author is not None
+        ), "Name and author must be set on the configuration!"
         self.name = name
         self.author = author
         self.version = version if version != "" else DEFAULT_VERSION
-        self.license = license
+        self.license = license if license != "" else DEFAULT_LICENSE
         self.fingerprint = fingerprint if fingerprint is not None else {}
         self.fingerprint_ignore_patterns = (
             fingerprint_ignore_patterns
@@ -689,8 +693,8 @@ class ComponentConfiguration(PackageConfiguration, ABC):
         self,
         name: str,
         author: str,
-        version: str,
-        license: str,
+        version: str = "",
+        license: str = "",
         aea_version: str = "",
         fingerprint: Optional[Dict[str, str]] = None,
         fingerprint_ignore_patterns: Optional[Sequence[str]] = None,
@@ -817,8 +821,8 @@ class ConnectionConfig(ComponentConfiguration):
 
     def __init__(
         self,
-        name: str = "",
-        author: str = "",
+        name: str,
+        author: str,
         version: str = "",
         license: str = "",
         aea_version: str = "",
@@ -930,8 +934,8 @@ class ProtocolConfig(ComponentConfiguration):
 
     def __init__(
         self,
-        name: str = "",
-        author: str = "",
+        name: str,
+        author: str,
         version: str = "",
         license: str = "",
         fingerprint: Optional[Dict[str, str]] = None,
@@ -1028,8 +1032,8 @@ class SkillConfig(ComponentConfiguration):
 
     def __init__(
         self,
-        name: str = "",
-        author: str = "",
+        name: str,
+        author: str,
         version: str = "",
         license: str = "",
         aea_version: str = "",
@@ -1156,14 +1160,14 @@ class AgentConfig(PackageConfiguration):
 
     def __init__(
         self,
-        agent_name: str = "",
-        author: str = "",
+        agent_name: str,
+        author: str,
         version: str = "",
         license: str = "",
         aea_version: str = "",
         fingerprint: Optional[Dict[str, str]] = None,
         fingerprint_ignore_patterns: Optional[Sequence[str]] = None,
-        registry_path: str = "",
+        registry_path: str = DEFAULT_REGISTRY_PATH,
         description: str = "",
         logging_config: Optional[Dict] = None,
     ):
@@ -1382,8 +1386,8 @@ class ProtocolSpecification(ProtocolConfig):
 
     def __init__(
         self,
-        name: str = "",
-        author: str = "",
+        name: str,
+        author: str,
         version: str = "",
         license: str = "",
         aea_version: str = "",
@@ -1484,8 +1488,8 @@ class ContractConfig(ComponentConfiguration):
 
     def __init__(
         self,
-        name: str = "",
-        author: str = "",
+        name: str,
+        author: str,
         version: str = "",
         license: str = "",
         aea_version: str = "",

--- a/aea/configurations/constants.py
+++ b/aea/configurations/constants.py
@@ -19,8 +19,8 @@
 
 """Module to declare constants."""
 
-from pathlib import Path
-
+from aea.configurations.base import DEFAULT_LICENSE as DL
+from aea.configurations.base import DEFAULT_REGISTRY_PATH as DRP
 from aea.configurations.base import PublicId
 from aea.crypto.fetchai import FETCHAI
 
@@ -28,5 +28,5 @@ DEFAULT_CONNECTION = PublicId.from_str("fetchai/stub:0.2.0")
 DEFAULT_PROTOCOL = PublicId.from_str("fetchai/default:0.1.0")
 DEFAULT_SKILL = PublicId.from_str("fetchai/error:0.2.0")
 DEFAULT_LEDGER = FETCHAI
-DEFAULT_REGISTRY_PATH = str(Path("./", "packages"))
-DEFAULT_LICENSE = "Apache-2.0"
+DEFAULT_REGISTRY_PATH = DRP
+DEFAULT_LICENSE = DL

--- a/benchmark/framework/aea_test_wrapper.py
+++ b/benchmark/framework/aea_test_wrapper.py
@@ -17,6 +17,8 @@
 #
 # ------------------------------------------------------------------------------
 """This test module contains AEA/AEABuilder wrapper to make performance tests easy."""
+
+import uuid
 from threading import Thread
 from typing import Dict, List, Optional, Tuple, Type, Union
 
@@ -89,7 +91,9 @@ class AEATestWrapper:
         """
         handlers = handlers or {}
         context = context or SkillContext()
-        config = config or SkillConfig()
+        config = config or SkillConfig(
+            name="skill_{}".format(uuid.uuid4().hex[0:5]), author="fetchai"
+        )
 
         handlers_instances = {
             name: cls(name=name, skill_context=context)

--- a/tests/test_aea_exectimeout.py
+++ b/tests/test_aea_exectimeout.py
@@ -85,7 +85,7 @@ class BaseTimeExecutionCase(TestCase):
         behaviour_cls = make_behaviour_cls_from_funcion(handler_func)
 
         test_skill = Skill(
-            SkillConfig(name="test_skill"),
+            SkillConfig(name="test_skill", author="fetchai"),
             skill_context=skill_context,
             handlers={
                 "handler1": handler_cls(name="handler1", skill_context=skill_context)

--- a/tests/test_configurations/test_base.py
+++ b/tests/test_configurations/test_base.py
@@ -238,11 +238,11 @@ class AgentConfigTestCase(TestCase):
 
     def test_init_logging_config_positive(self):
         """Test case for from_json method positive result."""
-        AgentConfig(logging_config={})
+        AgentConfig(agent_name="my_agent", author="fetchai", logging_config={})
 
     def test_default_connection(self):
         """Test case for default_connection setter positive result."""
-        agent_config = AgentConfig()
+        agent_config = AgentConfig(agent_name="my_agent", author="fetchai")
         agent_config.default_connection = None
         agent_config.default_connection = 1
         agent_config.public_id
@@ -279,11 +279,11 @@ class ProtocolSpecificationTestCase(TestCase):
 
     def test_init_positive(self):
         """Test case for __init__ method positive result."""
-        ProtocolSpecification()
+        ProtocolSpecification(name="my_protocol", author="fetchai")
 
     def test_json_positive(self):
         """Test case for json property positive result."""
-        obj = ProtocolSpecification()
+        obj = ProtocolSpecification(name="my_protocol", author="fetchai")
         obj.json
 
     @mock.patch("aea.configurations.base.SpeechActContentConfig.from_json")
@@ -302,7 +302,7 @@ class ProtocolSpecificationTestCase(TestCase):
 
     def test__check_consistency_positive(self):
         """Test case for _check_consistency method positive result."""
-        obj = ProtocolSpecification()
+        obj = ProtocolSpecification(name="my_protocol", author="fetchai")
         with self.assertRaises(ProtocolSpecificationParseError):
             obj._check_consistency()
 

--- a/tests/test_connections/test_base.py
+++ b/tests/test_connections/test_base.py
@@ -58,12 +58,12 @@ class ConnectionTestCase(TestCase):
 
     def test_loop_positive(self):
         """Test loop property positive result."""
-        obj = self.TestConnection(ConnectionConfig())
+        obj = self.TestConnection(ConnectionConfig("some_connection", "fetchai"))
         obj._loop = "loop"
         obj.loop
 
     def test_excluded_protocols_positive(self):
         """Test excluded_protocols property positive result."""
-        obj = self.TestConnection(ConnectionConfig())
+        obj = self.TestConnection(ConnectionConfig("some_connection", "fetchai"))
         obj._excluded_protocols = "excluded_protocols"
         obj.excluded_protocols


### PR DESCRIPTION
## Proposed changes

This PR fixes the configuration objects such that the name and author are now required arguments.

## Fixes

-

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

-