### PR TITLE
AEA-928 Allow finer-grained overwrite of component configuration from aea-config.yaml.

### DIFF
--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -1372,18 +1372,13 @@ class AEABuilder:
                         logging.Logger, make_logger(configuration, agent_name)
                     )
             else:
-                configuration = deepcopy(configuration)
-                configuration.update(
-                    self._custom_component_configurations.get(
-                        configuration.component_id, {}
-                    )
-                )
                 if configuration.is_abstract_component:
                     load_aea_package(configuration)
                     continue
-                _logger = make_logger(configuration, agent_name)
+                new_configuration = self._overwrite_custom_configuration(configuration)
+                _logger = make_logger(new_configuration, agent_name)
                 component = load_component_from_config(
-                    configuration, logger=_logger, **kwargs
+                    new_configuration, logger=_logger, **kwargs
                 )
 
             resources.add_component(component)
@@ -1396,6 +1391,23 @@ class AEABuilder:
                 "- added a private key manually.\n"
                 "Please call 'reset() if you want to build another agent."
             )
+
+    def _overwrite_custom_configuration(self, configuration: ComponentConfiguration):
+        """
+        Overwrite custom configurations.
+
+        It deep-copies the configuration, to avoid undesired side-effects.
+
+        :param configuration: the configuration object.
+        :param custom_config: the configurations to apply.
+        :return: the new configuration instance.
+        """
+        new_configuration = deepcopy(configuration)
+        custom_config = self._custom_component_configurations.get(
+            new_configuration.component_id, {}
+        )
+        new_configuration.update(custom_config)
+        return new_configuration
 
 
 def make_logger(

--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -1372,10 +1372,10 @@ class AEABuilder:
                         logging.Logger, make_logger(configuration, agent_name)
                     )
             else:
-                if configuration.is_abstract_component:
+                new_configuration = self._overwrite_custom_configuration(configuration)
+                if new_configuration.is_abstract_component:
                     load_aea_package(configuration)
                     continue
-                new_configuration = self._overwrite_custom_configuration(configuration)
                 _logger = make_logger(new_configuration, agent_name)
                 component = load_component_from_config(
                     new_configuration, logger=_logger, **kwargs

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -53,6 +53,7 @@ from packaging.version import Version
 
 from aea.__version__ import __version__ as __aea_version__
 from aea.exceptions import enforce
+from aea.helpers.base import merge_update
 from aea.helpers.ipfs.base import IPFSHashOnly
 
 
@@ -1058,10 +1059,13 @@ class ConnectionConfig(ComponentConfiguration):
         """
         Update configuration with other data.
 
-        :param data: the data to replace.
+        This method does side-effect on the configuration object.
+
+        :param data: the data to populate or replace.
         :return: None
         """
-        self.config = data.get("config", self.config)
+        new_config = data.get("config", {})
+        merge_update(self.config, new_config)
 
 
 class ProtocolConfig(ComponentConfiguration):
@@ -1318,18 +1322,34 @@ class SkillConfig(ComponentConfiguration):
         :param data: the data to replace.
         :return: None
         """
-        for behaviour_id, behaviour_data in data.get("behaviours", {}).items():
-            behaviour_config = SkillComponentConfiguration.from_json(behaviour_data)
-            self.behaviours.update(behaviour_id, behaviour_config)
 
-        for handler_id, handler_data in data.get("handlers", {}).items():
-            handler_config = SkillComponentConfiguration.from_json(handler_data)
-            self.handlers.update(handler_id, handler_config)
+        def _update_skill_component_config(type_plural: str, data: Dict):
+            """
+            Update skill component configurations with new data.
 
-        for model_id, model_data in data.get("models", {}).items():
-            model_config = SkillComponentConfiguration.from_json(model_data)
-            self.models.update(model_id, model_config)
+            Also check that there are not undeclared components.
+            """
+            registry: CRUDCollection[SkillComponentConfiguration] = getattr(
+                self, type_plural
+            )
+            new_component_config = data.get(type_plural, {})
+            all_component_names = dict(registry.read_all())
 
+            new_skill_component_names = set(new_component_config.keys()).difference(
+                set(all_component_names.keys())
+            )
+            if len(new_skill_component_names) > 0:
+                raise ValueError(
+                    f"The custom configuration for skill {self.public_id} includes new {type_plural}: {new_skill_component_names}. This is not allowed."
+                )
+
+            for component_name, component_data in data.get(type_plural, {}).items():
+                component_config = registry.read(component_name)
+                merge_update(component_config.args, component_data.get("args", {}))
+
+        _update_skill_component_config("behaviours", data)
+        _update_skill_component_config("handlers", data)
+        _update_skill_component_config("models", data)
         self.is_abstract = data.get("is_abstract", self.is_abstract)
 
 
@@ -1625,10 +1645,10 @@ class AgentConfig(PackageConfiguration):
         component_configurations = {}
         for config in obj.get("component_configurations", []):
             tmp = deepcopy(config)
-            name = tmp.pop("name")
-            author = tmp.pop("author")
-            version = tmp.pop("version")
-            type_ = tmp.pop("type")
+            name = tmp["name"]
+            author = tmp["author"]
+            version = tmp["version"]
+            type_ = tmp["type"]
             component_id = ComponentId(
                 ComponentType(type_), PublicId(author, name, version)
             )

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -53,7 +53,7 @@ from packaging.version import Version
 
 from aea.__version__ import __version__ as __aea_version__
 from aea.exceptions import enforce
-from aea.helpers.base import merge_update
+from aea.helpers.base import recursive_update
 from aea.helpers.ipfs.base import IPFSHashOnly
 
 
@@ -1065,7 +1065,7 @@ class ConnectionConfig(ComponentConfiguration):
         :return: None
         """
         new_config = data.get("config", {})
-        merge_update(self.config, new_config)
+        recursive_update(self.config, new_config)
 
 
 class ProtocolConfig(ComponentConfiguration):
@@ -1347,7 +1347,7 @@ class SkillConfig(ComponentConfiguration):
                 component_config = cast(
                     SkillComponentConfiguration, registry.read(component_name)
                 )
-                merge_update(component_config.args, component_data.get("args", {}))
+                recursive_update(component_config.args, component_data.get("args", {}))
 
         _update_skill_component_config("behaviours", data)
         _update_skill_component_config("handlers", data)

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -753,7 +753,6 @@ class PackageConfiguration(Configuration, ABC):
 
     default_configuration_filename: str
     package_type: PackageType
-    configurable_fields: Set[str] = set()
 
     def __init__(
         self,
@@ -930,7 +929,6 @@ class ConnectionConfig(ComponentConfiguration):
 
     default_configuration_filename = DEFAULT_CONNECTION_CONFIG_FILE
     package_type = PackageType.CONNECTION
-    configurable_fields = {"config"}
 
     def __init__(
         self,
@@ -1166,7 +1164,6 @@ class SkillConfig(ComponentConfiguration):
 
     default_configuration_filename = DEFAULT_SKILL_CONFIG_FILE
     package_type = PackageType.SKILL
-    configurable_fields = {"handlers", "behaviours", "models", "is_abstract"}
 
     def __init__(
         self,
@@ -1518,16 +1515,7 @@ class AgentConfig(PackageConfiguration):
 
     def component_configurations_json(self) -> List[OrderedDict]:
         """Get the component configurations in JSON format."""
-        return [
-            OrderedDict(
-                name=component_id.name,
-                author=component_id.author,
-                version=component_id.version,
-                type=component_id.component_type.value,
-                **obj,
-            )
-            for component_id, obj in self.component_configurations.items()
-        ]
+        return list(map(OrderedDict, self.component_configurations.values()))
 
     @property
     def json(self) -> Dict:

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -1344,7 +1344,9 @@ class SkillConfig(ComponentConfiguration):
                 )
 
             for component_name, component_data in data.get(type_plural, {}).items():
-                component_config = registry.read(component_name)
+                component_config = cast(
+                    SkillComponentConfiguration, registry.read(component_name)
+                )
                 merge_update(component_config.args, component_data.get("args", {}))
 
         _update_skill_component_config("behaviours", data)

--- a/aea/configurations/loader.py
+++ b/aea/configurations/loader.py
@@ -51,6 +51,11 @@ from aea.helpers.base import yaml_dump, yaml_dump_all, yaml_load, yaml_load_all
 _CUR_DIR = os.path.dirname(inspect.getfile(inspect.currentframe()))  # type: ignore
 _SCHEMAS_DIR = os.path.join(_CUR_DIR, "schemas")
 
+_PREFIX_BASE_CONFIGURABLE_PARTS = "base"
+_SCHEMAS_CONFIGURABLE_PARTS_DIRNAME = "configurable_parts"
+_POSTFIX_CUSTOM_CONFIG = "-custom_config.json"
+STARTING_INDEX_CUSTOM_CONFIGS = 1
+
 T = TypeVar(
     "T",
     AgentConfig,
@@ -83,12 +88,12 @@ def _get_path_to_custom_config_schema_from_type(component_type: ComponentType) -
     :param component_type: a component type.
     :return: the path to the JSON schema file.
     """
-    path_prefix: Path = Path(_SCHEMAS_DIR) / "configurable_parts"
+    path_prefix: Path = Path(_SCHEMAS_DIR) / _SCHEMAS_CONFIGURABLE_PARTS_DIRNAME
     if component_type in {ComponentType.SKILL, ComponentType.CONNECTION}:
         filename_prefix = component_type.value
     else:
-        filename_prefix = "base"
-    full_path = path_prefix / (filename_prefix + "-custom_config.json")
+        filename_prefix = _PREFIX_BASE_CONFIGURABLE_PARTS
+    full_path = path_prefix / (filename_prefix + _POSTFIX_CUSTOM_CONFIG)
     return str(full_path)
 
 
@@ -298,7 +303,9 @@ class ConfigLoader(Generic[T], BaseConfigLoader):
         """
         component_configurations: Dict[ComponentId, Dict] = {}
         # load the other components.
-        for i, component_configuration_json in enumerate(configuration_file_jsons[1:]):
+        for i, component_configuration_json in enumerate(
+            configuration_file_jsons[STARTING_INDEX_CUSTOM_CONFIGS:]
+        ):
             component_id = self._process_component_section(
                 i, component_configuration_json
             )

--- a/aea/configurations/loader.py
+++ b/aea/configurations/loader.py
@@ -326,7 +326,7 @@ class ConfigLoader(Generic[T], BaseConfigLoader):
         yaml_dump(result, file_pointer)
 
     def _process_component_section(
-        self, i: int, component_configuration_json: Dict
+        self, component_index: int, component_configuration_json: Dict
     ) -> ComponentId:
         """
         Process a component configuration in an agent configuration file.
@@ -336,12 +336,12 @@ class ConfigLoader(Generic[T], BaseConfigLoader):
         - validate the component configuration
         - check that there are only configurable fields
 
-        :param i: the index of the component in the file.
+        :param component_index: the index of the component in the file.
         :param component_configuration_json: the JSON object.
         :return: the processed component configuration.
         """
         component_id = self._split_component_id_and_config(
-            i, component_configuration_json
+            component_index, component_configuration_json
         )
         self._validate_component_configuration(
             component_id, component_configuration_json
@@ -350,12 +350,12 @@ class ConfigLoader(Generic[T], BaseConfigLoader):
 
     @staticmethod
     def _split_component_id_and_config(
-        i: int, component_configuration_json: Dict
+        component_index: int, component_configuration_json: Dict
     ) -> ComponentId:
         """
         Split component id and configuration.
 
-        :param i: the position of the component configuration in the agent config file..
+        :param component_index: the position of the component configuration in the agent config file..
         :param component_configuration_json: the JSON object to process.
         :return: the component id and the configuration object.
         :raises ValueError: if the component id cannot be extracted.
@@ -366,7 +366,7 @@ class ConfigLoader(Generic[T], BaseConfigLoader):
         )
         if len(missing_fields) > 0:
             raise ValueError(
-                f"There are missing fields in component id {i + 1}: {missing_fields}."
+                f"There are missing fields in component id {component_index + 1}: {missing_fields}."
             )
         component_name = component_configuration_json["name"]
         component_author = component_configuration_json["author"]

--- a/aea/configurations/schemas/configurable_parts/base-custom_config.json
+++ b/aea/configurations/schemas/configurable_parts/base-custom_config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Schema for the configurable part of a skill configuration in the agent configuration file.",
+  "description": "Base schema for a custom component configuration in the agent configuration file.",
   "additionalProperties": false,
   "required": [
     "name",
@@ -20,18 +20,6 @@
     },
     "type": {
       "$ref": "definitions.json#/definitions/component_type"
-    },
-    "handlers": {
-      "$ref": "skill-config_schema.json#/definitions/handlers"
-    },
-    "behaviours": {
-      "$ref": "skill-config_schema.json#/definitions/behaviours"
-    },
-    "models": {
-      "$ref": "skill-config_schema.json#/definitions/models"
-    },
-    "is_abstract": {
-      "$ref": "skill-config_schema.json#/properties/is_abstract"
     }
   }
 }

--- a/aea/configurations/schemas/configurable_parts/connection-custom_config.json
+++ b/aea/configurations/schemas/configurable_parts/connection-custom_config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Schema for the configurable part of a skill configuration in the agent configuration file.",
+  "description": "Schema for the configurable part of a connection configuration in the agent configuration file.",
   "additionalProperties": false,
   "required": [
     "name",
@@ -21,17 +21,8 @@
     "type": {
       "$ref": "definitions.json#/definitions/component_type"
     },
-    "handlers": {
-      "$ref": "skill-config_schema.json#/definitions/handlers"
-    },
-    "behaviours": {
-      "$ref": "skill-config_schema.json#/definitions/behaviours"
-    },
-    "models": {
-      "$ref": "skill-config_schema.json#/definitions/models"
-    },
-    "is_abstract": {
-      "$ref": "skill-config_schema.json#/properties/is_abstract"
+    "config": {
+      "type": "object"
     }
   }
 }

--- a/aea/configurations/schemas/configurable_parts/skill-custom_config.json
+++ b/aea/configurations/schemas/configurable_parts/skill-custom_config.json
@@ -22,16 +22,82 @@
       "$ref": "definitions.json#/definitions/component_type"
     },
     "handlers": {
-      "$ref": "skill-config_schema.json#/definitions/handlers"
+      "$ref": "#/definitions/handlers"
     },
     "behaviours": {
-      "$ref": "skill-config_schema.json#/definitions/behaviours"
+      "$ref": "#/definitions/behaviours"
     },
     "models": {
-      "$ref": "skill-config_schema.json#/definitions/models"
+      "$ref": "#/definitions/models"
     },
     "is_abstract": {
-      "$ref": "skill-config_schema.json#/properties/is_abstract"
+      "$ref": "#/properties/is_abstract"
+    }
+  },
+  "definitions": {
+    "handlers": {
+      "type": "object",
+      "additionalProperties": false,
+      "uniqueItems": true,
+      "patternProperties": {
+        "^[^\\d\\W]\\w*\\Z": {
+          "$ref": "#/definitions/handler"
+        }
+      }
+    },
+    "behaviours": {
+      "type": "object",
+      "uniqueItems": true,
+      "patternProperties": {
+        "^[^\\d\\W]\\w*\\Z": {
+          "$ref": "#/definitions/behaviour"
+        }
+      }
+    },
+    "models": {
+      "type": "object",
+      "uniqueItems": true,
+      "patternProperties": {
+        "^[^\\d\\W]\\w*\\Z": {
+          "$ref": "#/definitions/model"
+        }
+      }
+    },
+    "behaviour": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "args"
+      ],
+      "properties": {
+        "args": {
+          "type": "object"
+        }
+      }
+    },
+    "handler": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "args"
+      ],
+      "properties": {
+        "args": {
+          "type": "object"
+        }
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "args"
+      ],
+      "properties": {
+        "args": {
+          "type": "object"
+        }
+      }
     }
   }
 }

--- a/aea/configurations/schemas/configurable_parts/skill-custom_config.json
+++ b/aea/configurations/schemas/configurable_parts/skill-custom_config.json
@@ -31,7 +31,7 @@
       "$ref": "#/definitions/models"
     },
     "is_abstract": {
-      "$ref": "#/properties/is_abstract"
+      "$ref": "skill-config_schema.json#/properties/is_abstract"
     }
   },
   "definitions": {

--- a/aea/configurations/schemas/configurable_parts/skill-custom_config.json
+++ b/aea/configurations/schemas/configurable_parts/skill-custom_config.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Schema for the configurable part of a skill configuration file.",
+  "additionalProperties": false,
+  "required": [
+    "name",
+    "author",
+    "version",
+    "type"
+  ],
+  "properties": {
+    "name": {
+      "$ref": "definitions.json#/definitions/resource_name"
+    },
+    "author": {
+      "$ref": "definitions.json#/definitions/author"
+    },
+    "version": {
+      "$ref": "definitions.json#/definitions/package_version"
+    },
+    "type": {
+      "$ref": "definitions.json#/definitions/component_type"
+    },
+    "handlers": {
+      "$ref": "skill-config_schema.json#/definitions/handlers"
+    },
+    "behaviours": {
+      "$ref": "skill-config_schema.json#/definitions/behaviours"
+    },
+    "models": {
+      "$ref": "skill-config_schema.json#/definitions/models"
+    },
+    "is_abstract": {
+      "$ref": "skill-config_schema.json#/properties/is_abstract"
+    }
+  }
+}

--- a/aea/configurations/schemas/skill-config_schema.json
+++ b/aea/configurations/schemas/skill-config_schema.json
@@ -63,6 +63,26 @@
       }
     },
     "handlers": {
+      "$ref": "#/definitions/handlers"
+    },
+    "behaviours": {
+      "$ref": "#/definitions/behaviours"
+    },
+    "models": {
+      "$ref": "#/definitions/models"
+    },
+    "dependencies": {
+      "$ref": "definitions.json#/definitions/dependencies"
+    },
+    "description": {
+      "$ref": "definitions.json#/definitions/description"
+    },
+    "is_abstract": {
+      "type": "boolean"
+    }
+  },
+  "definitions": {
+    "handlers": {
       "type": "object",
       "additionalProperties": false,
       "uniqueItems": true,
@@ -90,17 +110,6 @@
         }
       }
     },
-    "dependencies": {
-      "$ref": "definitions.json#/definitions/dependencies"
-    },
-    "description": {
-      "$ref": "definitions.json#/definitions/description"
-    },
-    "is_abstract": {
-      "type": "boolean"
-    }
-  },
-  "definitions": {
     "behaviour": {
       "type": "object",
       "additionalProperties": false,

--- a/aea/helpers/base.py
+++ b/aea/helpers/base.py
@@ -390,3 +390,38 @@ def exception_log_and_reraise(log_method: Callable, message: str):
     except BaseException as e:  # pylint: disable=broad-except  # pragma: no cover  # generic code
         log_method(message.format(e))
         raise
+
+
+def merge_update(to_update: Dict, new_values: Dict):
+    """
+    Merge two dictionaries by replacing conflicts with the new values.
+
+    It does side-effects to the first dictionary.
+
+    >>> to_update = dict(a=1, b=2, subdict=dict(subfield1=1))
+    >>> new_values = dict(b=3, c=4, subdict=dict(subfield2=2))
+    >>> merge_update(to_update, new_values)
+    >>> to_update
+    {'a': 1, 'b': 3, 'subdict': {'subfield1': 1, 'subfield2': 2}, 'c': 4}
+
+    :param to_update: the dictionary to update.
+    :param new_values: the dictionary of new values to add/replace.
+    :return: the merged dictionary.
+    """
+    for key, value in new_values.items():
+        if key not in to_update:
+            to_update[key] = value
+            continue
+
+        value_to_update = to_update[key]
+        value_type = type(value)
+        value_to_update_type = type(value_to_update)
+        if value_type != value_to_update_type:
+            raise ValueError(
+                f"Trying to replace value '{value}' with value '{value_to_update}' which is of different type."
+            )
+
+        if value_type == value_to_update_type == dict:
+            merge_update(value_to_update, value)
+        else:
+            to_update[key] = value

--- a/aea/helpers/base.py
+++ b/aea/helpers/base.py
@@ -392,36 +392,37 @@ def exception_log_and_reraise(log_method: Callable, message: str):
         raise
 
 
-def merge_update(to_update: Dict, new_values: Dict):
+def recursive_update(to_update: Dict, new_values: Dict):
     """
-    Merge two dictionaries by replacing conflicts with the new values.
+    Update a dictionary by replacing conflicts with the new values.
 
     It does side-effects to the first dictionary.
 
     >>> to_update = dict(a=1, b=2, subdict=dict(subfield1=1))
-    >>> new_values = dict(b=3, c=4, subdict=dict(subfield2=2))
-    >>> merge_update(to_update, new_values)
+    >>> new_values = dict(b=3, subdict=dict(subfield1=2))
+    >>> recursive_update(to_update, new_values)
     >>> to_update
-    {'a': 1, 'b': 3, 'subdict': {'subfield1': 1, 'subfield2': 2}, 'c': 4}
+    {'a': 1, 'b': 3, 'subdict': {'subfield1': 2}}
 
     :param to_update: the dictionary to update.
-    :param new_values: the dictionary of new values to add/replace.
-    :return: the merged dictionary.
+    :param new_values: the dictionary of new values to replace.
+    :return: the updated dictionary.
     """
     for key, value in new_values.items():
         if key not in to_update:
-            to_update[key] = value
-            continue
+            raise ValueError(
+                f"Key '{key}' is not contained in the dictionary to update."
+            )
 
         value_to_update = to_update[key]
         value_type = type(value)
         value_to_update_type = type(value_to_update)
         if value_type != value_to_update_type:
             raise ValueError(
-                f"Trying to replace value '{value}' with value '{value_to_update}' which is of different type."
+                f"Trying to replace value '{value_to_update}' with value '{value}' which is of different type."
             )
 
         if value_type == value_to_update_type == dict:
-            merge_update(value_to_update, value)
+            recursive_update(value_to_update, value)
         else:
             to_update[key] = value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,6 +205,8 @@ DUMMY_PROTOCOL_PUBLIC_ID = PublicId("dummy_author", "dummy", "0.1.0")
 DUMMY_CONNECTION_PUBLIC_ID = PublicId("dummy_author", "dummy", "0.1.0")
 DUMMY_SKILL_PUBLIC_ID = PublicId("dummy_author", "dummy", "0.1.0")
 
+DUMMY_SKILL_PATH = os.path.join(CUR_PATH, "data", "dummy_skill", SKILL_YAML)
+
 MAX_FLAKY_RERUNS = 3
 MAX_FLAKY_RERUNS_ETH = 1
 MAX_FLAKY_RERUNS_INTEGRATION = 1
@@ -278,7 +280,7 @@ skill_config_files = [
     os.path.join(FETCHAI_PREF, "skills", "thermometer_client", SKILL_YAML),
     os.path.join(FETCHAI_PREF, "skills", "weather_client", SKILL_YAML),
     os.path.join(FETCHAI_PREF, "skills", "weather_station", SKILL_YAML),
-    os.path.join(CUR_PATH, "data", "dummy_skill", SKILL_YAML),
+    DUMMY_SKILL_PATH,
     os.path.join(CUR_PATH, "data", "dummy_aea", "skills", "dummy", SKILL_YAML),
     os.path.join(CUR_PATH, "data", "dependencies_skill", SKILL_YAML),
     os.path.join(CUR_PATH, "data", "exception_skill", SKILL_YAML),

--- a/tests/data/aea-config.example_multipage.yaml
+++ b/tests/data/aea-config.example_multipage.yaml
@@ -39,22 +39,18 @@ behaviours:
     args:
       behaviour_arg_1: 1
       behaviour_arg_2: '2'
-    class_name: DummyBehaviour
 handlers:
   dummy:
     args:
       handler_arg_1: 1
       handler_arg_2: '2'
-    class_name: DummyHandler
   dummy_internal:
     args:
       handler_arg_1: 1
       handler_arg_2: '2'
-    class_name: DummyInternalHandler
 models:
   dummy:
     args:
       model_arg_1: 1
       model_arg_2: '2'
-    class_name: DummyModel
 ...

--- a/tests/test_aea_builder.py
+++ b/tests/test_aea_builder.py
@@ -616,18 +616,15 @@ class TestFromAEAProjectWithCustomSkillConfig(AEATestCase):
         behaviours:
           dummy:
             args:
-            {indent(yaml.dump(self.expected_behaviour_args), "  ")}
-            class_name: DummyBehaviour
+            {indent(yaml.dump(self.new_behaviour_args), "  ")}
         handlers:
           dummy:
             args:
-            {indent(yaml.dump(self.expected_handler_args), "  ")}
-            class_name: DummyHandler
+            {indent(yaml.dump(self.new_handler_args), "  ")}
         models:
           dummy:
             args:
-            {indent(yaml.dump(self.expected_model_args), "  ")}
-            class_name: DummyModel
+            {indent(yaml.dump(self.new_model_args), "  ")}
         ...
         """
         )
@@ -635,9 +632,9 @@ class TestFromAEAProjectWithCustomSkillConfig(AEATestCase):
 
     def test_from_project(self):
         """Test builder set from project dir."""
-        self.expected_behaviour_args = {"behaviour_arg_1": 42}
-        self.expected_handler_args = {"handler_arg_1": 42}
-        self.expected_model_args = {"model_arg_1": 42}
+        self.new_behaviour_args = {"behaviour_arg_1": 42}
+        self.new_handler_args = {"handler_arg_1": 42}
+        self.new_model_args = {"model_arg_1": 42}
         self._add_dummy_skill_config()
         builder = AEABuilder.from_aea_project(Path(self._get_cwd()))
         with cd(self._get_cwd()):
@@ -647,11 +644,11 @@ class TestFromAEAProjectWithCustomSkillConfig(AEATestCase):
             PublicId("dummy_author", "dummy", "0.1.0")
         )
         dummy_behaviour = dummy_skill.behaviours["dummy"]
-        assert dummy_behaviour.config == self.expected_behaviour_args
+        assert dummy_behaviour.config == {"behaviour_arg_1": 42, "behaviour_arg_2": "2"}
         dummy_handler = dummy_skill.handlers["dummy"]
-        assert dummy_handler.config == self.expected_handler_args
+        assert dummy_handler.config == {"handler_arg_1": 42, "handler_arg_2": "2"}
         dummy_model = dummy_skill.models["dummy"]
-        assert dummy_model.config == self.expected_model_args
+        assert dummy_model.config == {"model_arg_1": 42, "model_arg_2": "2"}
 
 
 class TestFromAEAProjectMakeSkillAbstract(AEATestCase):

--- a/tests/test_configurations/test_base.py
+++ b/tests/test_configurations/test_base.py
@@ -208,20 +208,20 @@ class TestSkillConfig:
 
         dummy_behaviour = skill_config.behaviours.read("dummy")
         expected_dummy_behaviour_args = copy(dummy_behaviour.args)
-        expected_dummy_behaviour_args["new_arg"] = 1
+        expected_dummy_behaviour_args["behaviour_arg_1"] = 42
 
         dummy_handler = skill_config.handlers.read("dummy")
         expected_dummy_handler_args = copy(dummy_handler.args)
-        expected_dummy_handler_args["new_arg"] = 1
+        expected_dummy_handler_args["handler_arg_1"] = 42
 
         dummy_model = skill_config.models.read("dummy")
         expected_dummy_model_args = copy(dummy_model.args)
-        expected_dummy_model_args["new_arg"] = 1
+        expected_dummy_model_args["model_arg_1"] = 42
 
         new_configurations = {
-            "behaviours": {"dummy": {"args": dict(new_arg=1)}},
-            "handlers": {"dummy": {"args": dict(new_arg=1)}},
-            "models": {"dummy": {"args": dict(new_arg=1)}},
+            "behaviours": {"dummy": {"args": dict(behaviour_arg_1=42)}},
+            "handlers": {"dummy": {"args": dict(handler_arg_1=42)}},
+            "models": {"dummy": {"args": dict(model_arg_1=42)}},
         }
         skill_config.update(new_configurations)
 
@@ -744,3 +744,12 @@ def test_package_version_lt():
     v2 = PackageVersion("0.2.0")
     v3 = PackageVersion("latest")
     assert v1 < v2 < v3
+
+
+def test_configuration_class():
+    """Test the attribute 'configuration class' of PackageType."""
+    assert PackageType.PROTOCOL.configuration_class() == ProtocolConfig
+    assert PackageType.CONNECTION.configuration_class() == ConnectionConfig
+    assert PackageType.CONTRACT.configuration_class() == ContractConfig
+    assert PackageType.SKILL.configuration_class() == SkillConfig
+    assert PackageType.AGENT.configuration_class() == AgentConfig

--- a/tests/test_configurations/test_base.py
+++ b/tests/test_configurations/test_base.py
@@ -19,6 +19,7 @@
 
 """This module contains the tests for the aea.configurations.base module."""
 import re
+from copy import copy
 from pathlib import Path
 from unittest import TestCase, mock
 
@@ -52,6 +53,7 @@ from aea.configurations.loader import ConfigLoaders, load_component_configuratio
 
 from tests.conftest import (
     AUTHOR,
+    DUMMY_SKILL_PATH,
     ROOT_DIR,
     agent_config_files,
     connection_config_files,
@@ -200,6 +202,37 @@ class TestSkillConfig:
 
     def test_update_method(self):
         """Test the update method."""
+        skill_config_path = Path(DUMMY_SKILL_PATH)
+        loader = ConfigLoaders.from_package_type(PackageType.SKILL)
+        skill_config = loader.load(skill_config_path.open())
+
+        dummy_behaviour = skill_config.behaviours.read("dummy")
+        expected_dummy_behaviour_args = copy(dummy_behaviour.args)
+        expected_dummy_behaviour_args["new_arg"] = 1
+
+        dummy_handler = skill_config.handlers.read("dummy")
+        expected_dummy_handler_args = copy(dummy_handler.args)
+        expected_dummy_handler_args["new_arg"] = 1
+
+        dummy_model = skill_config.models.read("dummy")
+        expected_dummy_model_args = copy(dummy_model.args)
+        expected_dummy_model_args["new_arg"] = 1
+
+        new_configurations = {
+            "behaviours": {"dummy": {"args": dict(new_arg=1)}},
+            "handlers": {"dummy": {"args": dict(new_arg=1)}},
+            "models": {"dummy": {"args": dict(new_arg=1)}},
+        }
+        skill_config.update(new_configurations)
+
+        assert (
+            expected_dummy_behaviour_args == skill_config.behaviours.read("dummy").args
+        )
+        assert expected_dummy_handler_args == skill_config.handlers.read("dummy").args
+        assert expected_dummy_model_args == skill_config.models.read("dummy").args
+
+    def test_update_method_raises_error_if_skill_component_not_allowed(self):
+        """Test that we raise error if the custom configuration contain unexpected skill components."""
         skill_config_path = Path(
             ROOT_DIR, "aea", "skills", "error", DEFAULT_SKILL_CONFIG_FILE
         )
@@ -210,14 +243,12 @@ class TestSkillConfig:
             "handlers": {"new_handler": {"args": {}, "class_name": "SomeClass"}},
             "models": {"new_model": {"args": {}, "class_name": "SomeClass"}},
         }
-        skill_config.update(new_configurations)
 
-        new_behaviour = skill_config.behaviours.read("new_behaviour")
-        assert new_behaviour.json == new_configurations["behaviours"]["new_behaviour"]
-        new_handler = skill_config.handlers.read("new_handler")
-        assert new_handler.json == new_configurations["handlers"]["new_handler"]
-        new_model = skill_config.models.read("new_model")
-        assert new_model.json == new_configurations["models"]["new_model"]
+        with pytest.raises(
+            ValueError,
+            match="The custom configuration for skill fetchai/error:0.6.0 includes new behaviours: {'new_behaviour'}. This is not allowed.",
+        ):
+            skill_config.update(new_configurations)
 
 
 class TestAgentConfig:

--- a/tests/test_helpers/test_base.py
+++ b/tests/test_helpers/test_base.py
@@ -38,6 +38,7 @@ from aea.helpers.base import (
     load_env_file,
     load_module,
     locate,
+    recursive_update,
     retry_decorator,
     send_control_c,
     try_decorator,
@@ -209,7 +210,7 @@ def test_send_control_c():
     # because o/w pytest would be stopped.
     process = Popen(  # nosec
         ["timeout" if platform.system() == "Windows" else "sleep", "5"],
-        **win_popen_kwargs()
+        **win_popen_kwargs(),
     )
     time.sleep(0.001)
     send_control_c(process)
@@ -241,3 +242,51 @@ def test_yaml_dump_all_load_all():
 
     f.seek(0)
     assert yaml_load_all(f) == data
+
+
+def test_recursive_update_no_recursion():
+    """Test the 'recursive update' utility, in the case there's no recursion."""
+    to_update = dict(not_updated=0, an_integer=1, a_list=[1, 2, 3], a_tuple=(1, 2, 3))
+
+    new_integer, new_list, new_tuple = 2, [3], (3,)
+    new_values = dict(an_integer=new_integer, a_list=new_list, a_tuple=new_tuple)
+    recursive_update(to_update, new_values)
+    assert to_update == dict(
+        not_updated=0, an_integer=new_integer, a_list=new_list, a_tuple=new_tuple
+    )
+
+
+def test_recursive_update_with_recursion():
+    """Test the 'recursive update' utility with recursion."""
+    # here we try to update an integer and add a new value
+    to_update = dict(subdict=dict(to_update=1))
+    new_values = dict(subdict=dict(to_update=2))
+
+    recursive_update(to_update, new_values)
+    assert to_update == dict(subdict=dict(to_update=2))
+
+
+def test_recursive_update_negative_different_type():
+    """Test the 'recursive update' utility, when the types are different."""
+    # here we try to update an integer with a boolean - it raises error.
+    to_update = dict(subdict=dict(to_update=1))
+    new_values = dict(subdict=dict(to_update=False))
+
+    with pytest.raises(
+        ValueError,
+        match=f"Trying to replace value '1' with value 'False' which is of different type.",
+    ):
+        recursive_update(to_update, new_values)
+
+
+def test_recursive_update_negative_unknown_field():
+    """Test the 'recursive update' utility, when there are unknown fields."""
+    # here we try to update an integer with a boolean - it raises error.
+    to_update = dict(subdict=dict(field=1))
+    new_values = dict(subdict=dict(new_field=False))
+
+    with pytest.raises(
+        ValueError,
+        match=f"Key 'new_field' is not contained in the dictionary to update.",
+    ):
+        recursive_update(to_update, new_values)


### PR DESCRIPTION
## Proposed changes

Currently, it is not possible to overwrite configurations _only_ for specific fields from the `aea-config.yaml` file, as could be done with `aea set`.

This PR allows that. (TODO: add an example)

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a