### PR TITLE
Add method refactored: passing ctx instead of click_context.

### DIFF
--- a/aea/cli/add.py
+++ b/aea/cli/add.py
@@ -132,10 +132,10 @@ def add_item(ctx: Context, item_type: str, item_public_id: PublicId) -> None:
         raise click.ClickException("Failed to add an item with incorrect fingerprint.")
 
     register_item(ctx, item_type, item_public_id)
-    add_item_deps(ctx, item_type, item_config)
+    _add_item_deps(ctx, item_type, item_config)
 
 
-def add_item_deps(ctx: Context, item_type: str, item_config) -> None:
+def _add_item_deps(ctx: Context, item_type: str, item_config) -> None:
     """
     Add item dependencies. Calls add_item recursively.
 

--- a/aea/cli/create.py
+++ b/aea/cli/create.py
@@ -26,7 +26,7 @@ from typing import cast
 import click
 
 import aea
-from aea.cli.add import _add_item
+from aea.cli.add import add_item
 from aea.cli.init import do_init
 from aea.cli.utils.config import get_or_create_cli_config
 from aea.cli.utils.constants import AUTHOR_KEY
@@ -125,8 +125,8 @@ def _create_aea(
             click.echo("Adding default packages ...")
             if local:
                 ctx.set_config("is_local", True)
-            _add_item(click_context, "connection", DEFAULT_CONNECTION)
-            _add_item(click_context, "skill", DEFAULT_SKILL)
+            add_item(ctx, "connection", DEFAULT_CONNECTION)
+            add_item(ctx, "skill", DEFAULT_SKILL)
 
     except Exception as e:
         raise click.ClickException(str(e))

--- a/aea/cli/fetch.py
+++ b/aea/cli/fetch.py
@@ -25,7 +25,7 @@ from typing import Optional, cast
 
 import click
 
-from aea.cli.add import _add_item
+from aea.cli.add import add_item
 from aea.cli.registry.fetch import fetch_agent
 from aea.cli.utils.click_utils import PublicIdParameter
 from aea.cli.utils.config import try_to_load_agent_config
@@ -121,7 +121,7 @@ def _fetch_agent_deps(click_context: click.core.Context) -> None:
     :param ctx: context object.
 
     :return: None
-    :raises: ClickException re-raises if occures in _add_item call.
+    :raises: ClickException re-raises if occures in add_item call.
     """
     ctx = cast(Context, click_context.obj)
     ctx.set_config("is_local", True)
@@ -131,7 +131,7 @@ def _fetch_agent_deps(click_context: click.core.Context) -> None:
         required_items = getattr(ctx.agent_config, item_type_plural)
         for item_id in required_items:
             try:
-                _add_item(click_context, item_type, item_id)
+                add_item(ctx, item_type, item_id)
             except click.ClickException as e:
                 raise click.ClickException(
                     "Failed to add {} dependency {}: {}".format(

--- a/aea/cli/registry/fetch.py
+++ b/aea/cli/registry/fetch.py
@@ -23,7 +23,7 @@ from typing import Optional, cast
 
 import click
 
-from aea.cli.add import _add_item
+from aea.cli.add import add_item
 from aea.cli.registry.utils import download_file, extract, request_api
 from aea.cli.utils.config import try_to_load_agent_config
 from aea.cli.utils.context import Context
@@ -81,7 +81,7 @@ def fetch_agent(
         config = getattr(ctx.agent_config, item_type_plural)
         for item_public_id in config:
             try:
-                _add_item(click_context, item_type, item_public_id)
+                add_item(ctx, item_type, item_public_id)
             except Exception as e:
                 raise click.ClickException(
                     'Unable to fetch dependency for agent "{}", aborting. {}'.format(

--- a/tests/test_cli/test_add/test_contract.py
+++ b/tests/test_cli/test_add/test_contract.py
@@ -35,7 +35,7 @@ class AddContractCommandTestCase(TestCase):
         """Set the test up."""
         self.runner = CliRunner()
 
-    @mock.patch("aea.cli.add._add_item")
+    @mock.patch("aea.cli.add.add_item")
     def test_add_contract_positive(self, *mocks):
         """Test add contract command positive result."""
         result = self.runner.invoke(

--- a/tests/test_cli/test_fetch.py
+++ b/tests/test_cli/test_fetch.py
@@ -67,7 +67,7 @@ class FetchAgentLocallyTestCase(TestCase):
             _fetch_agent_locally(ContextMock(), PublicIdMock())
 
     @mock.patch("aea.cli.fetch._is_version_correct", return_value=True)
-    @mock.patch("aea.cli.fetch._add_item")
+    @mock.patch("aea.cli.fetch.add_item")
     @mock.patch("aea.cli.fetch.os.path.exists", return_value=False)
     @mock.patch("aea.cli.fetch.copy_tree")
     def test__fetch_agent_locally_with_deps_positive(self, *mocks):
@@ -84,7 +84,7 @@ class FetchAgentLocallyTestCase(TestCase):
     @mock.patch("aea.cli.fetch._is_version_correct", return_value=True)
     @mock.patch("aea.cli.fetch.os.path.exists", return_value=False)
     @mock.patch("aea.cli.fetch.copy_tree")
-    @mock.patch("aea.cli.fetch._add_item", _raise_click_exception)
+    @mock.patch("aea.cli.fetch.add_item", _raise_click_exception)
     def test__fetch_agent_locally_with_deps_fail(self, *mocks):
         """Test for fetch_agent_locally method with deps ClickException catch."""
         public_id = PublicIdMock.from_str("author/name:0.1.0")

--- a/tests/test_cli/test_registry/test_fetch.py
+++ b/tests/test_cli/test_registry/test_fetch.py
@@ -77,7 +77,7 @@ class TestFetchAgent(TestCase):
         download_file_mock.assert_called_once_with("url", "cwd")
         extract_mock.assert_called_once_with("filepath", "cwd")
 
-    @mock.patch("aea.cli.registry.fetch._add_item")
+    @mock.patch("aea.cli.registry.fetch.add_item")
     @mock.patch(
         "aea.cli.registry.fetch.request_api",
         return_value={
@@ -107,7 +107,7 @@ class TestFetchAgent(TestCase):
         extract_mock.assert_called_once_with("filepath", "cwd")
         add_item_mock.assert_called()
 
-    @mock.patch("aea.cli.registry.fetch._add_item", _raise_exception)
+    @mock.patch("aea.cli.registry.fetch.add_item", _raise_exception)
     @mock.patch(
         "aea.cli.registry.fetch.request_api",
         return_value={


### PR DESCRIPTION
## Proposed changes

Add method refactored: passing ctx instead of click_context.
That makes `add_item` programmatically callable without `click_context` object that is CLI command specific. Also it wasn't really needed as we operate our custom `ctx: aea.ci.utils.context.Context` object together with `@pass_ctx` decorator in CLI commands.
Also public method `add_item` name fixed.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
