### PR TITLE
Make connection list of the Multiplexer modifiable also after initialization

### DIFF
--- a/aea/mail/base.py
+++ b/aea/mail/base.py
@@ -583,7 +583,6 @@ class Multiplexer:
 
     async def _connect_all(self):
         """Set all the connection up."""
-        """Set all the connection up."""
         logger.debug("Start multiplexer connections.")
         connected = []  # type: List[PublicId]
         for connection_id, connection in self._id_to_connection.items():


### PR DESCRIPTION
## Proposed changes

This PR will let the connection list in a `Multiplexer` instance to be modifiable even after the initialization of the instance.

## Fixes

Preliminary work for #1290, #1291 and #1191 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
