### PR TITLE
CosmWasm message signing

### DIFF
--- a/aea/crypto/cosmos.py
+++ b/aea/crypto/cosmos.py
@@ -66,7 +66,7 @@ class CosmosCrypto(Crypto[SigningKey]):
     def private_key(self) -> str:
         """
         Return a private key.
-        
+
         :return: a private key string
         """
         return self.entity.to_string().hex()

--- a/aea/crypto/cosmos.py
+++ b/aea/crypto/cosmos.py
@@ -118,9 +118,15 @@ class CosmosCrypto(Crypto[SigningKey]):
         return signature_base64_str
 
     @staticmethod
-    def sign_default_transaction(transaction: Any, signed_transaction, base64_pbk) -> Any:
+    def format_default_transaction(transaction: Any, signature: str, base64_pbk: str) -> Any:
         """
-        Sign default CosmosSDK transaction
+        Format default CosmosSDK transaction and add signature
+
+        :param transaction: the transaction to be formatted
+        :param signature: the transaction signature
+        :param base64_pbk: the base64 formatted public key
+
+        :return: formatted transaction with signature
         """
         pushable_tx = {
             "tx": {
@@ -129,7 +135,7 @@ class CosmosCrypto(Crypto[SigningKey]):
                 "memo": transaction["memo"],
                 "signatures": [
                     {
-                        "signature": signed_transaction,
+                        "signature": signature,
                         "pub_key": {
                             "type": "tendermint/PubKeySecp256k1",
                             "value": base64_pbk,
@@ -144,9 +150,15 @@ class CosmosCrypto(Crypto[SigningKey]):
         return pushable_tx
 
     @staticmethod
-    def sign_wasm_transaction(transaction: Any, signed_transaction, base64_pbk) -> Any:
+    def format_wasm_transaction(transaction: Any, signature: str, base64_pbk: str) -> Any:
         """
-        Sign CosmWasm transaction
+        Format CosmWasm transaction and add signature
+
+        :param transaction: the transaction to be formatted
+        :param signature: the transaction signature
+        :param base64_pbk: the base64 formatted public key
+
+        :return: formatted transaction with signature
         """
 
         pushable_tx = {
@@ -160,7 +172,7 @@ class CosmosCrypto(Crypto[SigningKey]):
                             "type": "tendermint/PubKeySecp256k1",
                             "value": base64_pbk,
                         },
-                        "signature": signed_transaction,
+                        "signature": signature,
                     }
                 ],
                 "memo": transaction["memo"],
@@ -185,10 +197,9 @@ class CosmosCrypto(Crypto[SigningKey]):
                 and len(transaction["msgs"])==1 \
                 and "type" in transaction["msgs"][0] \
                 and "wasm" in transaction["msgs"][0]["type"] :
-            return self.sign_wasm_transaction(transaction, signed_transaction, base64_pbk)
+            return self.format_wasm_transaction(transaction, signed_transaction, base64_pbk)
         else:
-            return self.sign_default_transaction(transaction, signed_transaction, base64_pbk)
-
+            return self.format_default_transaction(transaction, signed_transaction, base64_pbk)
 
     @classmethod
     def generate_private_key(cls) -> SigningKey:

--- a/aea/crypto/cosmos.py
+++ b/aea/crypto/cosmos.py
@@ -118,7 +118,9 @@ class CosmosCrypto(Crypto[SigningKey]):
         return signature_base64_str
 
     @staticmethod
-    def format_default_transaction(transaction: Any, signature: str, base64_pbk: str) -> Any:
+    def format_default_transaction(
+        transaction: Any, signature: str, base64_pbk: str
+    ) -> Any:
         """
         Format default CosmosSDK transaction and add signature
 
@@ -150,7 +152,9 @@ class CosmosCrypto(Crypto[SigningKey]):
         return pushable_tx
 
     @staticmethod
-    def format_wasm_transaction(transaction: Any, signature: str, base64_pbk: str) -> Any:
+    def format_wasm_transaction(
+        transaction: Any, signature: str, base64_pbk: str
+    ) -> Any:
         """
         Format CosmWasm transaction and add signature
 
@@ -193,13 +197,19 @@ class CosmosCrypto(Crypto[SigningKey]):
         signed_transaction = self.sign_message(transaction_bytes)
         base64_pbk = base64.b64encode(bytes.fromhex(self.public_key)).decode("utf-8")
 
-        if "msgs" in transaction \
-                and len(transaction["msgs"])==1 \
-                and "type" in transaction["msgs"][0] \
-                and "wasm" in transaction["msgs"][0]["type"] :
-            return self.format_wasm_transaction(transaction, signed_transaction, base64_pbk)
+        if (
+            "msgs" in transaction
+            and len(transaction["msgs"]) == 1
+            and "type" in transaction["msgs"][0]
+            and "wasm" in transaction["msgs"][0]["type"]
+        ):
+            return self.format_wasm_transaction(
+                transaction, signed_transaction, base64_pbk
+            )
         else:
-            return self.format_default_transaction(transaction, signed_transaction, base64_pbk)
+            return self.format_default_transaction(
+                transaction, signed_transaction, base64_pbk
+            )
 
     @classmethod
     def generate_private_key(cls) -> SigningKey:

--- a/aea/crypto/cosmos.py
+++ b/aea/crypto/cosmos.py
@@ -66,6 +66,7 @@ class CosmosCrypto(Crypto[SigningKey]):
     def private_key(self) -> str:
         """
         Return a private key.
+        
         :return: a private key string
         """
         return self.entity.to_string().hex()

--- a/aea/crypto/cosmos.py
+++ b/aea/crypto/cosmos.py
@@ -41,7 +41,6 @@ from aea.mail.base import Address
 logger = logging.getLogger(__name__)
 
 _COSMOS = "cosmos"
-COSMOS_CURRENCY = "ATOM"
 COSMOS_TESTNET_FAUCET_URL = "https://faucet-agent-land.prod.fetch-ai.com:443/claim"
 DEFAULT_ADDRESS = "https://rest-agent-land.prod.fetch-ai.com:443"
 DEFAULT_CURRENCY_DENOM = "atestfet"
@@ -62,6 +61,14 @@ class CosmosCrypto(Crypto[SigningKey]):
         super().__init__(private_key_path=private_key_path)
         self._public_key = self.entity.get_verifying_key().to_string("compressed").hex()
         self._address = CosmosHelper.get_address_from_public_key(self.public_key)
+
+    @property
+    def private_key(self) -> str:
+        """
+        Return a private key.
+        :return: a private key string
+        """
+        return self.entity.to_string().hex()
 
     @property
     def public_key(self) -> str:
@@ -195,7 +202,7 @@ class CosmosCrypto(Crypto[SigningKey]):
         :param fp: the output file pointer. Must be set in binary mode (mode='wb')
         :return: None
         """
-        fp.write(self.entity.to_string().hex().encode("utf-8"))
+        fp.write(self.private_key.encode("utf-8"))
 
 
 class CosmosHelper(Helper):
@@ -272,7 +279,7 @@ class CosmosHelper(Helper):
         r = hashlib.new("ripemd160", s).digest()
         five_bit_r = convertbits(r, 8, 5)
         assert five_bit_r is not None, "Unsuccessful bech32.convertbits call"
-        address = bech32_encode("cosmos", five_bit_r)
+        address = bech32_encode(_COSMOS, five_bit_r)
         return address
 
     @staticmethod

--- a/tests/test_crypto/test_cosmos.py
+++ b/tests/test_crypto/test_cosmos.py
@@ -169,3 +169,97 @@ def test_get_wealth_positive(caplog):
         cc = CosmosCrypto()
         cosmos_faucet_api.get_wealth(cc.address)
         assert "Wealth generated" in caplog.text
+
+
+@pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)
+@pytest.mark.integration
+@pytest.mark.ledger
+def test_format_default():
+    """Test if default CosmosSDK transaction is correctly formated."""
+    account = CosmosCrypto(COSMOS_PRIVATE_KEY_PATH)
+    cc2 = CosmosCrypto()
+    cosmos_api = CosmosApi(**COSMOS_TESTNET_CONFIG)
+
+    amount = 10000
+
+    transfer_transaction = cosmos_api.get_transfer_transaction(
+        sender_address=account.address,
+        destination_address=cc2.address,
+        amount=amount,
+        tx_fee=1000,
+        tx_nonce="something",
+    )
+
+    signed_transaction = cc2.sign_transaction(transfer_transaction)
+
+    assert "tx" in signed_transaction
+    assert "signatures" in signed_transaction["tx"]
+    assert len(signed_transaction["tx"]["signatures"]) == 1
+
+    assert "pub_key" in signed_transaction["tx"]["signatures"][0]
+    assert "value" in signed_transaction["tx"]["signatures"][0]["pub_key"]
+    base64_pbk = signed_transaction["tx"]["signatures"][0]["pub_key"]["value"]
+
+    assert "signature" in signed_transaction["tx"]["signatures"][0]
+    signature = signed_transaction["tx"]["signatures"][0]["signature"]
+
+    default_formated_transaction = cc2.format_default_transaction(
+        transfer_transaction, signature, base64_pbk
+    )
+
+    # Compare default formatted transaction with signed transaction
+    assert signed_transaction == default_formated_transaction
+
+
+@pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)
+@pytest.mark.integration
+@pytest.mark.ledger
+def test_format_cosmwasm():
+    """Test if CosmWasm transaction is correctly formated."""
+    cc2 = CosmosCrypto()
+
+    # Dummy CosmWasm transaction
+    wasm_transaction = {
+        "account_number": "8",
+        "chain_id": "agent-land",
+        "fee": {"amount": [], "gas": "200000"},
+        "memo": "",
+        "msgs": [
+            {
+                "type": "wasm/execute",
+                "value": {
+                    "sender": "cosmos14xjnl2mwwfz6pztpwzj6s89npxr0e3lhxl52nv",
+                    "contract": "cosmos1xzlgeyuuyqje79ma6vllregprkmgwgav5zshcm",
+                    "msg": {
+                        "create_single": {
+                            "item_owner": "cosmos1fz0dcvvqv5at6dl39804jy92lnndf3d5saalx6",
+                            "id": "1234",
+                            "path": "SOME_URI",
+                        }
+                    },
+                    "sent_funds": [],
+                },
+            }
+        ],
+        "sequence": "25",
+    }
+
+    signed_transaction = cc2.sign_transaction(wasm_transaction)
+
+    assert "value" in signed_transaction
+    assert "signatures" in signed_transaction["value"]
+    assert len(signed_transaction["value"]["signatures"]) == 1
+
+    assert "pub_key" in signed_transaction["value"]["signatures"][0]
+    assert "value" in signed_transaction["value"]["signatures"][0]["pub_key"]
+    base64_pbk = signed_transaction["value"]["signatures"][0]["pub_key"]["value"]
+
+    assert "signature" in signed_transaction["value"]["signatures"][0]
+    signature = signed_transaction["value"]["signatures"][0]["signature"]
+
+    wasm_formated_transaction = cc2.format_wasm_transaction(
+        wasm_transaction, signature, base64_pbk
+    )
+
+    # Compare Wasm formatted transaction with signed transaction
+    assert signed_transaction == wasm_formated_transaction


### PR DESCRIPTION
## Proposed changes

This change adds support for signing CosmWasm messages which are in a different format than standard CosmosSDK messages.
I added if the message contains a specific type it is handled as CosmWasm message otherwise old functionality is kept.

- I need someone to help me to test this change if it doesn't break anything.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules


