### PR TITLE
AEA-625 flaky tests rerun

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -171,4 +171,4 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         yml: ./codecov.yml
-        fail_ci_if_error: true
+        fail_ci_if_error: false

--- a/Pipfile
+++ b/Pipfile
@@ -50,6 +50,7 @@ requests = ">=2.22.0"
 safety = "==1.8.5"
 tox = "==3.15.1"
 vyper = "==0.1.0b12"
+pytest-rerunfailures = "==9.0"
 
 [packages]
 # we don't specify dependencies for the library here for intallation as per: https://pipenv-fork.readthedocs.io/en/latest/advanced.html#pipfile-vs-setuppy

--- a/Pipfile
+++ b/Pipfile
@@ -46,11 +46,11 @@ pytest = "==5.3.5"
 pytest-asyncio = "==0.10.0"
 pytest-cov = "==2.8.1"
 pytest-randomly = "==3.2.1"
+pytest-rerunfailures = "==9.0"
 requests = ">=2.22.0"
 safety = "==1.8.5"
 tox = "==3.15.1"
 vyper = "==0.1.0b12"
-pytest-rerunfailures = "==9.0"
 
 [packages]
 # we don't specify dependencies for the library here for intallation as per: https://pipenv-fork.readthedocs.io/en/latest/advanced.html#pipfile-vs-setuppy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,6 +139,9 @@ DUMMY_PROTOCOL_PUBLIC_ID = PublicId("dummy_author", "dummy", "0.1.0")
 DUMMY_CONNECTION_PUBLIC_ID = PublicId("dummy_author", "dummy", "0.1.0")
 DUMMY_SKILL_PUBLIC_ID = PublicId("dummy_author", "dummy", "0.1.0")
 
+MAX_FLAKY_RERUNS = 2
+
+
 contract_config_files = [
     os.path.join(
         ROOT_DIR, "aea", "contracts", "scaffold", DEFAULT_CONTRACT_CONFIG_FILE

--- a/tests/test_cli/test_run.py
+++ b/tests/test_cli/test_run.py
@@ -492,6 +492,7 @@ def test_run_ethereum_private_key_config():
         pass
 
 
+@pytest.mark.flaky(reruns=5)  # cause ledger depends on network
 def test_run_ledger_apis():
     """Test that the command 'aea run' works as expected."""
     runner = CliRunner()
@@ -586,6 +587,7 @@ def test_run_ledger_apis():
             pass
 
 
+@pytest.mark.flaky(reruns=5)  # cause ledger depends on network
 def test_run_fet_ledger_apis():
     """Test that the command 'aea run' works as expected."""
     runner = CliRunner()
@@ -676,6 +678,7 @@ def test_run_fet_ledger_apis():
             pass
 
 
+@pytest.mark.flaky(reruns=5)  # install depends on network
 def test_run_with_install_deps():
     """Test that the command 'aea run --install-deps' does not crash."""
     runner = CliRunner()
@@ -746,6 +749,7 @@ def test_run_with_install_deps():
             pass
 
 
+@pytest.mark.flaky(reruns=5)  # install depends on network
 def test_run_with_install_deps_and_requirement_file():
     """Test that the command 'aea run --install-deps' with requirement file does not crash."""
     runner = CliRunner()

--- a/tests/test_cli/test_run.py
+++ b/tests/test_cli/test_run.py
@@ -16,7 +16,6 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-
 """This test module contains the tests for the `aea run` sub-command."""
 import os
 import shutil
@@ -47,7 +46,7 @@ from aea.test_tools.click_testing import CliRunner
 
 from tests.common.pexpect_popen import PexpectWrapper
 
-from ..conftest import AUTHOR, CLI_LOG_OPTION, ROOT_DIR
+from ..conftest import AUTHOR, CLI_LOG_OPTION, MAX_FLAKY_RERUNS, ROOT_DIR
 
 
 if sys.platform.startswith("win"):
@@ -492,7 +491,7 @@ def test_run_ethereum_private_key_config():
         pass
 
 
-@pytest.mark.flaky(reruns=5)  # cause ledger depends on network
+@pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)  # cause ledger depends on network
 def test_run_ledger_apis():
     """Test that the command 'aea run' works as expected."""
     runner = CliRunner()
@@ -587,7 +586,7 @@ def test_run_ledger_apis():
             pass
 
 
-@pytest.mark.flaky(reruns=5)  # cause ledger depends on network
+@pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)  # cause ledger depends on network
 def test_run_fet_ledger_apis():
     """Test that the command 'aea run' works as expected."""
     runner = CliRunner()
