### PR TITLE
Make 'private_key_path' to be None in AEABulider.add_private_key

### DIFF
--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -255,7 +255,7 @@ class AEABuilder:
         """
         self._name = None  # type: Optional[str]
         self._resources = Resources()
-        self._private_key_paths = {}  # type: Dict[str, str]
+        self._private_key_paths = {}  # type: Dict[str, Optional[str]]
         self._ledger_apis_configs = {}  # type: Dict[str, Dict[str, Union[str, int]]]
         self._default_key = None  # set by the user, or instantiate a default one.
         self._default_ledger = (
@@ -460,7 +460,7 @@ class AEABuilder:
         return self
 
     @property
-    def private_key_paths(self) -> Dict[str, str]:
+    def private_key_paths(self) -> Dict[str, Optional[str]]:
         """Get the private key paths."""
         return self._private_key_paths
 

--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -434,16 +434,19 @@ class AEABuilder:
         return self
 
     def add_private_key(
-        self, identifier: str, private_key_path: PathLike
+        self, identifier: str, private_key_path: Optional[PathLike] = None
     ) -> "AEABuilder":
         """
         Add a private key path.
 
         :param identifier: the identifier for that private key path.
-        :param private_key_path: path to the private key file.
+        :param private_key_path: an (optional) path to the private key file.
+            If None, the key will be created at build time.
         :return: the AEABuilder
         """
-        self._private_key_paths[identifier] = str(private_key_path)
+        self._private_key_paths[identifier] = (
+            str(private_key_path) if private_key_path is not None else None
+        )
         return self
 
     def remove_private_key(self, identifier: str) -> "AEABuilder":

--- a/aea/crypto/wallet.py
+++ b/aea/crypto/wallet.py
@@ -19,7 +19,7 @@
 
 """Module wrapping all the public and private keys cryptography."""
 
-from typing import Dict, cast
+from typing import Dict, Optional, cast
 
 import aea.crypto
 from aea.crypto.base import Crypto
@@ -28,7 +28,7 @@ from aea.crypto.base import Crypto
 class Wallet:
     """Store all the cryptos we initialise."""
 
-    def __init__(self, private_key_paths: Dict[str, str]):
+    def __init__(self, private_key_paths: Dict[str, Optional[str]]):
         """
         Instantiate a wallet object.
 


### PR DESCRIPTION
## Proposed changes

Make `AEABulider.add_private_key` to accept the `private_key_path` argument to be `None`.

## Fixes

Fixes #1237 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
n/a
