### PR TITLE
AEABuilder reentrancy

### DIFF
--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -1163,8 +1163,11 @@ class AEABuilder:
                 skill_context = SkillContext()
                 skill_context.set_agent_context(context)
                 skill_context.logger = logging.getLogger(logger_name)
-                skill = load_component_from_config(  # type: ignore
-                    ComponentType.SKILL, configuration, skill_context=skill_context
+                skill = cast(
+                    Skill,
+                    load_component_from_config(
+                        ComponentType.SKILL, configuration, skill_context=skill_context
+                    ),
                 )
             resources.add_component(skill)
 

--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -22,7 +22,7 @@ import itertools
 import logging
 import os
 import pprint
-from copy import deepcopy, copy
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Collection, Dict, List, Optional, Set, Tuple, Type, Union, cast
 

--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -22,7 +22,7 @@ import itertools
 import logging
 import os
 import pprint
-from copy import deepcopy
+from copy import copy, deepcopy
 from pathlib import Path
 from typing import Any, Collection, Dict, List, Optional, Set, Tuple, Type, Union, cast
 
@@ -725,9 +725,9 @@ class AEABuilder:
         :return: the AEA object.
         """
         resources = Resources()
-        wallet = Wallet(deepcopy(self.private_key_paths))
+        wallet = Wallet(copy(self.private_key_paths))
         identity = self._build_identity_from_wallet(wallet)
-        ledger_apis = deepcopy(self._load_ledger_apis(ledger_apis))
+        ledger_apis = self._load_ledger_apis(ledger_apis)
         self._load_and_add_components(ComponentType.PROTOCOL, resources)
         self._load_and_add_components(ComponentType.CONTRACT, resources)
         connections = self._load_connections(identity.address, connection_ids)
@@ -762,6 +762,7 @@ class AEABuilder:
         """
         if ledger_apis is not None:
             self._check_consistent(ledger_apis)
+            ledger_apis = deepcopy(ledger_apis)
         else:
             ledger_apis = LedgerApis(self.ledger_apis_config, self._default_ledger)
         return ledger_apis

--- a/tests/test_aea_builder.py
+++ b/tests/test_aea_builder.py
@@ -25,15 +25,9 @@ from pathlib import Path
 import pytest
 
 from aea.aea_builder import AEABuilder
-from aea.configurations.base import (
-    ComponentType,
-    SkillConfig,
-    DEFAULT_SKILL_CONFIG_FILE,
-)
+from aea.configurations.base import ComponentType
 from aea.crypto.fetchai import FetchAICrypto
 from aea.exceptions import AEAException
-from aea.skills.base import SkillContext, Skill
-from .common.utils import make_handler_cls_from_funcion, make_behaviour_cls_from_funcion
 
 from .conftest import CUR_PATH, ROOT_DIR, skip_test_windows
 

--- a/tests/test_aea_builder.py
+++ b/tests/test_aea_builder.py
@@ -160,11 +160,11 @@ class TestReentrancy:
 
         d1 = {c.component_id: c for c in components_a}
         d2 = {c.component_id: c for c in components_b}
-        assert d1 != d2
+        assert all(d1[k] is not d2[k] for k in d1.keys())
 
-        configurations_1 = {c.component_id: c.configuration for c in components_a}
-        configurations_2 = {c.component_id: c.configuration for c in components_b}
-        assert configurations_1 != configurations_2
+        c1 = {c.component_id: c.configuration for c in components_a}
+        c2 = {c.component_id: c.configuration for c in components_b}
+        assert all(c1[k] is not c2[k] for k in c1.keys())
 
     def test_skills_instances_are_different(self):
         """Test that skill instances are different."""

--- a/tests/test_aea_exception_policy.py
+++ b/tests/test_aea_exception_policy.py
@@ -25,7 +25,6 @@ import pytest
 
 from aea.aea import logger
 from aea.aea_builder import AEABuilder
-from aea.configurations.base import ComponentType
 from aea.crypto.fetchai import FetchAICrypto
 from aea.exceptions import AEAException
 from aea.helpers.exception_policy import ExceptionPolicyEnum


### PR DESCRIPTION
## Proposed changes

**Merge #1277 before this PR**

Make `AEABuilder.build` reentrant, but only for components loaded from directories.

The reason is that manually added component cannot be deep-copied due to unpredictable attributes that user-define classes could have. More importantly, objects like `queue.Queue` cannot be deep-copied.

Notice also that `copy.copy` is not enough because the component objects are complex.

## Fixes

Fixes #1190 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a
