### PR TITLE
Addressing generator bug for Python 3.6

### DIFF
--- a/aea/protocols/generator/common.py
+++ b/aea/protocols/generator/common.py
@@ -219,7 +219,7 @@ def try_run_protoc(path_to_generated_protocol_package, name) -> None:
                 "{}/{}.proto".format(path_to_generated_protocol_package, name),
             ],
             stderr=subprocess.PIPE,
-            encoding='utf-8',
+            encoding="utf-8",
             check=True,
             env=os.environ.copy(),
         )

--- a/aea/protocols/generator/common.py
+++ b/aea/protocols/generator/common.py
@@ -219,7 +219,7 @@ def try_run_protoc(path_to_generated_protocol_package, name) -> None:
                 "{}/{}.proto".format(path_to_generated_protocol_package, name),
             ],
             stderr=subprocess.PIPE,
-            text=True,
+            encoding='utf-8',
             check=True,
             env=os.environ.copy(),
         )

--- a/aea/protocols/generator/common.py
+++ b/aea/protocols/generator/common.py
@@ -218,7 +218,7 @@ def try_run_protoc(path_to_generated_protocol_package, name) -> None:
                 "--python_out={}".format(path_to_generated_protocol_package),
                 "{}/{}.proto".format(path_to_generated_protocol_package, name),
             ],
-            capture_output=True,
+            stderr=subprocess.PIPE,
             text=True,
             check=True,
             env=os.environ.copy(),


### PR DESCRIPTION
This PR address an incompatibility issue for Python 3.6 in the generator code.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules