### PR TITLE
libp2p tests print node log after timeout

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -793,6 +793,25 @@ def _make_libp2p_client_connection(
     return P2PLibp2pClientConnection(configuration=configuration, identity=identity)
 
 
+def libp2p_log_on_failure(fn: Callable) -> Callable:
+    """
+    Decorate a pytest method running a libp2p node to print its logs in case test fails.
+
+    :return: decorated method.
+    """
+    @wraps(fn)
+    def wrapper(self, *args, **kwargs):
+        try:
+            fn(self, *args, **kwargs)
+        except Exception as e:
+            for log_file in self.log_files:
+                print("libp2p log file ======================= {}".format(log_file))
+                with open(log_file, "r") as f:
+                    print(f.read())
+                print("=======================================") 
+            raise e
+    return wrapper
+
 class CwdException(Exception):
     """Exception to raise if cwd was not restored by test."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -799,6 +799,7 @@ def libp2p_log_on_failure(fn: Callable) -> Callable:
 
     :return: decorated method.
     """
+
     @wraps(fn)
     def wrapper(self, *args, **kwargs):
         try:
@@ -808,9 +809,11 @@ def libp2p_log_on_failure(fn: Callable) -> Callable:
                 print("libp2p log file ======================= {}".format(log_file))
                 with open(log_file, "r") as f:
                     print(f.read())
-                print("=======================================") 
+                print("=======================================")
             raise e
+
     return wrapper
+
 
 class CwdException(Exception):
     """Exception to raise if cwd was not restored by test."""

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_communication.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_communication.py
@@ -30,7 +30,7 @@ from aea.mail.base import Envelope
 from aea.multiplexer import Multiplexer
 from aea.protocols.default.message import DefaultMessage
 
-from ....conftest import _make_libp2p_connection, skip_test_windows
+from ....conftest import _make_libp2p_connection, skip_test_windows, libp2p_log_on_failure
 
 DEFAULT_PORT = 10234
 DEFAULT_NET_SIZE = 4
@@ -94,11 +94,15 @@ class TestP2PLibp2pConnectionEchoEnvelope:
         )
         cls.multiplexer2 = Multiplexer([cls.connection2])
         cls.multiplexer2.connect()
+        
+        cls.log_files = [cls.connection1.node.log_file, cls.connection2.node.log_file]
 
+    @libp2p_log_on_failure
     def test_connection_is_established(self):
         assert self.connection1.connection_status.is_connected is True
         assert self.connection2.connection_status.is_connected is True
 
+    @libp2p_log_on_failure
     def test_envelope_routed(self):
         addr_1 = self.connection1.node.address
         addr_2 = self.connection2.node.address
@@ -128,6 +132,7 @@ class TestP2PLibp2pConnectionEchoEnvelope:
         msg = DefaultMessage.serializer.decode(delivered_envelope.message)
         assert envelope.message == msg
 
+    @libp2p_log_on_failure
     def test_envelope_echoed_back(self):
         addr_1 = self.connection1.node.address
         addr_2 = self.connection2.node.address
@@ -207,12 +212,17 @@ class TestP2PLibp2pConnectionRouting:
             cls.multiplexers.append(muxer)
 
             muxer.connect()
+        
+        cls.log_files = [conn.node.log_file for conn in cls.connections]
+        cls.log_files.append(cls.connection_genesis.node.log_file)
 
+    @libp2p_log_on_failure
     def test_connection_is_established(self):
         assert self.connection_genesis.connection_status.is_connected is True
         for conn in self.connections:
             assert conn.connection_status.is_connected is True
 
+    @libp2p_log_on_failure
     def test_star_routing_connectivity(self):
         addrs = [conn.node.address for conn in self.connections]
 
@@ -289,12 +299,16 @@ class TestP2PLibp2pConnectionEchoEnvelopeRelayOneDHTNode:
         )
         cls.multiplexer2 = Multiplexer([cls.connection2])
         cls.multiplexer2.connect()
+        
+        cls.log_files = [cls.relay.node.log_file]
 
+    @libp2p_log_on_failure
     def test_connection_is_established(self):
         assert self.relay.connection_status.is_connected is True
         assert self.connection1.connection_status.is_connected is True
         assert self.connection2.connection_status.is_connected is True
 
+    @libp2p_log_on_failure
     def test_envelope_routed(self):
         addr_1 = self.connection1.node.address
         addr_2 = self.connection2.node.address
@@ -324,6 +338,7 @@ class TestP2PLibp2pConnectionEchoEnvelopeRelayOneDHTNode:
         msg = DefaultMessage.serializer.decode(delivered_envelope.message)
         assert envelope.message == msg
 
+    @libp2p_log_on_failure
     def test_envelope_echoed_back(self):
         addr_1 = self.connection1.node.address
         addr_2 = self.connection2.node.address
@@ -425,14 +440,17 @@ class TestP2PLibp2pConnectionRoutingRelayTwoDHTNodes:
             cls.multiplexers.append(muxer)
             muxer.connect()
 
+        cls.log_files = [cls.connection_relay_1.node.log_file, cls.connection_relay_2.node.log_file]
         time.sleep(2)
 
+    @libp2p_log_on_failure
     def test_connection_is_established(self):
         assert self.connection_relay_1.connection_status.is_connected is True
         assert self.connection_relay_2.connection_status.is_connected is True
         for conn in self.connections:
             assert conn.connection_status.is_connected is True
 
+    @libp2p_log_on_failure
     def test_star_routing_connectivity(self):
         addrs = [conn.node.address for conn in self.connections]
 

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_communication.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_communication.py
@@ -304,7 +304,11 @@ class TestP2PLibp2pConnectionEchoEnvelopeRelayOneDHTNode:
         cls.multiplexer2 = Multiplexer([cls.connection2])
         cls.multiplexer2.connect()
 
-        cls.log_files = [cls.relay.node.log_file]
+        cls.log_files = [
+            cls.relay.node.log_file,
+            cls.connection1.node.log_file,
+            cls.connection2.node.log_file,
+        ]
 
     @libp2p_log_on_failure
     def test_connection_is_established(self):
@@ -448,6 +452,7 @@ class TestP2PLibp2pConnectionRoutingRelayTwoDHTNodes:
             cls.connection_relay_1.node.log_file,
             cls.connection_relay_2.node.log_file,
         ]
+        cls.log_files.extend([conn.node.log_file for conn in cls.connections])
         time.sleep(2)
 
     @libp2p_log_on_failure

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_communication.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_communication.py
@@ -30,7 +30,11 @@ from aea.mail.base import Envelope
 from aea.multiplexer import Multiplexer
 from aea.protocols.default.message import DefaultMessage
 
-from ....conftest import _make_libp2p_connection, skip_test_windows, libp2p_log_on_failure
+from ....conftest import (
+    _make_libp2p_connection,
+    libp2p_log_on_failure,
+    skip_test_windows,
+)
 
 DEFAULT_PORT = 10234
 DEFAULT_NET_SIZE = 4
@@ -94,7 +98,7 @@ class TestP2PLibp2pConnectionEchoEnvelope:
         )
         cls.multiplexer2 = Multiplexer([cls.connection2])
         cls.multiplexer2.connect()
-        
+
         cls.log_files = [cls.connection1.node.log_file, cls.connection2.node.log_file]
 
     @libp2p_log_on_failure
@@ -212,7 +216,7 @@ class TestP2PLibp2pConnectionRouting:
             cls.multiplexers.append(muxer)
 
             muxer.connect()
-        
+
         cls.log_files = [conn.node.log_file for conn in cls.connections]
         cls.log_files.append(cls.connection_genesis.node.log_file)
 
@@ -299,7 +303,7 @@ class TestP2PLibp2pConnectionEchoEnvelopeRelayOneDHTNode:
         )
         cls.multiplexer2 = Multiplexer([cls.connection2])
         cls.multiplexer2.connect()
-        
+
         cls.log_files = [cls.relay.node.log_file]
 
     @libp2p_log_on_failure
@@ -440,7 +444,10 @@ class TestP2PLibp2pConnectionRoutingRelayTwoDHTNodes:
             cls.multiplexers.append(muxer)
             muxer.connect()
 
-        cls.log_files = [cls.connection_relay_1.node.log_file, cls.connection_relay_2.node.log_file]
+        cls.log_files = [
+            cls.connection_relay_1.node.log_file,
+            cls.connection_relay_2.node.log_file,
+        ]
         time.sleep(2)
 
     @libp2p_log_on_failure

--- a/tests/test_packages/test_connections/test_p2p_libp2p_client/test_communication.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p_client/test_communication.py
@@ -33,8 +33,8 @@ from aea.protocols.default.serialization import DefaultSerializer
 from ....conftest import (
     _make_libp2p_client_connection,
     _make_libp2p_connection,
-    skip_test_windows,
     libp2p_log_on_failure,
+    skip_test_windows,
 )
 
 DEFAULT_PORT = 10234
@@ -267,8 +267,11 @@ class TestLibp2pClientConnectionEchoEnvelopeTwoDHTNode:
         )
         cls.multiplexer_client_2 = Multiplexer([cls.connection_client_2])
         cls.multiplexer_client_2.connect()
-        
-        cls.log_files = [cls.connection_node_1.node.log_file, cls.connection_node_2.node.log_file]
+
+        cls.log_files = [
+            cls.connection_node_1.node.log_file,
+            cls.connection_node_2.node.log_file,
+        ]
 
     @libp2p_log_on_failure
     def test_connection_is_established(self):
@@ -438,7 +441,10 @@ class TestLibp2pClientConnectionRouting:
 
                 muxer.connect()
 
-        cls.log_files = [cls.connection_node_1.node.log_file, cls.connection_node_2.node.log_file]
+        cls.log_files = [
+            cls.connection_node_1.node.log_file,
+            cls.connection_node_2.node.log_file,
+        ]
 
     @libp2p_log_on_failure
     def test_connection_is_established(self):

--- a/tests/test_packages/test_connections/test_p2p_libp2p_client/test_communication.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p_client/test_communication.py
@@ -34,6 +34,7 @@ from ....conftest import (
     _make_libp2p_client_connection,
     _make_libp2p_connection,
     skip_test_windows,
+    libp2p_log_on_failure,
 )
 
 DEFAULT_PORT = 10234
@@ -105,10 +106,14 @@ class TestLibp2pClientConnectionEchoEnvelope:
         cls.multiplexer_client_2 = Multiplexer([cls.connection_client_2])
         cls.multiplexer_client_2.connect()
 
+        cls.log_files = [cls.connection_node.node.log_file]
+
+    @libp2p_log_on_failure
     def test_connection_is_established(self):
         assert self.connection_client_1.connection_status.is_connected is True
         assert self.connection_client_2.connection_status.is_connected is True
 
+    @libp2p_log_on_failure
     def test_envelope_routed(self):
         addr_1 = self.connection_client_1.address
         addr_2 = self.connection_client_2.address
@@ -136,6 +141,7 @@ class TestLibp2pClientConnectionEchoEnvelope:
         assert delivered_envelope.protocol_id == envelope.protocol_id
         assert delivered_envelope.message == envelope.message
 
+    @libp2p_log_on_failure
     def test_envelope_echoed_back(self):
         addr_1 = self.connection_client_1.address
         addr_2 = self.connection_client_2.address
@@ -170,6 +176,7 @@ class TestLibp2pClientConnectionEchoEnvelope:
         assert delivered_envelope.protocol_id == original_envelope.protocol_id
         assert delivered_envelope.message == original_envelope.message
 
+    @libp2p_log_on_failure
     def test_envelope_echoed_back_node_agent(self):
         addr_1 = self.connection_client_1.address
         addr_n = self.connection_node.address
@@ -260,13 +267,17 @@ class TestLibp2pClientConnectionEchoEnvelopeTwoDHTNode:
         )
         cls.multiplexer_client_2 = Multiplexer([cls.connection_client_2])
         cls.multiplexer_client_2.connect()
+        
+        cls.log_files = [cls.connection_node_1.node.log_file, cls.connection_node_2.node.log_file]
 
+    @libp2p_log_on_failure
     def test_connection_is_established(self):
         assert self.connection_node_1.connection_status.is_connected is True
         assert self.connection_node_2.connection_status.is_connected is True
         assert self.connection_client_1.connection_status.is_connected is True
         assert self.connection_client_2.connection_status.is_connected is True
 
+    @libp2p_log_on_failure
     def test_envelope_routed(self):
         addr_1 = self.connection_client_1.address
         addr_2 = self.connection_client_2.address
@@ -294,6 +305,7 @@ class TestLibp2pClientConnectionEchoEnvelopeTwoDHTNode:
         assert delivered_envelope.protocol_id == envelope.protocol_id
         assert delivered_envelope.message == envelope.message
 
+    @libp2p_log_on_failure
     def test_envelope_echoed_back(self):
         addr_1 = self.connection_client_1.address
         addr_2 = self.connection_client_2.address
@@ -328,6 +340,7 @@ class TestLibp2pClientConnectionEchoEnvelopeTwoDHTNode:
         assert delivered_envelope.protocol_id == original_envelope.protocol_id
         assert delivered_envelope.message == original_envelope.message
 
+    @libp2p_log_on_failure
     def test_envelope_echoed_back_node_agent(self):
         addr_1 = self.connection_client_1.address
         addr_n = self.connection_node_2.address
@@ -425,10 +438,14 @@ class TestLibp2pClientConnectionRouting:
 
                 muxer.connect()
 
+        cls.log_files = [cls.connection_node_1.node.log_file, cls.connection_node_2.node.log_file]
+
+    @libp2p_log_on_failure
     def test_connection_is_established(self):
         for conn in self.connections:
             assert conn.connection_status.is_connected is True
 
+    @libp2p_log_on_failure
     def test_star_routing_connectivity(self):
         msg = DefaultMessage(
             dialogue_reference=("", ""),


### PR DESCRIPTION
## Proposed changes

Add a decorator to libp2p-related tests that prints libp2p nodes logs to standard output in case of test failure. Practical for debugging ci test failures.

