### PR TITLE
Fix Generator Tests

### DIFF
--- a/tests/data/generator/t_protocol/dialogues.py
+++ b/tests/data/generator/t_protocol/dialogues.py
@@ -159,7 +159,7 @@ class TProtocolDialogues(Dialogues, ABC):
         self, dialogue_label: DialogueLabel, role: Dialogue.Role,
     ) -> TProtocolDialogue:
         """
-        Create an instance of {} dialogue.
+        Create an instance of t_protocol dialogue.
 
         :param dialogue_label: the identifier of the dialogue
         :param role: the role of the agent this dialogue is maintained for

--- a/tests/data/generator/t_protocol/message.py
+++ b/tests/data/generator/t_protocol/message.py
@@ -36,7 +36,7 @@ DEFAULT_BODY_SIZE = 4
 class TProtocolMessage(Message):
     """A protocol for testing purposes."""
 
-    protocol_id = ProtocolId("fetchai", "t_protocol", "0.1.0")
+    protocol_id = ProtocolId.from_str("fetchai/t_protocol:0.1.0")
 
     DataModel = CustomDataModel
 

--- a/tests/data/generator/t_protocol/protocol.yaml
+++ b/tests/data/generator/t_protocol/protocol.yaml
@@ -7,8 +7,8 @@ aea_version: '>=0.5.0, <0.6.0'
 fingerprint:
   __init__.py: QmTwLir2v2eYMkDeUomf9uL1hrQhjzVTTqrQwamGG5iwn4
   custom_types.py: Qmd5CrULVdtcNQLz5R1i9LpJi9Nhzd7nQnwN737FqibgLs
-  dialogues.py: QmayQSCYaGRvYixY8sLW5VrVMSy3Nf1p9pZszPhsbyY4Du
-  message.py: QmcNg3PinK4LsqaiJ7tmRfuSc7ohkeQeRgqiRoU64q9eNT
+  dialogues.py: QmSh74pVsprgNbz4Y2B2EWt4C6tsNDsRfuYcjwJYiu8apz
+  message.py: QmUrAcMnqoBMs1nSDzp8c6fr82qPMgbjGQNdQgxa4YYCxc
   serialization.py: QmcS33k6rHgCCkhBuQ5kiXVKFMxxEzcZManshPD51MEHbw
   t_protocol.proto: QmRuYvnojwkyZLzeECH3snomgoMJTB3m48yJiLq8LYsVb8
   t_protocol_pb2.py: QmXrSgBBJCj8hbGCynKrvdkSDohQzHLPBA2vi5hDHmaGid

--- a/tests/data/generator/t_protocol_no_ct/dialogues.py
+++ b/tests/data/generator/t_protocol_no_ct/dialogues.py
@@ -156,7 +156,7 @@ class TProtocolNoCtDialogues(Dialogues, ABC):
         self, dialogue_label: DialogueLabel, role: Dialogue.Role,
     ) -> TProtocolNoCtDialogue:
         """
-        Create an instance of {} dialogue.
+        Create an instance of t_protocol_no_ct dialogue.
 
         :param dialogue_label: the identifier of the dialogue
         :param role: the role of the agent this dialogue is maintained for

--- a/tests/data/generator/t_protocol_no_ct/message.py
+++ b/tests/data/generator/t_protocol_no_ct/message.py
@@ -34,7 +34,7 @@ DEFAULT_BODY_SIZE = 4
 class TProtocolNoCtMessage(Message):
     """A protocol for testing purposes."""
 
-    protocol_id = ProtocolId("fetchai", "t_protocol_no_ct", "0.1.0")
+    protocol_id = ProtocolId.from_str("fetchai/t_protocol_no_ct:0.1.0")
 
     class Performative(Enum):
         """Performatives for the t_protocol_no_ct protocol."""

--- a/tests/data/generator/t_protocol_no_ct/protocol.yaml
+++ b/tests/data/generator/t_protocol_no_ct/protocol.yaml
@@ -6,8 +6,8 @@ license: Apache-2.0
 aea_version: '>=0.5.0, <0.6.0'
 fingerprint:
   __init__.py: QmRGHGRoZHGCXQ29v3q93Nt6J5TuhggYvUvZoQfrM6c3yp
