### PR TITLE
AEA-516 Move functionalities from cli generate to generator

### DIFF
--- a/aea/cli/generate.py
+++ b/aea/cli/generate.py
@@ -129,7 +129,7 @@ def _generate_item(click_context, item_type, specification_path):
         )
     except Exception as e:
         raise click.ClickException(
-            "There was an error while generating the protocol. The protocol is NOT generated. Exception:\n"
+            "Protocol is NOT generated. The following error happened while generating the protocol:\n"
             + str(e)
         )
 

--- a/aea/protocols/generator/common.py
+++ b/aea/protocols/generator/common.py
@@ -16,8 +16,16 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-"""This module contains code common for multiple modules in the generator package."""
-# pylint: skip-file
+"""This module contains utility code for generator modules."""
+
+import os
+import re
+import subprocess  # nosec
+import sys
+from typing import Tuple
+
+from aea.configurations.base import ProtocolSpecification
+from aea.configurations.loader import ConfigLoader
 
 SPECIFICATION_PRIMITIVE_TYPES = ["pt:bytes", "pt:int", "pt:float", "pt:bool", "pt:str"]
 
@@ -108,3 +116,90 @@ def _get_sub_types_of_compositional_types(compositional_type: str) -> tuple:
                     inside_union = inside_union[inside_union.index(",") + 1 :].strip()
             sub_types_list.append(sub_type)
     return tuple(sub_types_list)
