### PR TITLE
AEA-573 CI check for consistent package usage

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -49,6 +49,8 @@ jobs:
            tox -e flake8
        - name: Static type check
          run: tox -e mypy
+       - name: Check package versions in documentation
+         run: tox -e package_version_checks
        - name: Generate Documentation
          run: tox -e docs
 

--- a/scripts/check_package_versions_in_docs.py
+++ b/scripts/check_package_versions_in_docs.py
@@ -32,7 +32,9 @@ from typing import Callable, Set
 
 import yaml
 
+
 from aea.configurations.base import ComponentType, PackageId, PackageType, PublicId
+
 
 PUBLIC_ID_REGEX = PublicId.PUBLIC_ID_REGEX[1:-1]
 """This regex removes the '^' and '$' respectively, at the beginning and at the end."""
@@ -60,7 +62,7 @@ This regex matches strings of the form:
 class PackageIdNotFound(Exception):
     """Custom exception for package id not found."""
 
-    def __init__(self, file: Path, package_id: PackageId, match_obj: re.Match, *args):
+    def __init__(self, file: Path, package_id: PackageId, match_obj, *args):
         """
         Initialize PackageIdNotFound exception.
 
@@ -101,9 +103,7 @@ ALL_PACKAGE_IDS: Set[PackageId] = find_all_packages_ids()
 
 
 def _checks(
-    file: Path,
-    regex: re.Pattern,
-    extract_package_id_from_match: Callable[[re.Match], PackageId],
+    file: Path, regex, extract_package_id_from_match: Callable[["re.Match"], PackageId],
 ):
     matches = regex.finditer(file.read_text())
     for match in matches:
@@ -126,7 +126,7 @@ def check_add_commands(file: Path):
     :raises PackageIdNotFound: if some package id is not found in packages/
     """
 
-    def extract_package_id(match: re.Match):
+    def extract_package_id(match):
         package_type, package = match.group(1), match.group(2)
         package_id = PackageId(PackageType(package_type), PublicId.from_str(package))
         return package_id
@@ -144,7 +144,7 @@ def check_fetch_commands(file: Path):
     :raises PackageIdNotFound: if some package id is not found in packages/
     """
 
-    def extract_package_id(match: re.Match):
+    def extract_package_id(match):
         package_public_id = match.group(1)
         package_id = PackageId(PackageType.AGENT, PublicId.from_str(package_public_id))
         return package_id

--- a/scripts/check_package_versions_in_docs.py
+++ b/scripts/check_package_versions_in_docs.py
@@ -1,4 +1,22 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
 """
 Check that package ids are in sync with the current packages.
 

--- a/scripts/check_package_versions_in_docs.py
+++ b/scripts/check_package_versions_in_docs.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+"""
+Check that package ids are in sync with the current packages.
+
+Run this script from the root of the project directory:
+
+    python scripts/check_package_versions_in_docs.py
+
+"""
+import re
+import sys
+from pathlib import Path
+from typing import Callable, Set
+
+import yaml
+
+from aea.configurations.base import ComponentType, PackageId, PackageType, PublicId
+
+PUBLIC_ID_REGEX = PublicId.PUBLIC_ID_REGEX[1:-1]
+"""This regex removes the '^' and '$' respectively, at the beginning and at the end."""
+
+ADD_COMMAND_IN_DOCS = re.compile(
+    "aea +add +({}) +({})".format("|".join(map(str, ComponentType)), PUBLIC_ID_REGEX)
+)
+"""
+This regex matches strings of the form:
+
+  aea add (protocol|connection|contract|skill) some_author/some_package:some_version_number
+
+"""
+
+
+FETCH_COMMAND_IN_DOCS = re.compile("aea +fetch +({})".format(PUBLIC_ID_REGEX))
+"""
+This regex matches strings of the form:
+
+  aea fetch some_author/some_package:some_version_number
+
+"""
+
+
+class PackageIdNotFound(Exception):
+    """Custom exception for package id not found."""
+
+    def __init__(self, file: Path, package_id: PackageId, match_obj: re.Match, *args):
+        """
+        Initialize PackageIdNotFound exception.
+
+        :param file: path to the file checked.
+        :param package_id: package id not found.
+        :param match_obj: re.Match object.
+        :param args: super class args.
+        """
+        super().__init__(*args)
+        self.file = file
+        self.package_id = package_id
+        self.match_obj = match_obj
+
+
+def get_public_id_from_yaml(configuration_file: Path):
+    data = yaml.safe_load(configuration_file.open())
+    author = data["author"]
+    # handle the case when it's a package or agent config file.
+    name = data["name"] if "name" in data else data["agent_name"]
+    version = data["version"]
+    return PublicId(author, name, version)
+
+
+def find_all_packages_ids() -> Set[PackageId]:
+    """Find all packages ids."""
+    package_ids: Set[PackageId] = set()
+    packages_dir = Path("packages")
+    for configuration_file in packages_dir.glob("*/*/*/*.yaml"):
+        package_type = PackageType(configuration_file.parts[2][:-1])
+        package_public_id = get_public_id_from_yaml(configuration_file)
+        package_id = PackageId(package_type, package_public_id)
+        package_ids.add(package_id)
+
+    return package_ids
+
+
+ALL_PACKAGE_IDS: Set[PackageId] = find_all_packages_ids()
+
+
+def _checks(
+    file: Path,
+    regex: re.Pattern,
+    extract_package_id_from_match: Callable[[re.Match], PackageId],
+):
+    matches = regex.finditer(file.read_text())
+    for match in matches:
+        package_id = extract_package_id_from_match(match)
+        if package_id not in ALL_PACKAGE_IDS:
+            raise PackageIdNotFound(
+                file, package_id, match, "Package {} not found.".format(package_id)
+            )
+        else:
+            print(str(package_id), "OK!")
+
+
+def check_add_commands(file: Path):
+    """
+    Check that 'aea add' commands of the documentation file contains
+    known package ids.
+
+    :param file: path to the file.
+    :return: None
+    :raises PackageIdNotFound: if some package id is not found in packages/
+    """
+
+    def extract_package_id(match: re.Match):
+        package_type, package = match.group(1), match.group(2)
+        package_id = PackageId(PackageType(package_type), PublicId.from_str(package))
+        return package_id
+
+    _checks(file, ADD_COMMAND_IN_DOCS, extract_package_id)
+
+
+def check_fetch_commands(file: Path):
+    """
+    Check that 'aea fetch' commands of the documentation file contains
+    known package ids.
+
+    :param file: path to the file.
+    :return: None
+    :raises PackageIdNotFound: if some package id is not found in packages/
+    """
+
+    def extract_package_id(match: re.Match):
+        package_public_id = match.group(1)
+        package_id = PackageId(PackageType.AGENT, PublicId.from_str(package_public_id))
+        return package_id
+
+    _checks(file, FETCH_COMMAND_IN_DOCS, extract_package_id)
+
+
+def check_file(file: Path):
+    """
+    Check documentation file.
+
+    :param file: path to the file to check.
+    :return: None
+    :raises PackageIdNotFound: if a package id does not pass the checks.
+    """
+    check_add_commands(file)
+    check_fetch_commands(file)
+
+
+def handle_package_not_found(e: PackageIdNotFound):
+    """Handle PackageIdNotFound errors."""
+    print("=" * 50)
+    print("Package {} not found.".format(e.package_id))
+    print("Path to file: ", e.file)
+    print("Span: ", e.match_obj.span(0))
+    print("Full Match: ", e.match_obj.group(0))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    docs_files = Path("docs").glob("**/*.md")
+
+    try:
+        for file in docs_files:
+            print("Processing " + str(file))
+            check_file(file)
+    except PackageIdNotFound as e:
+        handle_package_not_found(e)
+        sys.exit(1)
+
+    print("Done!")
+    sys.exit(0)

--- a/tox.ini
+++ b/tox.ini
@@ -108,6 +108,9 @@ commands = {toxinidir}/scripts/check_copyright_notice.py --directory {toxinidir}
 deps = python-dotenv
 commands = {toxinidir}/scripts/generate_ipfs_hashes.py --check {posargs}
 
+[testenv:package_version_checks]
+commands = {toxinidir}/scripts/check_package_versions_in_docs.py
+
 [testenv:docs]
 description = Build the documentation.
 deps = markdown==3.2.1


### PR DESCRIPTION
## Proposed changes

This PR adds a new script to check that the package ids in the docs are not out of sync with the current state of the local registry `packages/`.

## Fixes

Fixes #1188 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