@@ -678,7 +677,7 @@ def test_run_fet_ledger_apis():
             pass
 
 
-@pytest.mark.flaky(reruns=5)  # install depends on network
+@pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)  # install depends on network
 def test_run_with_install_deps():
     """Test that the command 'aea run --install-deps' does not crash."""
     runner = CliRunner()
@@ -749,7 +748,7 @@ def test_run_with_install_deps():
             pass
 
 
-@pytest.mark.flaky(reruns=5)  # install depends on network
+@pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)  # install depends on network
 def test_run_with_install_deps_and_requirement_file():
     """Test that the command 'aea run --install-deps' with requirement file does not crash."""
     runner = CliRunner()

--- a/tests/test_docs/test_agent_vs_aea/test_agent_vs_aea.py
+++ b/tests/test_docs/test_agent_vs_aea/test_agent_vs_aea.py
@@ -22,6 +22,8 @@
 import os
 from pathlib import Path
 
+import pytest
+
 from aea.test_tools.test_cases import BaseAEATestCase
 
 from .agent_code_block import run
@@ -50,6 +52,9 @@ class TestAgentVsAEA(BaseAEATestCase):
             self.code_blocks[-1] == self.python_file
         ), "Files must be exactly the same."
 
+    @pytest.mark.flaky(
+        reruns=5
+    )  # TODO: check why it raises permission error on file on windows platform!
     def test_run_agent(self):
         """Run the agent from the file."""
         run()

--- a/tests/test_docs/test_agent_vs_aea/test_agent_vs_aea.py
+++ b/tests/test_docs/test_agent_vs_aea/test_agent_vs_aea.py
@@ -16,7 +16,6 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-
 """This module contains the tests for the code-blocks in the agent-vs-aea.md file."""
 
 import os
@@ -28,7 +27,7 @@ from aea.test_tools.test_cases import BaseAEATestCase
 
 from .agent_code_block import run
 from ..helper import extract_code_blocks, extract_python_code
-from ...conftest import CUR_PATH, ROOT_DIR
+from ...conftest import CUR_PATH, MAX_FLAKY_RERUNS, ROOT_DIR
 
 MD_FILE = "docs/agent-vs-aea.md"
 PY_FILE = "test_docs/test_agent_vs_aea/agent_code_block.py"
@@ -53,7 +52,7 @@ class TestAgentVsAEA(BaseAEATestCase):
         ), "Files must be exactly the same."
 
     @pytest.mark.flaky(
-        reruns=5
+        reruns=MAX_FLAKY_RERUNS
     )  # TODO: check why it raises permission error on file on windows platform!
     def test_run_agent(self):
         """Run the agent from the file."""

--- a/tests/test_packages/test_connections/test_local/test_search_services.py
+++ b/tests/test_packages/test_connections/test_local/test_search_services.py
@@ -16,7 +16,6 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-
 """This module contains the tests for the search feature of the local OEF node."""
 import time
 
@@ -40,7 +39,7 @@ from packages.fetchai.protocols.fipa.serialization import FipaSerializer
 from packages.fetchai.protocols.oef_search.message import OefSearchMessage
 from packages.fetchai.protocols.oef_search.serialization import OefSearchSerializer
 
-from ....conftest import _make_local_connection
+from ....conftest import MAX_FLAKY_RERUNS, _make_local_connection
 
 DEFAULT_OEF = "default_oef"
 
@@ -136,7 +135,9 @@ class TestSimpleSearchResult:
         )
         cls.multiplexer.put(envelope)
 
-    @pytest.mark.flaky(reruns=5)  # TODO: check reasons!. quite unstable test
+    @pytest.mark.flaky(
+        reruns=MAX_FLAKY_RERUNS
+    )  # TODO: check reasons!. quite unstable test
     def test_not_empty_search_result(self):
         """Test that the search result contains one entry after a successful registration."""
         request_id = 1
@@ -459,7 +460,9 @@ class TestFilteredSearchResult:
         )
         cls.multiplexer1.put(envelope)
 
-    @pytest.mark.flaky(reruns=5)  # TODO: check reasons!. quite unstable test
+    @pytest.mark.flaky(
+        reruns=MAX_FLAKY_RERUNS
+    )  # TODO: check reasons!. quite unstable test
     def test_filtered_search_result(self):
         """Test that the search result contains only the entries matching the query."""
         request_id = 1

--- a/tests/test_packages/test_connections/test_local/test_search_services.py
+++ b/tests/test_packages/test_connections/test_local/test_search_services.py
@@ -136,6 +136,7 @@ class TestSimpleSearchResult:
         )
         cls.multiplexer.put(envelope)
 
+    @pytest.mark.flaky(reruns=5)  # TODO: check reasons!. quite unstable test
     def test_not_empty_search_result(self):
         """Test that the search result contains one entry after a successful registration."""
         request_id = 1
@@ -458,6 +459,7 @@ class TestFilteredSearchResult:
         )
         cls.multiplexer1.put(envelope)
 
+    @pytest.mark.flaky(reruns=5)  # TODO: check reasons!. quite unstable test
     def test_filtered_search_result(self):
         """Test that the search result contains only the entries matching the query."""
         request_id = 1

--- a/tests/test_packages/test_skills/test_erc1155.py
+++ b/tests/test_packages/test_skills/test_erc1155.py
@@ -16,21 +16,24 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-
 """This test module contains the integration test for the generic buyer and seller skills."""
 
 import pytest
 
 from aea.test_tools.test_cases import AEATestCaseMany, UseOef
 
-from ...conftest import FUNDED_ETH_PRIVATE_KEY_1, FUNDED_ETH_PRIVATE_KEY_2
+from ...conftest import (
+    FUNDED_ETH_PRIVATE_KEY_1,
+    FUNDED_ETH_PRIVATE_KEY_2,
+    MAX_FLAKY_RERUNS,
+)
 
 
 @pytest.mark.unstable
 class TestERCSkillsEthereumLedger(AEATestCaseMany, UseOef):
     """Test that erc1155 skills work."""
 
-    @pytest.mark.flaky(reruns=5)  # cause possible network issues
+    @pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)  # cause possible network issues
     def test_generic(self):
         """Run the generic skills sequence."""
         deploy_aea_name = "deploy_aea"

--- a/tests/test_packages/test_skills/test_erc1155.py
+++ b/tests/test_packages/test_skills/test_erc1155.py
@@ -30,6 +30,7 @@ from ...conftest import FUNDED_ETH_PRIVATE_KEY_1, FUNDED_ETH_PRIVATE_KEY_2
 class TestERCSkillsEthereumLedger(AEATestCaseMany, UseOef):
     """Test that erc1155 skills work."""
 
+    @pytest.mark.flaky(reruns=5)  # cause possible network issues
     def test_generic(self):
         """Run the generic skills sequence."""
         deploy_aea_name = "deploy_aea"

--- a/tests/test_packages/test_skills/test_generic.py
+++ b/tests/test_packages/test_skills/test_generic.py
@@ -16,19 +16,18 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-
 """This test module contains the integration test for the generic buyer and seller skills."""
 import pytest
 
 from aea.test_tools.test_cases import AEATestCaseMany, UseOef
 
-from ...conftest import FUNDED_FET_PRIVATE_KEY_1
+from ...conftest import FUNDED_FET_PRIVATE_KEY_1, MAX_FLAKY_RERUNS
 
 
 class TestGenericSkills(AEATestCaseMany, UseOef):
     """Test that generic skills work."""
 
-    @pytest.mark.flaky(reruns=5)  # cause possible network issues
+    @pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)  # cause possible network issues
     def test_generic(self, pytestconfig):
         """Run the generic skills sequence."""
         seller_aea_name = "my_generic_seller"
@@ -105,7 +104,7 @@ class TestGenericSkills(AEATestCaseMany, UseOef):
 class TestGenericSkillsFetchaiLedger(AEATestCaseMany, UseOef):
     """Test that generic skills work."""
 
-    @pytest.mark.flaky(reruns=5)  # cause possible network issues
+    @pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)  # cause possible network issues
     def test_generic(self, pytestconfig):
         """Run the generic skills sequence."""
         seller_aea_name = "my_generic_seller"

--- a/tests/test_packages/test_skills/test_generic.py
+++ b/tests/test_packages/test_skills/test_generic.py
@@ -18,6 +18,7 @@
 # ------------------------------------------------------------------------------
 
 """This test module contains the integration test for the generic buyer and seller skills."""
+import pytest
 
 from aea.test_tools.test_cases import AEATestCaseMany, UseOef
 
@@ -27,6 +28,7 @@ from ...conftest import FUNDED_FET_PRIVATE_KEY_1
 class TestGenericSkills(AEATestCaseMany, UseOef):
     """Test that generic skills work."""
 
+    @pytest.mark.flaky(reruns=5)  # cause possible network issues
     def test_generic(self, pytestconfig):
         """Run the generic skills sequence."""
         seller_aea_name = "my_generic_seller"
@@ -103,6 +105,7 @@ class TestGenericSkills(AEATestCaseMany, UseOef):
 class TestGenericSkillsFetchaiLedger(AEATestCaseMany, UseOef):
     """Test that generic skills work."""
 
+    @pytest.mark.flaky(reruns=5)  # cause possible network issues
     def test_generic(self, pytestconfig):
         """Run the generic skills sequence."""
         seller_aea_name = "my_generic_seller"

--- a/tests/test_packages/test_skills/test_tac.py
+++ b/tests/test_packages/test_skills/test_tac.py
@@ -16,7 +16,6 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-
 """This test module contains the integration test for the tac skills."""
 
 import datetime
@@ -25,13 +24,13 @@ import pytest
 
 from aea.test_tools.test_cases import AEATestCaseMany, UseOef
 
-from ...conftest import FUNDED_ETH_PRIVATE_KEY_1
+from ...conftest import FUNDED_ETH_PRIVATE_KEY_1, MAX_FLAKY_RERUNS
 
 
 class TestTacSkills(AEATestCaseMany, UseOef):
     """Test that tac skills work."""
 
-    @pytest.mark.flaky(reruns=5)  # cause possible network issues
+    @pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)  # cause possible network issues
     def test_tac(self):
         """Run the tac skills sequence."""
         tac_aea_one = "tac_participant_one"
@@ -150,7 +149,7 @@ class TestTacSkills(AEATestCaseMany, UseOef):
 class TestTacSkillsContract(AEATestCaseMany, UseOef):
     """Test that tac skills work."""
 
-    @pytest.mark.flaky(reruns=5)  # cause possible network issues
+    @pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)  # cause possible network issues
     def test_tac(self):
         """Run the tac skills sequence."""
         tac_aea_one = "tac_participant_one"

--- a/tests/test_packages/test_skills/test_tac.py
+++ b/tests/test_packages/test_skills/test_tac.py
@@ -31,6 +31,7 @@ from ...conftest import FUNDED_ETH_PRIVATE_KEY_1
 class TestTacSkills(AEATestCaseMany, UseOef):
     """Test that tac skills work."""
 
+    @pytest.mark.flaky(reruns=5)  # cause possible network issues
     def test_tac(self):
         """Run the tac skills sequence."""
         tac_aea_one = "tac_participant_one"
@@ -149,6 +150,7 @@ class TestTacSkills(AEATestCaseMany, UseOef):
 class TestTacSkillsContract(AEATestCaseMany, UseOef):
     """Test that tac skills work."""
 
+    @pytest.mark.flaky(reruns=5)  # cause possible network issues
     def test_tac(self):
         """Run the tac skills sequence."""
         tac_aea_one = "tac_participant_one"

--- a/tests/test_packages/test_skills/test_thermometer.py
+++ b/tests/test_packages/test_skills/test_thermometer.py
@@ -18,6 +18,7 @@
 # ------------------------------------------------------------------------------
 
 """This test module contains the integration test for the thermometer skills."""
+import pytest
 
 from aea.test_tools.test_cases import AEATestCaseMany, UseOef
 
@@ -27,6 +28,7 @@ from ...conftest import FUNDED_FET_PRIVATE_KEY_1
 class TestThermometerSkill(AEATestCaseMany, UseOef):
     """Test that thermometer skills work."""
 
+    @pytest.mark.flaky(reruns=5)  # cause possible network issues
     def test_thermometer(self):
         """Run the thermometer skills sequence."""
 
@@ -108,6 +110,7 @@ class TestThermometerSkill(AEATestCaseMany, UseOef):
 class TestThermometerSkillFetchaiLedger(AEATestCaseMany, UseOef):
     """Test that thermometer skills work."""
 
+    @pytest.mark.flaky(reruns=5)  # cause possible network issues
     def test_thermometer(self):
         """Run the thermometer skills sequence."""
 

--- a/tests/test_packages/test_skills/test_thermometer.py
+++ b/tests/test_packages/test_skills/test_thermometer.py
@@ -16,19 +16,18 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-
 """This test module contains the integration test for the thermometer skills."""
 import pytest
 
 from aea.test_tools.test_cases import AEATestCaseMany, UseOef
 
-from ...conftest import FUNDED_FET_PRIVATE_KEY_1
+from ...conftest import FUNDED_FET_PRIVATE_KEY_1, MAX_FLAKY_RERUNS
 
 
 class TestThermometerSkill(AEATestCaseMany, UseOef):
     """Test that thermometer skills work."""
 
-    @pytest.mark.flaky(reruns=5)  # cause possible network issues
+    @pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)  # cause possible network issues
     def test_thermometer(self):
         """Run the thermometer skills sequence."""
 
@@ -110,7 +109,7 @@ class TestThermometerSkill(AEATestCaseMany, UseOef):
 class TestThermometerSkillFetchaiLedger(AEATestCaseMany, UseOef):
     """Test that thermometer skills work."""
 
-    @pytest.mark.flaky(reruns=5)  # cause possible network issues
+    @pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)  # cause possible network issues
     def test_thermometer(self):
         """Run the thermometer skills sequence."""
 

--- a/tests/test_packages/test_skills/test_weather.py
+++ b/tests/test_packages/test_skills/test_weather.py
@@ -16,20 +16,19 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-
 """This test module contains the integration test for the weather skills."""
 import pytest
 
 
 from aea.test_tools.test_cases import AEATestCaseMany, UseOef
 
-from ...conftest import FUNDED_FET_PRIVATE_KEY_1
+from ...conftest import FUNDED_FET_PRIVATE_KEY_1, MAX_FLAKY_RERUNS
 
 
 class TestWeatherSkills(AEATestCaseMany, UseOef):
     """Test that weather skills work."""
 
-    @pytest.mark.flaky(reruns=5)  # cause possible network issues
+    @pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)  # cause possible network issues
     def test_weather(self):
         """Run the weather skills sequence."""
         weather_station_aea_name = "my_weather_station"
@@ -106,7 +105,7 @@ class TestWeatherSkills(AEATestCaseMany, UseOef):
 class TestWeatherSkillsFetchaiLedger(AEATestCaseMany, UseOef):
     """Test that weather skills work."""
 
-    @pytest.mark.flaky(reruns=5)  # cause possible network issues
+    @pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)  # cause possible network issues
     def test_weather(self):
         """Run the weather skills sequence."""
         weather_station_aea_name = "my_weather_station"

--- a/tests/test_packages/test_skills/test_weather.py
+++ b/tests/test_packages/test_skills/test_weather.py
@@ -18,6 +18,8 @@
 # ------------------------------------------------------------------------------
 
 """This test module contains the integration test for the weather skills."""
+import pytest
+
 
 from aea.test_tools.test_cases import AEATestCaseMany, UseOef
 
@@ -27,6 +29,7 @@ from ...conftest import FUNDED_FET_PRIVATE_KEY_1
 class TestWeatherSkills(AEATestCaseMany, UseOef):
     """Test that weather skills work."""
 
+    @pytest.mark.flaky(reruns=5)  # cause possible network issues
     def test_weather(self):
         """Run the weather skills sequence."""
         weather_station_aea_name = "my_weather_station"
@@ -103,6 +106,7 @@ class TestWeatherSkills(AEATestCaseMany, UseOef):
 class TestWeatherSkillsFetchaiLedger(AEATestCaseMany, UseOef):
     """Test that weather skills work."""
 
+    @pytest.mark.flaky(reruns=5)  # cause possible network issues
     def test_weather(self):
         """Run the weather skills sequence."""
         weather_station_aea_name = "my_weather_station"

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ deps =
     SQLAlchemy==1.3.16
     pynacl==1.3.0
     pexpect==4.8.0
+    pytest-rerunfailures==9.0
 
 commands =
     pip install git+https://github.com/pytoolz/cytoolz.git#egg=cytoolz==0.10.1.dev0
@@ -58,6 +59,7 @@ deps =
     SQLAlchemy==1.3.16
     pynacl==1.3.0
     pexpect==4.8.0
+    pytest-rerunfailures==9.0
 
 commands =
     pip install -e .[all]
@@ -88,6 +90,7 @@ deps =
     SQLAlchemy==1.3.16
     pynacl==1.3.0
     pexpect==4.8.0
+    pytest-rerunfailures==9.0
 
 
 commands =


### PR DESCRIPTION
## Proposed changes
pytest rerun decorator applied to some flaky tests

## Fixes

help to pass CI tests 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist



- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
adds new development/ci dependency:  https://github.com/pytest-dev/pytest-rerunfailures