+
+
+def load_protocol_specification(specification_path: str) -> ProtocolSpecification:
+    """
+    Load a protocol specification.
+
+    :param specification_path: path to the protocol specification yaml file.
+    :return: A ProtocolSpecification object
+    """
+    config_loader = ConfigLoader(
+        "protocol-specification_schema.json", ProtocolSpecification
+    )
+    protocol_spec = config_loader.load_protocol_specification(open(specification_path))
+    return protocol_spec
+
+
+def run_black_formatting(path_to_protocol_package: str) -> None:
+    """
+    Run Black code formatting via subprocess.
+
+    :param path_to_protocol_package: a path where formatting should be applied.
+    :return: None
+    """
+    try:
+        subp = subprocess.Popen(  # nosec
+            [sys.executable, "-m", "black", path_to_protocol_package, "--quiet"]
+        )
+        subp.wait(10.0)
+    finally:
+        poll = subp.poll()
+        if poll is None:  # pragma: no cover
+            subp.terminate()
+            subp.wait(5)
+
+
+def check_protobuf_using_protoc(
+    path_to_generated_protocol_package, name
+) -> Tuple[bool, str]:
+    """
+    Check whether a protocol buffer schema file is valid.
+
+    Validation is via trying to compile the schema file. If successfully compiled it is valid, otherwise invalid.
+    If valid, return True and a 'protobuf file is valid' message, otherwise return False and the error thrown by the compiler.
+
+    :param path_to_generated_protocol_package: path to the protocol buffer schema file.
+    :param name: name of the protocol buffer schema file.
+
+    :return: Boolean result and an accompanying message
+    """
+    try:
+        run_protoc(path_to_generated_protocol_package, name)
+        os.remove(os.path.join(path_to_generated_protocol_package, name + "_pb2.py"))
+        return True, "protobuf file is valid"
+    except subprocess.CalledProcessError as e:
+        pattern = name + ".proto:[0-9]+:[0-9]+: "
+        error_message = re.sub(pattern, "", e.stderr[:-1])
+        return False, error_message
+    except Exception:
+        raise
+
+
+def run_protoc(path_to_generated_protocol_package, name) -> subprocess.CompletedProcess:
+    """
+    Run 'protoc' protocol buffer compiler via subprocess.
+
+    :param path_to_generated_protocol_package: path to the protocol buffer schema file.
+    :param name: name of the protocol buffer schema file.
+
+    :return: A completed process object.
+    """
+    try:
+        # command: "protoc -I={} --python_out={} {}/{}.proto"
+        protoc_process = subprocess.run(  # nosec
+            [
+                "protoc",
+                "-I={}".format(path_to_generated_protocol_package),
+                "--python_out={}".format(path_to_generated_protocol_package),
+                "{}/{}.proto".format(path_to_generated_protocol_package, name),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=os.environ.copy(),
+        )
+    except Exception:
+        raise
+    return protoc_process

--- a/aea/protocols/generator/extract_specification.py
+++ b/aea/protocols/generator/extract_specification.py
@@ -17,7 +17,6 @@
 #
 # ------------------------------------------------------------------------------
 """This module extracts a valid protocol specification into pythonic objects."""
-# pylint: skip-file
 
 import re
 from typing import Dict, List, cast

--- a/aea/protocols/generator/validate.py
+++ b/aea/protocols/generator/validate.py
@@ -18,8 +18,6 @@
 # ------------------------------------------------------------------------------
 """This module validates a protocol specification."""
 
-# pylint: skip-file
-
 from typing import Tuple
 
 from aea.configurations.base import ProtocolSpecification

--- a/tests/test_cli/test_generate/test_generate.py
+++ b/tests/test_cli/test_generate/test_generate.py
@@ -45,7 +45,7 @@ def _raise_psperror(*args, **kwargs):
 
 
 @mock.patch("builtins.open", mock.mock_open())
-@mock.patch("aea.cli.generate.ConfigLoader")
+@mock.patch("aea.protocols.generator.common.ConfigLoader")
 @mock.patch("aea.cli.generate.os.path.join", return_value="joined-path")
 @mock.patch("aea.cli.utils.decorators._cast_ctx")
 class GenerateItemTestCase(TestCase):
@@ -57,20 +57,21 @@ class GenerateItemTestCase(TestCase):
         with self.assertRaises(ClickException):
             _generate_item(ctx_mock, "protocol", "path")
 
-    @mock.patch("aea.cli.generate.shutil.which", _which_mock)
+    @mock.patch("aea.protocols.generator.base.shutil.which", _which_mock)
     def test__generate_item_no_res(self, *mocks):
         """Test for fetch_agent_locally method no black."""
         ctx_mock = ContextMock()
         with self.assertRaises(ClickException) as cm:
             _generate_item(ctx_mock, "protocol", "path")
         expected_msg = (
-            "Please install black code formater first! See the following link: "
+            "There was an error while generating the protocol. The protocol is NOT generated. Exception:\n"
+            "Cannot find black code formatter. To install, please follow this link: "
             "https://black.readthedocs.io/en/stable/installation_and_usage.html"
         )
         self.assertEqual(cm.exception.message, expected_msg)
 
     @mock.patch("aea.cli.generate.os.path.exists", return_value=False)
-    @mock.patch("aea.cli.generate.shutil.which", return_value="some")
+    @mock.patch("aea.protocols.generator.base.shutil.which", return_value="some")
     @mock.patch("aea.cli.generate.ProtocolGenerator.generate", _raise_psperror)
     def test__generate_item_parsing_specs_fail(self, *mocks):
         """Test for fetch_agent_locally method parsing specs fail."""

--- a/tests/test_cli/test_generate/test_generate.py
+++ b/tests/test_cli/test_generate/test_generate.py
@@ -64,8 +64,8 @@ class GenerateItemTestCase(TestCase):
         with self.assertRaises(ClickException) as cm:
             _generate_item(ctx_mock, "protocol", "path")
         expected_msg = (
-            "There was an error while generating the protocol. The protocol is NOT generated. Exception:\n"
-            "Cannot find black code formatter. To install, please follow this link: "
+            "Protocol is NOT generated. The following error happened while generating the protocol:\n"
+            "Cannot find black code formatter! To install, please follow this link: "
             "https://black.readthedocs.io/en/stable/installation_and_usage.html"
         )
         self.assertEqual(cm.exception.message, expected_msg)

--- a/tests/test_cli/test_generate/test_protocols.py
+++ b/tests/test_cli/test_generate/test_protocols.py
@@ -350,7 +350,7 @@ class TestGenerateProtocolFailsWhenConfigFileIsNotCompliant:
 
         The expected message is: 'Cannot find protocol: '{protocol_name}'
         """
-        s = "There was an error while generating the protocol. The protocol is NOT generated. Exception: test error message"
+        s = "There was an error while generating the protocol. The protocol is NOT generated. Exception:\ntest error message"
         assert self.result.exception.message == s
 
     @classmethod

--- a/tests/test_cli/test_generate/test_protocols.py
+++ b/tests/test_cli/test_generate/test_protocols.py
@@ -350,7 +350,7 @@ class TestGenerateProtocolFailsWhenConfigFileIsNotCompliant:
 
         The expected message is: 'Cannot find protocol: '{protocol_name}'
         """
-        s = "There was an error while generating the protocol. The protocol is NOT generated. Exception:\ntest error message"
+        s = "Protocol is NOT generated. The following error happened while generating the protocol:\ntest error message"
         assert self.result.exception.message == s
 
     @classmethod

--- a/tests/test_protocols/test_generator.py
+++ b/tests/test_protocols/test_generator.py
@@ -91,7 +91,9 @@ class TestEndToEndGenerator(UseOef):
         try:
             check_prerequisites()
         except FileNotFoundError:
-            pytest.skip("Some prerequisite applications are not installed. Skipping this test.")
+            pytest.skip(
+                "Some prerequisite applications are not installed. Skipping this test."
+            )
 
         # Specification
         # protocol_name = "t_protocol"

--- a/tests/test_protocols/test_generator.py
+++ b/tests/test_protocols/test_generator.py
@@ -47,6 +47,7 @@ from aea.protocols.generator.base import (
     ProtocolGenerator,
     _union_sub_type_to_protobuf_variable_name,
 )
+from aea.protocols.generator.common import check_prerequisites
 from aea.protocols.generator.extract_specification import (
     _specification_type_to_python_type,
 )
@@ -86,6 +87,11 @@ class TestEndToEndGenerator(UseOef):
 
     def test_compare_latest_generator_output_with_test_protocol(self):
         """Test that the "t_protocol" test protocol matches with what the latest generator generates based on the specification."""
+        # Skip if prerequisite applications are not installed
+        try:
+            check_prerequisites()
+        except FileNotFoundError:
+            pytest.skip("Some prerequisite applications are not installed. Skipping this test.")
 
         # Specification
         # protocol_name = "t_protocol"

--- a/tests/test_protocols/test_generator.py
+++ b/tests/test_protocols/test_generator.py
@@ -22,8 +22,6 @@ import inspect
 import logging
 import os
 import shutil
-import subprocess  # nosec
-import sys
 import tempfile
 import time
 from pathlib import Path
@@ -37,12 +35,10 @@ from aea.aea_builder import AEABuilder
 from aea.configurations.base import (
     ComponentType,
     ProtocolId,
-    ProtocolSpecification,
     ProtocolSpecificationParseError,
     PublicId,
     SkillConfig,
 )
-from aea.configurations.loader import ConfigLoader
 from aea.crypto.fetchai import FetchAICrypto
 from aea.crypto.helpers import create_private_key
 from aea.mail.base import Envelope
@@ -90,15 +86,9 @@ class TestEndToEndGenerator(UseOef):
 
     def test_compare_latest_generator_output_with_test_protocol(self):
         """Test that the "t_protocol" test protocol matches with what the latest generator generates based on the specification."""
-        # check protoc is installed
-        res = shutil.which("protoc")
-        if res is None:
-            pytest.skip(
-                "Please install protocol buffer first! See the following link: https://developers.google.com/protocol-buffers/"
-            )
 
         # Specification
-        protocol_name = "t_protocol"
+        # protocol_name = "t_protocol"
         path_to_specification = os.path.join(
             ROOT_DIR, "tests", "data", "sample_specification.yaml"
         )
@@ -108,41 +98,15 @@ class TestEndToEndGenerator(UseOef):
         # )
         path_to_package = "tests.data.generator."
 
-        # Load the config
-        config_loader = ConfigLoader(
-            "protocol-specification_schema.json", ProtocolSpecification
-        )
-        protocol_specification = config_loader.load_protocol_specification(
-            open(path_to_specification)
-        )
-
         # Generate the protocol
         protocol_generator = ProtocolGenerator(
-            protocol_specification,
+            path_to_specification,
             path_to_generated_protocol,
             path_to_protocol_package=path_to_package,
         )
         protocol_generator.generate()
 
-        # Apply black
-        try:
-            subp = subprocess.Popen(  # nosec
-                [
-                    sys.executable,
-                    "-m",
-                    "black",
-                    os.path.join(path_to_generated_protocol, protocol_name),
-                    "--quiet",
-                ]
-            )
-            subp.wait(10.0)
-        finally:
-            poll = subp.poll()
-            if poll is None:  # pragma: no cover
-                subp.terminate()
-                subp.wait(5)
-
-        # compare __init__.py
+        # # compare __init__.py
         # init_file_generated = Path(self.t, protocol_name, "__init__.py")
         # init_file_original = Path(path_to_original_protocol, "__init__.py",)
         # assert filecmp.cmp(init_file_generated, init_file_original)


### PR DESCRIPTION
This PR includes the following:

- Moved the following functionalities from CLI generate to the generator:
  - Checking `protoc` is installed
  - Checking `black` is installed
  - Loading protocol specification yaml file
  - Run black code formatting
- Added the following functionalities:
  - Checking whether a protobuf schema file is valid, by trying to compile it.
  - The above process is now atomic, if invalid it rolls back everything generated. If any errors, it correctly forwards them as part of exception message.
- Running `protoc` is now via `subprocess` instead of `os.system(cmd)`
- `extract_specification.py`, `validate.py`, `common.py` pass `pylint` now
- Updating tests to reflect the above changes

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules