### PR TITLE
Fix Skill loading order

### DIFF
--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -23,6 +23,7 @@ import logging
 import logging.config
 import os
 import pprint
+from collections import defaultdict, deque
 from copy import copy, deepcopy
 from pathlib import Path
 from typing import Any, Collection, Dict, List, Optional, Set, Tuple, Type, Union, cast
@@ -1231,10 +1232,6 @@ class AEABuilder:
                 ComponentId(ComponentType.CONNECTION, p_id)
                 for p_id in agent_configuration.connections
             ],
-            [
-                ComponentId(ComponentType.SKILL, p_id)
-                for p_id in agent_configuration.skills
-            ],
         )
         for component_id in component_ids:
             component_path = self._find_component_directory_from_component_id(
@@ -1245,6 +1242,70 @@ class AEABuilder:
                 component_path,
                 skip_consistency_check=skip_consistency_check,
             )
+
+        skill_ids = [
+            ComponentId(ComponentType.SKILL, p_id)
+            for p_id in agent_configuration.skills
+        ]
+        skill_import_order = self._find_import_order(skill_ids, aea_project_path)
+        for skill_id in skill_import_order:
+            component_path = self._find_component_directory_from_component_id(
+                aea_project_path, skill_id
+            )
+            self.add_component(
+                skill_id.component_type,
+                component_path,
+                skip_consistency_check=skip_consistency_check,
+            )
+
+    def _find_import_order(self, skill_ids, aea_project_path):
+        """Find import order for skills.
+
+        We need to handle skills separately, since skills can depend on each other.
+        That is, we need to:
+        - load the skill configurations to find the import order
+        - detect if there are cycles
+        - import skills from the leaves of the dependency graph, by finding a topological ordering.
+        """
+        # the adjacency list for the dependency graph
+        depends_on: Dict[PublicId, Set[PublicId]] = defaultdict(set)
+        # the adjacency list for the inverse dependency graph
+        supports: Dict[PublicId, Set[PublicId]] = defaultdict(set)
+        # nodes with no incoming edges
+        roots = copy(skill_ids)
+
+        for skill_id in skill_ids:
+            component_path = self._find_component_directory_from_component_id(
+                aea_project_path, skill_id
+            )
+            configuration = cast(
+                SkillConfig,
+                ComponentConfiguration.load(
+                    skill_id.component_type, component_path, False
+                ),
+            )
+
+            if len(configuration.skills) != 0:
+                roots.remove(skill_id)
+            depends_on[skill_id].update(configuration.skills)
+            for dependency in configuration.skills:
+                supports[dependency].add(skill_id)
+
+        if len(roots) == 0:
+            raise AEAException("Cannot load skill, there is a cyclic dependency.")
+
+        # find topological order (Kahn's algorithm)
+        queue = deque()
+        order = []
+        queue.extend(roots)
+        while len(queue) > 0:
+            current = queue.pop()
+            order.append(current)
+            for node in supports[current]:
+                depends_on[node].discard(current)
+                if len(depends_on[node]) == 0:
+                    queue.append(node)
+        return order
 
     @classmethod
     def from_aea_project(

--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -1295,9 +1295,6 @@ class AEABuilder:
             for dependency in configuration.skills:
                 supports[dependency].add(skill_id)
 
-        if len(roots) == 0:
-            raise AEAException("Cannot load skill, there is a cyclic dependency.")
-
         # find topological order (Kahn's algorithm)
         queue = deque()
         order = []
@@ -1309,6 +1306,10 @@ class AEABuilder:
                 depends_on[node].discard(current)
                 if len(depends_on[node]) == 0:
                     queue.append(node)
+
+        if any(len(edges) > 0 for edges in depends_on.values()):
+            raise AEAException("Cannot load skills, there is a cyclic dependency.")
+
         return order
 
     @classmethod

--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -1247,6 +1247,10 @@ class AEABuilder:
             ComponentId(ComponentType.SKILL, p_id)
             for p_id in agent_configuration.skills
         ]
+
+        if len(skill_ids) == 0:
+            return
+
         skill_import_order = self._find_import_order(skill_ids, aea_project_path)
         for skill_id in skill_import_order:
             component_path = self._find_component_directory_from_component_id(


### PR DESCRIPTION
## Proposed changes

After #939 , it is possible to load a skill from another skill. However, it is important the order in which the skills declared in aea-config.yaml file are processed. This PR aims to fix that, by finding the topological order in the skill dependency graph.


## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
