### PR TITLE
Update aea.configurations.pypi.is_satisfiable so to handle '~=' operator correctly

### DIFF
--- a/tests/test_configurations/test_pypi.py
+++ b/tests/test_configurations/test_pypi.py
@@ -48,6 +48,13 @@ def test_is_satisfiable_with_compatibility_constraints():
     assert is_satisfiable(SpecifierSet("~=1.1,==1.2")) is True
     assert is_satisfiable(SpecifierSet("~=1.1,>1.2")) is True
     assert is_satisfiable(SpecifierSet("==1.1,==1.2")) is False
+    assert is_satisfiable(SpecifierSet("~= 1.4.5.0")) is True
+    assert is_satisfiable(SpecifierSet("~= 1.4.5.0,>1.4.6")) is False
+    assert is_satisfiable(SpecifierSet("~=2.2.post3,==2.*")) is True
+    assert is_satisfiable(SpecifierSet("~=2.2.post3,>2.3")) is True
+    assert is_satisfiable(SpecifierSet("~=2.2.post3,>3")) is False
+    assert is_satisfiable(SpecifierSet("~=1.4.5a4,>1.4.6")) is True
+    assert is_satisfiable(SpecifierSet("~=1.4.5a4,>1.5")) is False
 
 
 def test_is_satisfiable_with_legacy_version():


### PR DESCRIPTION
## Proposed changes

Update aea.configurations.pypi.is_satisfiable so to handle '~=' operator correctly.

Previously, only versions of the form `~=<major>.<minor>` were handled. After this PR this restriction is not imposed anymore.

## Fixes

Partially addresses #1702

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a