### PR TITLE
AEA-637 Feature/partial reset

### DIFF
--- a/aea/agent.py
+++ b/aea/agent.py
@@ -233,10 +233,6 @@ class Agent(ABC):
         """Get the agent loop mode."""
         return self._loop_mode
 
-    def setup_multiplexer(self) -> None:
-        """Set up the multiplexer"""
-        # implemented in AEA class
-
     @property
     def main_loop(self) -> BaseAgentLoop:
         """Get the main agent loop."""
@@ -246,6 +242,10 @@ class Agent(ABC):
     def runtime(self) -> BaseRuntime:
         """Get the runtime."""
         return self._runtime
+
+    def setup_multiplexer(self) -> None:
+        """Set up the multiplexer"""
+        pass
 
     def start(self) -> None:
         """

--- a/tests/test_aea_builder.py
+++ b/tests/test_aea_builder.py
@@ -211,7 +211,8 @@ def test_multiple_builds_with_private_keys():
     builder.reset()
     builder.set_name("aea_1")
     builder.add_private_key("fetchai", FETCHAI_PRIVATE_KEY_PATH)
-    builder.build()
+    aea_2 = builder.build()
+    assert isinstance(aea_2, AEA)
 
 
 def test_multiple_builds_with_component_instance():
@@ -227,6 +228,7 @@ def test_multiple_builds_with_component_instance():
 
     # the first call works
     aea_1 = builder.build()
+    assert isinstance(aea_1, AEA)
 
     # the second call fails
     with pytest.raises(ValueError, match="Cannot build.*"):
@@ -237,5 +239,5 @@ def test_multiple_builds_with_component_instance():
     builder.set_name("aea_1")
     builder.add_private_key("fetchai")
     builder.add_component_instance(a_protocol)
-    aea_1 = builder.build()
-    isinstance(aea_1, AEA)
+    aea_2 = builder.build()
+    assert isinstance(aea_2, AEA)


### PR DESCRIPTION
## Proposed changes

This PR updates docstrings in the builder and adds the partial reset by default.

Partial reset only resets the private keys and components added as instances.

## Fixes

-

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

-