### PR TITLE
[DO NOT MERGE] CI Send remaining funds back to faucet

### DIFF
--- a/tests/test_crypto/test_fetchai.py
+++ b/tests/test_crypto/test_fetchai.py
@@ -647,10 +647,11 @@ def test_execute_shell_command(mock_api_call):
 
 
 def send_remaining_funds_back_to_faucet(account: FetchAICrypto):
-    """Sends remainind funds back to faucet"""
+    """Sends remaining funds back to faucet"""
     faucet_address = "fetch193vvag846gz3pt3q0mdjuxn0s5jrt39fsjrays"
     fetchai_api = FetchAIApi(**FETCHAI_TESTNET_CONFIG)
     balance = fetchai_api.get_balance(account.address)
+    assert balance is not None, "balance is of type None"
 
     tx_fee = 1000
     amount = balance - tx_fee

--- a/tests/test_crypto/test_fetchai.py
+++ b/tests/test_crypto/test_fetchai.py
@@ -654,9 +654,7 @@ def send_remaining_funds_back_to_faucet(account: FetchAICrypto):
 
     tx_fee = 1000
     amount = balance - tx_fee
-    nonce = FetchAIApi.generate_tx_nonce(
-        seller=account.address, client=faucet_address
-    )
+    nonce = FetchAIApi.generate_tx_nonce(seller=account.address, client=faucet_address)
     transfer_transaction = fetchai_api.get_transfer_transaction(
         sender_address=account.address,
         destination_address=faucet_address,

--- a/tests/test_crypto/test_fetchai.py
+++ b/tests/test_crypto/test_fetchai.py
@@ -645,6 +645,7 @@ def test_execute_shell_command(mock_api_call):
     res = cosmos_api._execute_shell_command(["test", "command"])
     assert res == {"SOME": "RESULT"}
 
+
 def send_remaining_funds_back_to_faucet(account: FetchAICrypto):
     """Sends remainind funds back to faucet"""
     faucet_address = "fetch193vvag846gz3pt3q0mdjuxn0s5jrt39fsjrays"
@@ -696,6 +697,7 @@ def send_remaining_funds_back_to_faucet(account: FetchAICrypto):
     )
     assert is_valid, "Failed to settle tx correctly!"
     assert tx == transaction_receipt, "Should be same!"
+
 
 def check_balance_0(account: FetchAICrypto):
     """Check if account balance is 0"""

--- a/tests/test_crypto/test_fetchai.py
+++ b/tests/test_crypto/test_fetchai.py
@@ -180,6 +180,7 @@ def test_construct_sign_and_submit_transfer_transaction():
     )
     assert is_valid, "Failed to settle tx correctly!"
     assert tx == transaction_receipt, "Should be same!"
+    send_remaining_funds_back_to_faucet(account)
 
 
 # @pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)
@@ -193,6 +194,7 @@ def test_get_balance():
     assert balance == 0, "New account has a positive balance."
     balance = get_wealth(fc.address)
     assert balance > 0, "Existing account has no balance."
+    send_remaining_funds_back_to_faucet(fc)
 
 
 def get_wealth(address: str):
@@ -218,6 +220,7 @@ def test_get_wealth_positive(caplog):
         fetchai_faucet_api = FetchAIFaucetApi()
         fc = FetchAICrypto()
         fetchai_faucet_api.get_wealth(fc.address)
+        send_remaining_funds_back_to_faucet(fc)
 
 
 @pytest.mark.ledger
@@ -255,6 +258,7 @@ def test_successful_faucet_operation(mock_post, mock_get):
             )
         ]
     )
+    send_remaining_funds_back_to_faucet(address)
 
 
 @pytest.mark.ledger
@@ -316,6 +320,7 @@ def test_successful_realistic_faucet_operation(mock_post, mock_get):
             ),
         ]
     )
+    send_remaining_funds_back_to_faucet(address)
 
 
 @pytest.mark.flaky(reruns=MAX_FLAKY_RERUNS)
@@ -644,7 +649,7 @@ def send_remaining_funds_back_to_faucet(account: FetchAICrypto):
     """Sends remainind funds back to faucet"""
     faucet_address = "fetch193vvag846gz3pt3q0mdjuxn0s5jrt39fsjrays"
     fetchai_api = FetchAIApi(**FETCHAI_TESTNET_CONFIG)
-    balance = get_wealth(account.address)
+    balance = fetchai_api.get_balance(account.address)
 
     tx_fee = 1000
     amount = balance - tx_fee
@@ -691,3 +696,8 @@ def send_remaining_funds_back_to_faucet(account: FetchAICrypto):
     )
     assert is_valid, "Failed to settle tx correctly!"
     assert tx == transaction_receipt, "Should be same!"
+
+def check_balance_0(account: FetchAICrypto):
+    fetchai_api = FetchAIApi(**FETCHAI_TESTNET_CONFIG)
+    balance = fetchai_api.get_balance(account.address)
+    assert balance = 0, "Remaining funds were not sent back to faucet"

--- a/tests/test_crypto/test_fetchai.py
+++ b/tests/test_crypto/test_fetchai.py
@@ -658,7 +658,7 @@ def send_remaining_funds_back_to_faucet(account: FetchAICrypto):
     )
     transfer_transaction = fetchai_api.get_transfer_transaction(
         sender_address=account.address,
-        destination_address=fc2.faucet_address,
+        destination_address=faucet_address,
         amount=amount,
         tx_fee=tx_fee,
         tx_nonce=nonce,
@@ -692,7 +692,7 @@ def send_remaining_funds_back_to_faucet(account: FetchAICrypto):
 
     tx = fetchai_api.get_transaction(transaction_digest)
     is_valid = fetchai_api.is_transaction_valid(
-        tx, fc2.address, account.address, "", amount
+        tx, faucet_address, account.address, "", amount
     )
     assert is_valid, "Failed to settle tx correctly!"
     assert tx == transaction_receipt, "Should be same!"
@@ -700,4 +700,4 @@ def send_remaining_funds_back_to_faucet(account: FetchAICrypto):
 def check_balance_0(account: FetchAICrypto):
     fetchai_api = FetchAIApi(**FETCHAI_TESTNET_CONFIG)
     balance = fetchai_api.get_balance(account.address)
-    assert balance = 0, "Remaining funds were not sent back to faucet"
+    assert balance == 0, "Remaining funds were not sent back to faucet"

--- a/tests/test_crypto/test_fetchai.py
+++ b/tests/test_crypto/test_fetchai.py
@@ -698,6 +698,7 @@ def send_remaining_funds_back_to_faucet(account: FetchAICrypto):
     assert tx == transaction_receipt, "Should be same!"
 
 def check_balance_0(account: FetchAICrypto):
+    """Check if account balance is 0"""
     fetchai_api = FetchAIApi(**FETCHAI_TESTNET_CONFIG)
     balance = fetchai_api.get_balance(account.address)
     assert balance == 0, "Remaining funds were not sent back to faucet"


### PR DESCRIPTION
This PR sends the unused funds requested by the faucet, back to the faucet account.

I'm not sure if there is anywhere in similar code needs to be added to the cli tests.
Waiting for your comments.
Thanks