### PR TITLE
Remove 'inject contract' feature

### DIFF
--- a/aea/registries/resources.py
+++ b/aea/registries/resources.py
@@ -19,7 +19,7 @@
 
 """This module contains the resources class."""
 from contextlib import suppress
-from typing import Dict, List, Optional, cast
+from typing import List, Optional, cast
 
 from aea.components.base import Component
 from aea.configurations.base import (
@@ -244,28 +244,6 @@ class Resources:
         if skill.models is not None:
             for model in skill.models.values():
                 self._model_registry.register((skill.public_id, model.name), model)
-        self.inject_contracts(skill)
-
-    def inject_contracts(self, skill: Skill) -> None:
-        """
-        Inject contracts into a skill context.
-
-        :param skill: a skill
-        :return: None
-        """
-        if skill.config.contracts is not None:
-            # check all contracts are present
-            contracts = {}  # type: Dict[str, Contract]
-            for contract_id in skill.config.contracts:
-                contract = self._component_registry.fetch(
-                    ComponentId(ComponentType.CONTRACT, contract_id)
-                )
-                if contract is None:
-                    raise ValueError(
-                        "Missing contract for contract id {}".format(contract_id)
-                    )
-                contracts[contract_id.name] = cast(Contract, contract)
-            skill.inject_contracts(contracts)
 
     def get_skill(self, skill_id: SkillId) -> Optional[Skill]:
         """

--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -644,10 +644,6 @@ class Skill(Component):
         """Get the contracts associated with the skill."""
         return self._contracts
 
-    def inject_contracts(self, contracts: Dict[str, Contract]) -> None:
-        """Add the contracts to the skill."""
-        self._contracts = contracts
-
     @property
     def skill_context(self) -> SkillContext:
         """Get the skill context."""

--- a/tests/test_registries/test_base.py
+++ b/tests/test_registries/test_base.py
@@ -390,24 +390,6 @@ class TestResources:
         with pytest.raises(ValueError):
             self.resources.add_component(a_component)
 
-    def test_inject_contracts_unknown_contract(self):
-        """Test inject contracts when there is a missing contract."""
-        public_id = PublicId.from_str("author/name:0.1.0")
-        mock_skill = MagicMock(**{"config.contracts": {public_id}})
-        with pytest.raises(
-            ValueError, match=f"Missing contract for contract id {public_id}"
-        ):
-            self.resources.inject_contracts(mock_skill)
-
-    def test_inject_contracts(self):
-        """Test inject contracts."""
-        with unittest.mock.patch.object(
-            self.resources._component_registry, "fetch", return_value=object()
-        ):
-            public_id = PublicId.from_str("author/name:0.1.0")
-            mock_skill = MagicMock(**{"config.contracts": {public_id}})
-            self.resources.inject_contracts(mock_skill)
-
     def test_register_behaviour_with_already_existing_skill_id(self):
         """Test that registering a behaviour with an already existing skill id behaves as expected."""
         # this should raise an error, since the 'dummy" skill already has a behaviour named "dummy"

--- a/tests/test_skills/test_base.py
+++ b/tests/test_skills/test_base.py
@@ -455,10 +455,3 @@ class TestSkill:
         """Test the skill context getter."""
         context = self.skill.skill_context
         assert isinstance(context, SkillContext)
-
-    def test_inject_contracts(self):
-        """Test inject contracts."""
-        assert self.skill.contracts == {}
-        d = {"foo": MagicMock()}
-        self.skill.inject_contracts(d)
-        assert self.skill.contracts == d


### PR DESCRIPTION
## Proposed changes

This PR removes the `inject_contract` feature of the `Skill` and `Resources` classes, made obsolete by recent changes on contract loading and usage.

## Fixes

Fixes #1465 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a