### PR TITLE
patch.__enter__/__exit__ replaced with more suitable start/stop

### DIFF
--- a/tests/test_cli/test_add/test_connection.py
+++ b/tests/test_cli/test_add/test_connection.py
@@ -381,7 +381,7 @@ class TestAddConnectionFailsWhenConfigFileIsNotCompliant:
             "from_json",
             side_effect=ValidationError("test error message"),
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         os.chdir(cls.agent_name)
         cls.result = cls.runner.invoke(
@@ -405,7 +405,7 @@ class TestAddConnectionFailsWhenConfigFileIsNotCompliant:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)

--- a/tests/test_cli/test_add/test_protocol.py
+++ b/tests/test_cli/test_add/test_protocol.py
@@ -375,7 +375,7 @@ class TestAddProtocolFailsWhenConfigFileIsNotCompliant:
             "from_json",
             side_effect=ValidationError("test error message"),
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         os.chdir(cls.agent_name)
         cls.result = cls.runner.invoke(
@@ -399,7 +399,7 @@ class TestAddProtocolFailsWhenConfigFileIsNotCompliant:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)

--- a/tests/test_cli/test_add/test_skill.py
+++ b/tests/test_cli/test_add/test_skill.py
@@ -386,7 +386,7 @@ class TestAddSkillFailsWhenConfigFileIsNotCompliant:
             "from_json",
             side_effect=ValidationError("test error message"),
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         cls.result = cls.runner.invoke(
             cli,
@@ -409,7 +409,7 @@ class TestAddSkillFailsWhenConfigFileIsNotCompliant:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)

--- a/tests/test_cli/test_create.py
+++ b/tests/test_cli/test_create.py
@@ -331,7 +331,7 @@ class TestCreateFailsWhenConfigFileIsNotCompliant:
         cls.patch = patch.object(
             aea.configurations.base.AgentConfig, "json", return_value={"hello": "world"}
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
@@ -361,7 +361,7 @@ class TestCreateFailsWhenConfigFileIsNotCompliant:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)
@@ -380,7 +380,7 @@ class TestCreateFailsWhenExceptionOccurs:
 
         # change the serialization of the AgentConfig class so to make the parsing to fail.
         cls.patch = patch.object(ConfigLoader, "dump", side_effect=Exception)
-        cls.patch.__enter__()
+        cls.patch.start()
 
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
@@ -409,7 +409,7 @@ class TestCreateFailsWhenExceptionOccurs:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)

--- a/tests/test_cli/test_generate/test_protocols.py
+++ b/tests/test_cli/test_generate/test_protocols.py
@@ -317,7 +317,7 @@ class TestGenerateProtocolFailsWhenConfigFileIsNotCompliant:
         cls.patch = unittest.mock.patch(
             "yaml.dump", side_effect=ValidationError("test error message")
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         # generate protocol
         os.chdir(cls.agent_name)
@@ -354,7 +354,7 @@ class TestGenerateProtocolFailsWhenConfigFileIsNotCompliant:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         try:
             shutil.rmtree(cls.t)
         except (OSError, IOError):
@@ -390,7 +390,7 @@ class TestGenerateProtocolFailsWhenExceptionOccurs:
         cls.patch = unittest.mock.patch(
             "shutil.copytree", side_effect=Exception("unknwon exception")
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         # generate protocol
         os.chdir(cls.agent_name)
@@ -419,7 +419,7 @@ class TestGenerateProtocolFailsWhenExceptionOccurs:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         try:
             shutil.rmtree(cls.t)
         except (OSError, IOError):

--- a/tests/test_cli/test_remove/test_connection.py
+++ b/tests/test_cli/test_remove/test_connection.py
@@ -52,7 +52,7 @@ class TestRemoveConnectionWithPublicId:
         cls.connection_id = "fetchai/local:0.1.0"
         cls.connection_name = "local"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, "error")
-        cls.mocked_logger_error = cls.patch.__enter__()
+        cls.mocked_logger_error = cls.patch.start()
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
@@ -171,7 +171,7 @@ class TestRemoveConnectionFailsWhenExceptionOccurs:
         cls.connection_id = "fetchai/local:0.1.0"
         cls.connection_name = "local"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, "error")
-        cls.mocked_logger_error = cls.patch.__enter__()
+        cls.mocked_logger_error = cls.patch.start()
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
@@ -195,7 +195,7 @@ class TestRemoveConnectionFailsWhenExceptionOccurs:
         cls.patch = unittest.mock.patch(
             "shutil.rmtree", side_effect=BaseException("an exception")
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         cls.result = cls.runner.invoke(
             cli,
@@ -210,7 +210,7 @@ class TestRemoveConnectionFailsWhenExceptionOccurs:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)

--- a/tests/test_cli/test_remove/test_protocol.py
+++ b/tests/test_cli/test_remove/test_protocol.py
@@ -52,7 +52,7 @@ class TestRemoveProtocolWithPublicId:
         cls.protocol_id = "fetchai/gym:0.1.0"
         cls.protocol_name = "gym"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, "error")
-        cls.mocked_logger_error = cls.patch.__enter__()
+        cls.mocked_logger_error = cls.patch.start()
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
@@ -170,7 +170,7 @@ class TestRemoveProtocolFailsWhenExceptionOccurs:
         shutil.copytree(Path(CUR_PATH, "..", "packages"), Path(cls.t, "packages"))
         cls.protocol_id = "fetchai/gym:0.1.0"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, "error")
-        cls.mocked_logger_error = cls.patch.__enter__()
+        cls.mocked_logger_error = cls.patch.start()
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
@@ -194,7 +194,7 @@ class TestRemoveProtocolFailsWhenExceptionOccurs:
         cls.patch = unittest.mock.patch(
             "shutil.rmtree", side_effect=BaseException("an exception")
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         cls.result = cls.runner.invoke(
             cli,
@@ -209,7 +209,7 @@ class TestRemoveProtocolFailsWhenExceptionOccurs:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)

--- a/tests/test_cli/test_remove/test_skill.py
+++ b/tests/test_cli/test_remove/test_skill.py
@@ -50,7 +50,7 @@ class TestRemoveSkillWithPublicId:
         cls.skill_id = "fetchai/gym:0.2.0"
         cls.skill_name = "gym"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, "error")
-        cls.mocked_logger_error = cls.patch.__enter__()
+        cls.mocked_logger_error = cls.patch.start()
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
@@ -175,7 +175,7 @@ class TestRemoveSkillFailsWhenExceptionOccurs:
         cls.skill_id = "fetchai/gym:0.2.0"
         cls.skill_name = "gym"
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, "error")
-        cls.mocked_logger_error = cls.patch.__enter__()
+        cls.mocked_logger_error = cls.patch.start()
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
@@ -206,7 +206,7 @@ class TestRemoveSkillFailsWhenExceptionOccurs:
         cls.patch = unittest.mock.patch(
             "shutil.rmtree", side_effect=BaseException("an exception")
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         cls.result = cls.runner.invoke(
             cli,
@@ -221,7 +221,7 @@ class TestRemoveSkillFailsWhenExceptionOccurs:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)

--- a/tests/test_cli/test_scaffold/test_connection.py
+++ b/tests/test_cli/test_scaffold/test_connection.py
@@ -60,7 +60,7 @@ class TestScaffoldConnection:
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, "error")
-        cls.mocked_logger_error = cls.patch.__enter__()
+        cls.mocked_logger_error = cls.patch.start()
 
         cls.schema = json.load(open(CONNECTION_CONFIGURATION_SCHEMA))
         cls.resolver = jsonschema.RefResolver(
@@ -286,7 +286,7 @@ class TestScaffoldConnectionFailsWhenConfigFileIsNotCompliant:
         cls.patch = unittest.mock.patch(
             "yaml.dump", side_effect=ValidationError("test error message")
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         os.chdir(cls.agent_name)
         cls.result = cls.runner.invoke(
@@ -319,7 +319,7 @@ class TestScaffoldConnectionFailsWhenConfigFileIsNotCompliant:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)
@@ -355,7 +355,7 @@ class TestScaffoldConnectionFailsWhenExceptionOccurs:
         cls.patch = unittest.mock.patch(
             "shutil.copytree", side_effect=Exception("unknwon exception")
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         os.chdir(cls.agent_name)
         cls.result = cls.runner.invoke(
@@ -380,7 +380,7 @@ class TestScaffoldConnectionFailsWhenExceptionOccurs:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)

--- a/tests/test_cli/test_scaffold/test_protocols.py
+++ b/tests/test_cli/test_scaffold/test_protocols.py
@@ -60,7 +60,7 @@ class TestScaffoldProtocol:
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, "error")
-        cls.mocked_logger_error = cls.patch.__enter__()
+        cls.mocked_logger_error = cls.patch.start()
 
         cls.schema = json.load(open(PROTOCOL_CONFIGURATION_SCHEMA))
         cls.resolver = jsonschema.RefResolver(
@@ -288,7 +288,7 @@ class TestScaffoldProtocolFailsWhenConfigFileIsNotCompliant:
         cls.patch = unittest.mock.patch(
             "yaml.dump", side_effect=ValidationError("test error message")
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         os.chdir(cls.agent_name)
         cls.result = cls.runner.invoke(
@@ -321,7 +321,7 @@ class TestScaffoldProtocolFailsWhenConfigFileIsNotCompliant:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)
@@ -356,7 +356,7 @@ class TestScaffoldProtocolFailsWhenExceptionOccurs:
         cls.patch = unittest.mock.patch(
             "shutil.copytree", side_effect=Exception("unknwon exception")
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         os.chdir(cls.agent_name)
         cls.result = cls.runner.invoke(
@@ -381,7 +381,7 @@ class TestScaffoldProtocolFailsWhenExceptionOccurs:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)

--- a/tests/test_cli/test_scaffold/test_skills.py
+++ b/tests/test_cli/test_scaffold/test_skills.py
@@ -60,7 +60,7 @@ class TestScaffoldSkill:
         cls.cwd = os.getcwd()
         cls.t = tempfile.mkdtemp()
         cls.patch = unittest.mock.patch.object(aea.cli.common.logger, "error")
-        cls.mocked_logger_error = cls.patch.__enter__()
+        cls.mocked_logger_error = cls.patch.start()
 
         cls.schema = json.load(open(SKILL_CONFIGURATION_SCHEMA))
         cls.resolver = jsonschema.RefResolver(
@@ -292,7 +292,7 @@ class TestScaffoldSkillFailsWhenConfigFileIsNotCompliant:
         cls.patch = unittest.mock.patch(
             "yaml.dump", side_effect=ValidationError("test error message"),
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         os.chdir(cls.agent_name)
         cls.result = cls.runner.invoke(
@@ -323,7 +323,7 @@ class TestScaffoldSkillFailsWhenConfigFileIsNotCompliant:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)
@@ -358,7 +358,7 @@ class TestScaffoldSkillFailsWhenExceptionOccurs:
         cls.patch = unittest.mock.patch(
             "shutil.copytree", side_effect=Exception("unknwon exception")
         )
-        cls.patch.__enter__()
+        cls.patch.start()
 
         os.chdir(cls.agent_name)
         cls.result = cls.runner.invoke(
@@ -381,7 +381,7 @@ class TestScaffoldSkillFailsWhenExceptionOccurs:
     @classmethod
     def teardown_class(cls):
         """Tear the test down."""
-        cls.patch.__exit__()
+        cls.patch.stop()
         os.chdir(cls.cwd)
         try:
             shutil.rmtree(cls.t)

--- a/tests/test_connections/test_stub.py
+++ b/tests/test_connections/test_stub.py
@@ -91,7 +91,7 @@ class TestStubConnectionReception:
     def test_reception_fails(self):
         """Test the case when an error occurs during the processing of a line."""
         patch = mock.patch.object(aea.connections.stub.connection.logger, "error")
-        mocked_logger_error = patch.__enter__()
+        mocked_logger_error = patch.start()
         with mock.patch(
             "aea.connections.stub.connection._decode",
             side_effect=Exception("an error."),
@@ -101,7 +101,7 @@ class TestStubConnectionReception:
                 "Error when processing a line. Message: an error."
             )
 
-        patch.__exit__()
+        patch.stop()
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_packages/test_connections/test_oef/test_communication.py
+++ b/tests/test_packages/test_connections/test_oef/test_communication.py
@@ -1039,7 +1039,7 @@ class TestSendWithOEF(UseOef):
         patch = unittest.mock.patch.object(
             packages.fetchai.connections.oef.connection.logger, "debug"
         )
-        mocked_logger_debug = patch.__enter__()
+        mocked_logger_debug = patch.start()
 
         async def receive():
             await oef_connection.receive()
@@ -1100,7 +1100,7 @@ async def test_cannot_connect_to_oef():
     patch = unittest.mock.patch.object(
         packages.fetchai.connections.oef.connection.logger, "warning"
     )
-    mocked_logger_warning = patch.__enter__()
+    mocked_logger_warning = patch.start()
 
     async def try_to_connect():
         await oef_connection.connect()

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -55,7 +55,7 @@ class TestContractRegistry:
     def setup_class(cls):
         """Set the tests up."""
         cls.patch = unittest.mock.patch.object(aea.registries.base.logger, "exception")
-        cls.mocked_logger = cls.patch.__enter__()
+        cls.mocked_logger = cls.patch.start()
 
         cls.oldcwd = os.getcwd()
         cls.agent_name = "agent_dir_test"
@@ -83,7 +83,7 @@ class TestContractRegistry:
         assert set(c.id for c in contracts) == self.expected_contract_ids
 
     def test_fetch(self):
-        """ Test that the `fetch` method works as expected."""
+        """Test that the `fetch` method works as expected."""
         contract_id = PublicId.from_str("fetchai/erc1155:0.3.0")
         contract = self.registry.fetch(contract_id)
         assert isinstance(contract, Contract)
@@ -120,7 +120,7 @@ class TestProtocolRegistry:
     def setup_class(cls):
         """Set the tests up."""
         cls.patch = unittest.mock.patch.object(aea.registries.base.logger, "exception")
-        cls.mocked_logger = cls.patch.__enter__()
+        cls.mocked_logger = cls.patch.start()
 
         cls.oldcwd = os.getcwd()
         cls.agent_name = "agent_dir_test"


### PR DESCRIPTION
## Proposed changes

use patch.start and patch.stop instead of patch.__enter__ and patch.__exit__

## Fixes

got a problem with mac os ci:
```

    @classmethod
    def teardown_class(cls):
        """Tear the test down."""
>       cls.patch.__exit__()

/Users/runner/runners/2.262.1/work/agents-aea/agents-aea/tests/test_cli/test_scaffold/test_protocols.py:384: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/runner/hostedtoolcache/Python/3.8.3/x64/lib/python3.8/unittest/mock.py:1524: in __exit__
    return exit_stack.__exit__(*exc_info)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <contextlib.ExitStack object at 0x12048aa90>, exc_details = ()

    def __exit__(self, *exc_details):
>       received_exc = exc_details[0] is not None
E       IndexError: tuple index out of range
```

context.__exit__ requires three parameters with details about the exception, and not sure should be called manually. wondering why it fails only on one mac os instance.


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that code coverage does not decrease.
- [X] I have checked that the documentation about the `aea cli` tool works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules
