### PR TITLE
fix set up of identity object in case one address is provided

### DIFF
--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -786,7 +786,9 @@ class AEABuilder:
             )
         else:  # pragma: no cover
             identity = Identity(
-                self._name, address=wallet.addresses[self._default_ledger],
+                self._name,
+                address=wallet.addresses[self._default_ledger],
+                default_address_key=self._default_ledger,
             )
         return identity
 


### PR DESCRIPTION
## Proposed changes

Fix a bug in the case when only one address is provided to the AEA builder, and the default is not `fetchai`.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
