### PR TITLE
AEA-817 Make the nonce for dialogue reference randomly generated

### DIFF
--- a/aea/helpers/base.py
+++ b/aea/helpers/base.py
@@ -27,6 +27,7 @@ import os
 import platform
 import re
 import signal
+import string
 import subprocess  # nosec
 import sys
 import time
@@ -375,3 +376,25 @@ def exception_log_and_reraise(log_method: Callable, message: str):
     except BaseException as e:  # pylint: disable=broad-except  # pragma: no cover  # generic code
         log_method(message.format(e))
         raise
+
+
+def is_hexadecimal(s: str) -> bool:
+    """
+    Check if a string is hexadecimal.
+
+    >>> is_hexadecimal("")
+    False
+
+    >>> is_hexadecimal("q")
+    False
+
+    >>> is_hexadecimal("123456789abcdef")
+    True
+
+    >>> is_hexadecimal("1234w")
+    False
+
+    :param s: the string to check.
+    :return True if the argument is hexadecimal; False otherwise.
+    """
+    return all(c in string.hexdigits for c in s) and len(s) > 0

--- a/aea/helpers/dialogue/base.py
+++ b/aea/helpers/dialogue/base.py
@@ -1039,7 +1039,7 @@ class Dialogues(ABC):
         )
         new_dialogue_reference = (
             dialogue_reference[0],
-            str(self._generate_dialogue_nonce()),
+            self._generate_dialogue_nonce(),
         )
         complete_dialogue_label = DialogueLabel(
             new_dialogue_reference, dialogue_opponent_addr, dialogue_opponent_addr

--- a/aea/helpers/dialogue/base.py
+++ b/aea/helpers/dialogue/base.py
@@ -26,12 +26,16 @@ This module contains the classes required for dialogue management.
 """
 
 import itertools
+import secrets
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Callable, Dict, FrozenSet, List, Optional, Set, Tuple, Type, cast
 
 from aea.mail.base import Address
 from aea.protocols.base import Message
+
+
+NONCE_BYTES_NB = 32
 
 
 class DialogueLabel:
@@ -733,7 +737,6 @@ class Dialogues(ABC):
             {}
         )  # type: Dict[DialogueLabel, DialogueLabel]
         self._agent_address = agent_address
-        self._dialogue_nonce = 0
         self._dialogue_stats = DialogueStats(end_states)
 
         if message_class is not None:
@@ -777,7 +780,7 @@ class Dialogues(ABC):
 
         :return: the next nonce
         """
-        return str(self._next_dialogue_nonce()), Dialogue.OPPONENT_STARTER_REFERENCE
+        return self._generate_dialogue_nonce(), Dialogue.OPPONENT_STARTER_REFERENCE
 
     def create(
         self, counterparty: Address, performative: Message.Performative, **kwargs,
@@ -814,7 +817,6 @@ class Dialogues(ABC):
 
         if not successfully_updated:
             self._dialogues_by_dialogue_label.pop(dialogue.dialogue_label)
-            self._dialogue_nonce -= 1
             raise Exception(
                 "Cannot create the a dialogue with the specified performative and contents."
             )
@@ -1037,7 +1039,7 @@ class Dialogues(ABC):
         )
         new_dialogue_reference = (
             dialogue_reference[0],
-            str(self._next_dialogue_nonce()),
+            str(self._generate_dialogue_nonce()),
         )
         complete_dialogue_label = DialogueLabel(
             new_dialogue_reference, dialogue_opponent_addr, dialogue_opponent_addr
@@ -1116,11 +1118,11 @@ class Dialogues(ABC):
         """
         pass  # pragma: no cover
 
-    def _next_dialogue_nonce(self) -> int:
+    @staticmethod
+    def _generate_dialogue_nonce() -> str:
         """
-        Increment the nonce and return it.
+        Generate the nonce and return it.
 
-        :return: the next nonce
+        :return: the nonce
         """
-        self._dialogue_nonce += 1
-        return self._dialogue_nonce
+        return secrets.token_hex(NONCE_BYTES_NB)

--- a/tests/test_helpers/test_dialogue/test_base.py
+++ b/tests/test_helpers/test_dialogue/test_base.py
@@ -1403,8 +1403,8 @@ class TestDialoguesBase:
         assert not result
         assert len(self.dialogues.dialogues) == 0
 
-    def test_next_dialogue_nonce(self):
-        """Test the '_next_dialogue_nonce' method."""
+    def test_generate_dialogue_nonce(self):
+        """Test the '_generate_dialogue_nonce' method."""
         assert self.dialogues._dialogue_nonce == 0
-        assert self.dialogues._next_dialogue_nonce() == 1
+        assert self.dialogues._generate_dialogue_nonce() == 1
         assert self.dialogues._dialogue_nonce == 1

--- a/tests/test_helpers/test_dialogue/test_base.py
+++ b/tests/test_helpers/test_dialogue/test_base.py
@@ -18,7 +18,7 @@
 # ------------------------------------------------------------------------------
 
 """This module contains the tests for the dialogue/base.py module."""
-
+import string
 from typing import Dict, FrozenSet, Optional, Type, cast
 
 import pytest
@@ -1405,6 +1405,9 @@ class TestDialoguesBase:
 
     def test_generate_dialogue_nonce(self):
         """Test the '_generate_dialogue_nonce' method."""
-        assert self.dialogues._dialogue_nonce == 0
-        assert self.dialogues._generate_dialogue_nonce() == 1
-        assert self.dialogues._dialogue_nonce == 1
+        nonce_1 = self.dialogues._generate_dialogue_nonce()
+        assert isinstance(nonce_1, str)
+        assert len(nonce_1) == 64
+        assert all(c in string.hexdigits for c in nonce_1)
+        nonce_2 = self.dialogues._generate_dialogue_nonce()
+        assert nonce_1 != nonce_2, "Nonces are equal."


### PR DESCRIPTION
## Proposed changes

Make the nonce for dialogue reference randomly generated.

We use `secrets`, a Python Standard Library module designed to be cryptographically secure, since it relies on source of randomness provided by the operating system.

https://docs.python.org/3/library/secrets.html

I think that it's enough for modern operating systems, and for our purposes (relatively low scale atm).

Useful resources:
- https://www.2uo.de/myths-about-urandom/
- https://security.stackexchange.com/a/3939/146388
- https://man7.org/linux/man-pages/man2/getrandom.2.html

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