-  dialogues.py: QmYpqVhKoMjepiJSe6Wu6umUCvhpNC7VmXK7RCstFvRhZh
-  message.py: QmbG2pkq15efBUWjgWL9cxkzaBTwCZyZQ9Z7ekBPSCShyt
+  dialogues.py: QmR8zDLTaKpxeuJU2wRXo4vnVQVHGcY2FX9xjy62c5n9jX
+  message.py: QmcMYvB4MwQgZ8Z33aGAUUBMqx3Eq7uXBZwhdeKWMyvZWg
   serialization.py: Qmc3tJ5vk1AbtkF5BrPUeuyrnvVUTrfuUMF9MgDfkiiMkB
   t_protocol_no_ct.proto: QmeZWVLhb6EUGr5AgVwgf2YTEZTSuCskpmxCwAE3sDU9sY
   t_protocol_no_ct_pb2.py: QmYtjyYTv1fQrwTS2x5ZkrNB8bpgH2vpPUJsUV29B7E4d9

--- a/tests/test_protocols/test_generator/test_end_to_end.py
+++ b/tests/test_protocols/test_generator/test_end_to_end.py
@@ -336,7 +336,9 @@ class Agent2Handler(Handler):
 
     SUPPORTED_PROTOCOL = TProtocolMessage.protocol_id  # type: Optional[ProtocolId]
 
-    def __init__(self, message: TProtocolMessage, dialogue: TProtocolDialogue, **kwargs):
+    def __init__(
+        self, message: TProtocolMessage, dialogue: TProtocolDialogue, **kwargs
+    ):
         """Initialize the handler."""
         print("inside handler's initialisation method for agent 2")
         super().__init__(**kwargs)

--- a/tests/test_protocols/test_generator/test_end_to_end.py
+++ b/tests/test_protocols/test_generator/test_end_to_end.py
@@ -35,7 +35,7 @@ from aea.configurations.base import (
 )
 from aea.configurations.constants import DEFAULT_LEDGER, DEFAULT_PRIVATE_KEY_FILE
 from aea.crypto.helpers import create_private_key
-from aea.mail.base import Envelope
+from aea.helpers.dialogue.base import DialogueLabel, Dialogue
 from aea.protocols.base import Message
 from aea.skills.base import Handler, Skill, SkillContext
 from aea.test_tools.test_cases import UseOef
@@ -44,6 +44,7 @@ from tests.conftest import ROOT_DIR
 from tests.data.generator.t_protocol.message import (  # type: ignore
     TProtocolMessage,
 )
+from tests.data.generator.t_protocol.dialogues import TProtocolDialogue
 from tests.test_protocols.test_generator.common import PATH_TO_T_PROTOCOL
 
 logger = logging.getLogger("aea")
@@ -117,10 +118,16 @@ class TestEndToEndGenerator(UseOef):
         aea_1 = builder_1.build(connection_ids=[PublicId.from_str("fetchai/oef:0.7.0")])
         aea_2 = builder_2.build(connection_ids=[PublicId.from_str("fetchai/oef:0.7.0")])
 
+        # dialogues
+        dialogue_label_1 = DialogueLabel((str(1), ""), aea_2.identity.address, aea_1.identity.address)
+        aea_1_dialogue = TProtocolDialogue(dialogue_label_1, aea_1.identity.address, TProtocolDialogue.Role.ROLE_1)
+        dialogue_label_2 = DialogueLabel((str(1), str(1)), aea_1.identity.address, aea_1.identity.address)
+        aea_2_dialogue = TProtocolDialogue(dialogue_label_2, aea_2.identity.address, TProtocolDialogue.Role.ROLE_2)
+
         # message 1
-        message = TProtocolMessage(
+        message_1 = TProtocolMessage(
             message_id=1,
-            dialogue_reference=(str(0), ""),
+            dialogue_reference=(str(1), ""),
             target=0,
             performative=TProtocolMessage.Performative.PERFORMATIVE_PT,
             content_bytes=b"some bytes",
@@ -129,18 +136,13 @@ class TestEndToEndGenerator(UseOef):
             content_bool=True,
             content_str="some string",
         )
-        message.counterparty = aea_2.identity.address
-        envelope = Envelope(
-            to=aea_2.identity.address,
-            sender=aea_1.identity.address,
-            protocol_id=TProtocolMessage.protocol_id,
-            message=message,
-        )
+        message_1.counterparty = aea_2.identity.address
+        message_1.is_incoming = False
 
         # message 2
         message_2 = TProtocolMessage(
             message_id=2,
-            dialogue_reference=(str(0), ""),
+            dialogue_reference=(str(1), str(1)),
             target=1,
             performative=TProtocolMessage.Performative.PERFORMATIVE_PT,
             content_bytes=b"some other bytes",
@@ -150,6 +152,7 @@ class TestEndToEndGenerator(UseOef):
             content_str="some other string",
         )
         message_2.counterparty = aea_1.identity.address
+        message_2.is_incoming = False
 
         # add handlers to AEA resources
         skill_context_1 = SkillContext(aea_1.context)
@@ -157,7 +160,7 @@ class TestEndToEndGenerator(UseOef):
         skill_context_1._skill = skill_1
 
         agent_1_handler = Agent1Handler(
-            skill_context=skill_context_1, name="fake_handler_1"
+            skill_context=skill_context_1, name="fake_handler_1", dialogue=aea_1_dialogue
         )
         aea_1.resources._handler_registry.register(
             (
@@ -171,7 +174,7 @@ class TestEndToEndGenerator(UseOef):
         skill_context_2._skill = skill_2
 
         agent_2_handler = Agent2Handler(
-            message=message_2, skill_context=skill_context_2, name="fake_handler_2",
+            message=message_2, dialogue=aea_2_dialogue, skill_context=skill_context_2, name="fake_handler_2",
         )
         aea_2.resources._handler_registry.register(
             (
@@ -188,41 +191,44 @@ class TestEndToEndGenerator(UseOef):
             t_1.start()
             t_2.start()
             time.sleep(1.0)
-            aea_1.outbox.put(envelope)
+            aea_1_dialogue.update(message_1)
+            aea_1.outbox.put_message(message_1)
             time.sleep(5.0)
             assert (
-                agent_2_handler.handled_message.message_id == message.message_id
+                agent_2_handler.handled_message.message_id == message_1.message_id
             ), "Message from Agent 1 to 2: message ids do not match"
             assert (
                 agent_2_handler.handled_message.dialogue_reference
-                == message.dialogue_reference
+                == message_1.dialogue_reference
             ), "Message from Agent 1 to 2: dialogue references do not match"
             assert (
                 agent_2_handler.handled_message.dialogue_reference[0]
-                == message.dialogue_reference[0]
+                == message_1.dialogue_reference[0]
             ), "Message from Agent 1 to 2: dialogue reference[0]s do not match"
             assert (
                 agent_2_handler.handled_message.dialogue_reference[1]
-                == message.dialogue_reference[1]
+                == message_1.dialogue_reference[1]
             ), "Message from Agent 1 to 2: dialogue reference[1]s do not match"
             assert (
-                agent_2_handler.handled_message.target == message.target
+                agent_2_handler.handled_message.target == message_1.target
             ), "Message from Agent 1 to 2: targets do not match"
             assert (
-                agent_2_handler.handled_message.performative == message.performative
+                agent_2_handler.handled_message.performative == message_1.performative
             ), "Message from Agent 1 to 2: performatives do not match"
             assert (
-                agent_2_handler.handled_message.content_bytes == message.content_bytes
+                agent_2_handler.handled_message.content_bytes == message_1.content_bytes
             ), "Message from Agent 1 to 2: content_bytes do not match"
             assert (
-                agent_2_handler.handled_message.content_int == message.content_int
+                agent_2_handler.handled_message.content_int == message_1.content_int
             ), "Message from Agent 1 to 2: content_int do not match"
-            # assert agent_2_handler.handled_message.content_float == message.content_float, "Message from Agent 1 to 2: content_float do not match"
+            # assert (
+            #     agent_2_handler.handled_message.content_float == message_1.content_float
+            # ), "Message from Agent 1 to 2: content_float do not match"
             assert (
-                agent_2_handler.handled_message.content_bool == message.content_bool
+                agent_2_handler.handled_message.content_bool == message_1.content_bool
             ), "Message from Agent 1 to 2: content_bool do not match"
             assert (
-                agent_2_handler.handled_message.content_str == message.content_str
+                agent_2_handler.handled_message.content_str == message_1.content_str
             ), "Message from Agent 1 to 2: content_str do not match"
 
             assert (
@@ -252,7 +258,9 @@ class TestEndToEndGenerator(UseOef):
             assert (
                 agent_1_handler.handled_message.content_int == message_2.content_int
             ), "Message from Agent 2 to 1: content_int do not match"
-            # assert agent_1_handler.handled_message.content_float == message_2.content_float, "Message from Agent 2 to 1: content_float do not match"
+            # assert (
+            #     agent_1_handler.handled_message.content_float == message_2.content_float
+            # ), "Message from Agent 2 to 1: content_float do not match"
             assert (
                 agent_1_handler.handled_message.content_bool == message_2.content_bool
             ), "Message from Agent 2 to 1: content_bool do not match"
@@ -281,11 +289,12 @@ class Agent1Handler(Handler):
 
     SUPPORTED_PROTOCOL = TProtocolMessage.protocol_id  # type: Optional[ProtocolId]
 
-    def __init__(self, **kwargs):
+    def __init__(self, dialogue, **kwargs):
         """Initialize the handler."""
         super().__init__(**kwargs)
         self.kwargs = kwargs
         self.handled_message = None
+        self.dialogue = dialogue
 
     def setup(self) -> None:
         """Implement the setup for the handler."""
@@ -298,6 +307,7 @@ class Agent1Handler(Handler):
         :param message: the message
         :return: None
         """
+        self.dialogue.update(message)
         self.handled_message = message
 
     def teardown(self) -> None:
@@ -313,13 +323,14 @@ class Agent2Handler(Handler):
 
     SUPPORTED_PROTOCOL = TProtocolMessage.protocol_id  # type: Optional[ProtocolId]
 
-    def __init__(self, message, **kwargs):
+    def __init__(self, message, dialogue: Dialogue, **kwargs):
         """Initialize the handler."""
         print("inside handler's initialisation method for agent 2")
         super().__init__(**kwargs)
         self.kwargs = kwargs
         self.handled_message = None
         self.message_2 = message
+        self.dialogue = dialogue
 
     def setup(self) -> None:
         """Implement the setup for the handler."""
@@ -332,14 +343,11 @@ class Agent2Handler(Handler):
         :param message: the message
         :return: None
         """
+        self.dialogue.update(message)
         self.handled_message = message
-        envelope = Envelope(
-            to=message.counterparty,
-            sender=self.context.agent_address,
-            protocol_id=TProtocolMessage.protocol_id,
-            message=self.message_2,
-        )
-        self.context.outbox.put(envelope)
+        message.counterparty = self.dialogue.dialogue_label.dialogue_opponent_addr
+        self.dialogue.update(self.message_2)
+        self.context.outbox.put_message(self.message_2)
 
     def teardown(self) -> None:
         """

--- a/tests/test_protocols/test_generator/test_end_to_end.py
+++ b/tests/test_protocols/test_generator/test_end_to_end.py
@@ -35,16 +35,16 @@ from aea.configurations.base import (
 )
 from aea.configurations.constants import DEFAULT_LEDGER, DEFAULT_PRIVATE_KEY_FILE
 from aea.crypto.helpers import create_private_key
-from aea.helpers.dialogue.base import DialogueLabel, Dialogue
+from aea.helpers.dialogue.base import DialogueLabel
 from aea.protocols.base import Message
 from aea.skills.base import Handler, Skill, SkillContext
 from aea.test_tools.test_cases import UseOef
 
 from tests.conftest import ROOT_DIR
+from tests.data.generator.t_protocol.dialogues import TProtocolDialogue
 from tests.data.generator.t_protocol.message import (  # type: ignore
     TProtocolMessage,
 )
-from tests.data.generator.t_protocol.dialogues import TProtocolDialogue
 from tests.test_protocols.test_generator.common import PATH_TO_T_PROTOCOL
 
 logger = logging.getLogger("aea")
@@ -119,10 +119,18 @@ class TestEndToEndGenerator(UseOef):
         aea_2 = builder_2.build(connection_ids=[PublicId.from_str("fetchai/oef:0.7.0")])
 
         # dialogues
-        dialogue_label_1 = DialogueLabel((str(1), ""), aea_2.identity.address, aea_1.identity.address)
-        aea_1_dialogue = TProtocolDialogue(dialogue_label_1, aea_1.identity.address, TProtocolDialogue.Role.ROLE_1)
-        dialogue_label_2 = DialogueLabel((str(1), str(1)), aea_1.identity.address, aea_1.identity.address)
-        aea_2_dialogue = TProtocolDialogue(dialogue_label_2, aea_2.identity.address, TProtocolDialogue.Role.ROLE_2)
+        dialogue_label_1 = DialogueLabel(
+            (str(1), ""), aea_2.identity.address, aea_1.identity.address
+        )
+        aea_1_dialogue = TProtocolDialogue(
+            dialogue_label_1, aea_1.identity.address, TProtocolDialogue.Role.ROLE_1
+        )
+        dialogue_label_2 = DialogueLabel(
+            (str(1), str(1)), aea_1.identity.address, aea_1.identity.address
+        )
+        aea_2_dialogue = TProtocolDialogue(
+            dialogue_label_2, aea_2.identity.address, TProtocolDialogue.Role.ROLE_2
+        )
 
         # message 1
         message_1 = TProtocolMessage(
@@ -160,7 +168,9 @@ class TestEndToEndGenerator(UseOef):
         skill_context_1._skill = skill_1
 
         agent_1_handler = Agent1Handler(
-            skill_context=skill_context_1, name="fake_handler_1", dialogue=aea_1_dialogue
+            skill_context=skill_context_1,
+            name="fake_handler_1",
+            dialogue=aea_1_dialogue,
         )
         aea_1.resources._handler_registry.register(
             (
@@ -174,7 +184,10 @@ class TestEndToEndGenerator(UseOef):
         skill_context_2._skill = skill_2
 
         agent_2_handler = Agent2Handler(
-            message=message_2, dialogue=aea_2_dialogue, skill_context=skill_context_2, name="fake_handler_2",
+            message=message_2,
+            dialogue=aea_2_dialogue,
+            skill_context=skill_context_2,
+            name="fake_handler_2",
         )
         aea_2.resources._handler_registry.register(
             (
@@ -289,11 +302,11 @@ class Agent1Handler(Handler):
 
     SUPPORTED_PROTOCOL = TProtocolMessage.protocol_id  # type: Optional[ProtocolId]
 
-    def __init__(self, dialogue, **kwargs):
+    def __init__(self, dialogue: TProtocolDialogue, **kwargs):
         """Initialize the handler."""
         super().__init__(**kwargs)
         self.kwargs = kwargs
-        self.handled_message = None
+        self.handled_message = None  # type: Optional[Message]
         self.dialogue = dialogue
 
     def setup(self) -> None:
@@ -323,12 +336,12 @@ class Agent2Handler(Handler):
 
     SUPPORTED_PROTOCOL = TProtocolMessage.protocol_id  # type: Optional[ProtocolId]
 
-    def __init__(self, message, dialogue: Dialogue, **kwargs):
+    def __init__(self, message: TProtocolMessage, dialogue: TProtocolDialogue, **kwargs):
         """Initialize the handler."""
         print("inside handler's initialisation method for agent 2")
         super().__init__(**kwargs)
         self.kwargs = kwargs
-        self.handled_message = None
+        self.handled_message = None  # type: Optional[Message]
         self.message_2 = message
         self.dialogue = dialogue
 


### PR DESCRIPTION
This PR fixes the generator tests that failed due to the recent generator changes.It:

* Regenerates the `t_protocol` and `t_protocol_no_ct` protocols.
* Adds dialogues into the generator end_to_end test.


## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules