### PR TITLE
Add generic agent component registry

### DIFF
--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -31,7 +31,7 @@ import pytest
 import aea
 import aea.registries.base
 from aea.aea import AEA
-from aea.configurations.base import PublicId
+from aea.configurations.base import ComponentId, ComponentType, PublicId
 from aea.configurations.constants import DEFAULT_PROTOCOL, DEFAULT_SKILL
 from aea.contracts.base import Contract
 from aea.crypto.fetchai import FetchAICrypto
@@ -41,7 +41,7 @@ from aea.decision_maker.messages.transaction import TransactionMessage
 from aea.identity.base import Identity
 from aea.protocols.base import Protocol
 from aea.protocols.default.message import DefaultMessage
-from aea.registries.base import ContractRegistry, ProtocolRegistry
+from aea.registries.base import AgentComponentRegistry
 from aea.registries.resources import Resources
 from aea.skills.base import Skill
 
@@ -68,39 +68,43 @@ class TestContractRegistry:
             str(Path(ROOT_DIR, "packages", "fetchai", "contracts", "erc1155"))
         )
 
-        cls.registry = ContractRegistry()
-        cls.registry.register(
-            contract.configuration.public_id, cast(Contract, contract)
-        )
+        cls.registry = AgentComponentRegistry()
+        cls.registry.register(contract.component_id, cast(Contract, contract))
         cls.expected_contract_ids = {
             PublicId.from_str("fetchai/erc1155:0.3.0"),
         }
 
     def test_fetch_all(self):
         """Test that the 'fetch_all' method works as expected."""
-        contracts = self.registry.fetch_all()
+        contracts = self.registry.fetch_by_type(ComponentType.CONTRACT)
         assert all(isinstance(c, Contract) for c in contracts)
-        assert set(c.id for c in contracts) == self.expected_contract_ids
+        assert set(c.public_id for c in contracts) == self.expected_contract_ids
 
     def test_fetch(self):
         """Test that the `fetch` method works as expected."""
         contract_id = PublicId.from_str("fetchai/erc1155:0.3.0")
-        contract = self.registry.fetch(contract_id)
+        contract = self.registry.fetch(ComponentId(ComponentType.CONTRACT, contract_id))
         assert isinstance(contract, Contract)
         assert contract.id == contract_id
 
     def test_unregister(self):
         """Test that the 'unregister' method works as expected."""
         contract_id_removed = PublicId.from_str("fetchai/erc1155:0.3.0")
-        contract_removed = self.registry.fetch(contract_id_removed)
-        self.registry.unregister(contract_id_removed)
+        component_id = ComponentId(ComponentType.CONTRACT, contract_id_removed)
+        contract_removed = self.registry.fetch(component_id)
+        self.registry.unregister(contract_removed.component_id)
         expected_contract_ids = set(self.expected_contract_ids)
         expected_contract_ids.remove(contract_id_removed)
 
-        assert set(c.id for c in self.registry.fetch_all()) == expected_contract_ids
+        assert (
+            set(
+                c.public_id for c in self.registry.fetch_by_type(ComponentType.CONTRACT)
+            )
+            == expected_contract_ids
+        )
 
         # restore the contract
-        self.registry.register(contract_id_removed, contract_removed)
+        self.registry.register(component_id, contract_removed)
 
     @classmethod
     def teardown_class(cls):
@@ -129,14 +133,14 @@ class TestProtocolRegistry:
         shutil.copytree(os.path.join(CUR_PATH, "data", "dummy_aea"), cls.agent_folder)
         os.chdir(cls.agent_folder)
 
-        cls.registry = ProtocolRegistry()
+        cls.registry = AgentComponentRegistry()
 
         protocol_1 = Protocol.from_dir(Path(aea.AEA_DIR, "protocols", "default"))
         protocol_2 = Protocol.from_dir(
             Path(ROOT_DIR, "packages", "fetchai", "protocols", "fipa"),
         )
-        cls.registry.register(protocol_1.public_id, protocol_1)
-        cls.registry.register(protocol_2.public_id, protocol_2)
+        cls.registry.register(protocol_1.component_id, protocol_1)
+        cls.registry.register(protocol_2.component_id, protocol_2)
 
         cls.expected_protocol_ids = {
             DEFAULT_PROTOCOL,
@@ -145,25 +149,28 @@ class TestProtocolRegistry:
 
     def test_fetch_all(self):
         """Test that the 'fetch_all' method works as expected."""
-        protocols = self.registry.fetch_all()
+        protocols = self.registry.fetch_by_type(ComponentType.PROTOCOL)
         assert all(isinstance(p, Protocol) for p in protocols)
         assert set(p.public_id for p in protocols) == self.expected_protocol_ids
 
     def test_unregister(self):
         """Test that the 'unregister' method works as expected."""
         protocol_id_removed = DEFAULT_PROTOCOL
-        protocol_removed = self.registry.fetch(protocol_id_removed)
-        self.registry.unregister(protocol_id_removed)
+        component_id = ComponentId(ComponentType.PROTOCOL, protocol_id_removed)
+        protocol_removed = self.registry.fetch(component_id)
+        self.registry.unregister(component_id)
         expected_protocols_ids = set(self.expected_protocol_ids)
         expected_protocols_ids.remove(protocol_id_removed)
 
         assert (
-            set(p.public_id for p in self.registry.fetch_all())
+            set(
+                p.public_id for p in self.registry.fetch_by_type(ComponentType.PROTOCOL)
+            )
             == expected_protocols_ids
         )
 
         # restore the protocol
-        self.registry.register(protocol_id_removed, protocol_removed)
+        self.registry.register(component_id, protocol_removed)
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
## Proposed changes

Changes:
- add `AgentComponentRegistry`, a generic registry for `Component` objects
- remove `ProtocolRegistry` and `ContractRegistry` since they are subsumed by the `AgentComponentRegistry`

## Fixes

Preliminary work to address #1291 and #1290 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
