### PR TITLE
[DO NOT MERGE] load_aea_package do not replace modules if exist

### DIFF
--- a/aea/components/base.py
+++ b/aea/components/base.py
@@ -123,9 +123,12 @@ def load_aea_package(configuration: ComponentConfiguration) -> None:
     prefix_author = prefix_root + f".{configuration.author}"
     prefix_pkg_type = prefix_author + f".{configuration.component_type.to_plural()}"
     prefix_pkg = prefix_pkg_type + f".{configuration.name}"
-    sys.modules[prefix_root] = types.ModuleType(prefix_root)
-    sys.modules[prefix_author] = types.ModuleType(prefix_author)
-    sys.modules[prefix_pkg_type] = types.ModuleType(prefix_pkg_type)
+    if prefix_root not in sys.modules:
+        sys.modules[prefix_root] = types.ModuleType(prefix_root)
+    if prefix_author not in sys.modules:
+        sys.modules[prefix_author] = types.ModuleType(prefix_author)
+    if prefix_pkg_type not in sys.modules:
+        sys.modules[prefix_pkg_type] = types.ModuleType(prefix_pkg_type)
 
     for subpackage_init_file in dir_.rglob("__init__.py"):
         parent_dir = subpackage_init_file.parent


### PR DESCRIPTION
## Proposed changes

fix for existing module replacement in load_aea_package.

## Fixes

fix for existing module replacement in load_aea_package.
cause it replaces already imported module

## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist


- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules