### PR TITLE
Prevent update of 'class_name' in SkillConfig.update for skill component configuration

### DIFF
--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -1380,6 +1380,14 @@ class SkillConfig(ComponentConfiguration):
                 component_config = cast(
                     SkillComponentConfiguration, registry.read(component_name)
                 )
+                component_data_keys = set(component_data.keys())
+                unallowed_keys = component_data_keys.difference(
+                    SkillConfig.NESTED_FIELDS_ALLOWED_TO_UPDATE
+                )
+                if len(unallowed_keys) > 0:
+                    raise ValueError(
+                        f"These fields of skill component configuration '{component_name}' of skill '{self.public_id}' are not allowed to change: {unallowed_keys}."
+                    )
                 recursive_update(component_config.args, component_data.get("args", {}))
 
         _update_skill_component_config("behaviours", data)

--- a/tests/test_configurations/test_base.py
+++ b/tests/test_configurations/test_base.py
@@ -242,14 +242,33 @@ class TestSkillConfig:
         loader = ConfigLoaders.from_package_type(PackageType.SKILL)
         skill_config = loader.load(skill_config_path.open())
         new_configurations = {
-            "behaviours": {"new_behaviour": {"args": {}, "class_name": "SomeClass"}},
-            "handlers": {"new_handler": {"args": {}, "class_name": "SomeClass"}},
-            "models": {"new_model": {"args": {}, "class_name": "SomeClass"}},
+            "behaviours": {"new_behaviour": {"args": {}}},
+            "handlers": {"new_handler": {"args": {}}},
+            "models": {"new_model": {"args": {}}},
         }
 
         with pytest.raises(
             ValueError,
             match="The custom configuration for skill fetchai/error:0.6.0 includes new behaviours: {'new_behaviour'}. This is not allowed.",
+        ):
+            skill_config.update(new_configurations)
+
+    def test_update_method_raises_error_if_we_try_to_change_classname_of_skill_component(
+        self,
+    ):
+        """Test that we raise error if we try to change the 'class_name' field of a skill component configuration."""
+        skill_config_path = Path(
+            ROOT_DIR, "aea", "skills", "error", DEFAULT_SKILL_CONFIG_FILE
+        )
+        loader = ConfigLoaders.from_package_type(PackageType.SKILL)
+        skill_config = loader.load(skill_config_path.open())
+        new_configurations = {
+            "handlers": {"error_handler": {"class_name": "SomeClass", "args": {}}},
+        }
+
+        with pytest.raises(
+            ValueError,
+            match=f"These fields of skill component configuration 'error_handler' of skill 'fetchai/error:0.6.0' are not allowed to change: {{'class_name'}}.",
         ):
             skill_config.update(new_configurations)
 


### PR DESCRIPTION
## Proposed changes

Prevent update of 'class_name' in SkillConfig.update for skill component configuration.

The field `class_name` was already ignored, but now we also add a consistency check to the input of the `SkillConfig.update` function.

## Fixes

Partially addresses #1702 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a