### PR TITLE
Remove sys.exit from subcalls to AEABuilder.build

### DIFF
--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -24,7 +24,6 @@ import logging
 import os
 import pprint
 import re
-import sys
 from pathlib import Path
 from typing import Any, Collection, Dict, List, Optional, Set, Tuple, Type, Union, cast
 
@@ -801,7 +800,10 @@ class AEABuilder:
     def _update_identity(
         self, identity: Identity, wallet: Wallet, connections: List[Connection]
     ) -> Identity:
-        """TEMPORARY fix to update identity with address from noise p2p connection. Only affects the noise p2p connection."""
+        """
+        TEMPORARY fix to update identity with address from noise p2p connection.
+        Only affects the noise p2p connection.
+        """
         public_ids = []  # type: List[PublicId]
         for connection in connections:
             public_ids.append(connection.public_id)
@@ -824,12 +826,11 @@ class AEABuilder:
                 identity = Identity(self._name, address=p2p_noise_connection.noise_address)  # type: ignore
             return identity
         else:
-            logger.error(
+            raise AEAException(
                 "The p2p-noise connection can only be used as a single connection. "
                 "Set it as the default connection with `aea config set agent.default_connection fetchai/p2p_noise:0.2.0` "
                 "And use `aea run --connections fetchai/p2p_noise:0.2.0` to run it as a single connection."
             )
-            sys.exit(1)
 
     def _get_agent_loop_timeout(self) -> float:
         """


### PR DESCRIPTION
## Proposed changes

There was an execution path where the sys.exit was called on AEABuilder.build. This is not right since we don't want the app to stop, for instance when used programmatically A good alternative is to raise an exception.

## Fixes

Fixes #1190 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
n/a