### PR TITLE
Make 'setup' and 'teardown' of SkillComponent non-abstract method

### DIFF
--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -279,7 +279,6 @@ class SkillComponent(ABC):
         """Get the config of the skill component."""
         return self.configuration.args
 
-    @abstractmethod
     def setup(self) -> None:
         """
         Implement the setup.
@@ -287,7 +286,6 @@ class SkillComponent(ABC):
         :return: None
         """
 
-    @abstractmethod
     def teardown(self) -> None:
         """
         Implement the teardown.
@@ -503,12 +501,6 @@ class Handler(SkillComponent, ABC):
 
 class Model(SkillComponent, ABC):
     """This class implements an abstract model."""
-
-    def setup(self) -> None:
-        """Set the class up."""
-
-    def teardown(self) -> None:
-        """Tear the class down."""
 
     @classmethod
     def parse_module(

--- a/aea/skills/behaviours.py
+++ b/aea/skills/behaviours.py
@@ -39,15 +39,9 @@ class SimpleBehaviour(Behaviour, ABC):
         if act is not None:
             self.act = act  # type: ignore
 
-    def setup(self) -> None:
-        """Set the behaviour up."""
-
     def act(self) -> None:
         """Do the action."""
         raise NotImplementedError  # pragma: no cover
-
-    def teardown(self) -> None:
-        """Tear the behaviour down."""
 
 
 class CompositeBehaviour(Behaviour, ABC):


### PR DESCRIPTION
## Proposed changes

Make 'setup' and 'teardown' of SkillComponent non-abstract method.

This will make the programmatic usage a bit less verbose in case `setup` and `teardown` don't need to be specified. It mostly changes the thing for `Handler` class, since `Model` and `SimpleBehaviour` (but not `Behaviour) already overwrote the methods.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
Not very important PR.