### PR TITLE
[AEA-903] multiplexer cancel recv send loops before disconnecting connections

### DIFF
--- a/aea/helpers/async_utils.py
+++ b/aea/helpers/async_utils.py
@@ -26,7 +26,7 @@ import time
 from asyncio import CancelledError
 from asyncio.events import AbstractEventLoop, TimerHandle
 from asyncio.futures import Future
-from asyncio.tasks import FIRST_COMPLETED, Task
+from asyncio.tasks import FIRST_COMPLETED
 from collections.abc import Iterable
 from contextlib import contextmanager, suppress
 from threading import Thread
@@ -375,20 +375,6 @@ class ThreadedAsyncRunner(Thread):
         logger.debug("Wait thread to join...")
         self.join(10)
         logger.debug("Stopped.")
-
-
-async def cancel_and_wait(task: Optional[Task]) -> Any:
-    """Wait cancelled task and skip CancelledError."""
-    if not task:  # pragma: nocover
-        return
-    try:
-        if task.done():
-            return await task
-
-        task.cancel()
-        return await task
-    except CancelledError as e:
-        return e
 
 
 class AwaitableProc:

--- a/tests/test_helpers/test_async_utils.py
+++ b/tests/test_helpers/test_async_utils.py
@@ -29,7 +29,6 @@ from aea.helpers.async_utils import (
     HandlerItemGetter,
     PeriodicCaller,
     ThreadedAsyncRunner,
-    cancel_and_wait,
     ensure_list,
     ensure_loop,
 )
@@ -215,24 +214,6 @@ async def test_threaded_async_run_cancel_task():
     with pytest.raises(CancelledError):
         task.result()
     assert task.done()
-    runner.stop()
-
-
-@pytest.mark.asyncio
-async def test_cancel_and_wait():
-    """Test task cancel and wait."""
-    loop = asyncio.get_event_loop()
-    task = loop.create_task(asyncio.sleep(1))
-
-    r = await cancel_and_wait(task)
-    assert isinstance(r, asyncio.CancelledError)
-
-    # cancel and wait completed task
-    task = loop.create_task(asyncio.sleep(0))
-    await asyncio.sleep(0.01)
-    assert task.done()
-    r = await cancel_and_wait(task)
-    assert r is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_packages/test_connections/test_oef/test_communication.py
+++ b/tests/test_packages/test_connections/test_oef/test_communication.py
@@ -17,7 +17,6 @@
 #
 # ------------------------------------------------------------------------------
 
-
 """This test module contains the tests for the OEF communication using an OEF."""
 
 import asyncio
@@ -25,6 +24,7 @@ import logging
 import sys
 import time
 import unittest
+from contextlib import suppress
 from typing import Dict, cast
 from unittest import mock
 from unittest.mock import patch
@@ -35,7 +35,6 @@ from oef.query import ConstraintExpr
 import pytest
 
 from aea.common import Address
-from aea.helpers.async_utils import cancel_and_wait
 from aea.helpers.search.models import (
     Attribute,
     Constraint,
@@ -1103,8 +1102,9 @@ async def test_cannot_connect_to_oef():
         mock_logger.assert_any_call(
             "Cannot connect to OEFChannel. Retrying in 5 seconds..."
         )
-
-        await cancel_and_wait(task)
+        with suppress(asyncio.CancelledError):
+            task.cancel()
+            await task
         await oef_connection.disconnect()
 
 


### PR DESCRIPTION
## Proposed changes

multiplexer cancel recv send loops before disconnecting connections

## Fixes

https://github.com/fetchai/agents-aea/issues/1738

fixes issue when multiplexer tries to handle messages in queues but connections alraedy disconnected.
now it stops message processing loops and disconnect connections

## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
