### PR TITLE
add Message.reply helper method

### DIFF
--- a/aea/protocols/base.py
+++ b/aea/protocols/base.py
@@ -94,7 +94,7 @@ class Message:
     @sender.setter
     def sender(self, sender: Address) -> None:
         """Set the sender of the message."""
-        # assert self._sender is None, "Sender already set."
+        assert self._sender is None, "Sender already set."
         self._sender = sender
 
     @property
@@ -212,6 +212,24 @@ class Message:
     def is_set(self, key: str) -> bool:
         """Check value is set for key."""
         return key in self._body
+
+    def reply(self) -> "Message":
+        """
+        Return the same message, but with inverted sender/recipient.
+
+        >>> msg = Message()
+        >>> msg.sender = "sender"
+        >>> msg.to = "to"
+        >>> reply = msg.reply()
+        >>> reply.sender
+        'to'
+        >>> reply.to
+        'sender'
+        """
+        result = Message(**self.body)
+        result.sender = self.to
+        result.to = self.sender
+        return result
 
     def _is_consistent(self) -> bool:  # pylint: disable=no-self-use
         """Check that the data is consistent."""

--- a/aea/protocols/base.py
+++ b/aea/protocols/base.py
@@ -94,7 +94,7 @@ class Message:
     @sender.setter
     def sender(self, sender: Address) -> None:
         """Set the sender of the message."""
-        assert self._sender is None, "Sender already set."
+        # assert self._sender is None, "Sender already set."
         self._sender = sender
 
     @property

--- a/tests/test_mail/test_base.py
+++ b/tests/test_mail/test_base.py
@@ -325,3 +325,14 @@ def test_envelope_skill_id_raises_value_error():
         mock_logger_method.assert_called_with(
             f"URI - {bad_uri} - not a valid skill id."
         )
+
+
+def test_message_reply():
+    """Test Message.reply() method."""
+    msg = Message(foo="bar")
+    msg.sender = "sender"
+    msg.to = "to"
+    reply = msg.reply()
+    assert msg.body == reply.body
+    assert reply.sender == msg.to
+    assert reply.to == msg.sender


### PR DESCRIPTION
## Proposed changes

add `Message.reply` helper method. It should simplify some code in the handlers, when generating a reply to a message.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a