### PR TITLE
Add validation of component configurations in agent config setter

### DIFF
--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -1513,7 +1513,9 @@ class AgentConfig(PackageConfiguration):
                 in package_type_to_set[component_id.package_type],
                 f"Component {component_id} not declared in the agent configuration.",
             )
-            from aea.configurations.loader import ConfigLoader  # pylint: disable=import-outside-toplevel,cyclic-import
+            from aea.configurations.loader import (  # pylint: disable=import-outside-toplevel,cyclic-import
+                ConfigLoader,
+            )
 
             ConfigLoader.validate_component_configuration(
                 component_id, component_configuration

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -1487,6 +1487,8 @@ class AgentConfig(PackageConfiguration):
         )  # type: Dict[PublicId, PublicId]
         self.loop_mode = loop_mode
         self.runtime_mode = runtime_mode
+        # this attribute will be set through the setter below
+        self._component_configurations: Dict[ComponentId, Dict] = {}
         self.component_configurations = (
             component_configurations if component_configurations is not None else {}
         )

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -1487,7 +1487,6 @@ class AgentConfig(PackageConfiguration):
         )  # type: Dict[PublicId, PublicId]
         self.loop_mode = loop_mode
         self.runtime_mode = runtime_mode
-        self._component_configurations: Dict[ComponentId, Dict] = {}
         self.component_configurations = (
             component_configurations if component_configurations is not None else {}
         )
@@ -1506,11 +1505,16 @@ class AgentConfig(PackageConfiguration):
             PackageType.CONTRACT: self.contracts,
             PackageType.SKILL: self.skills,
         }
-        for component_id, _ in d.items():
+        for component_id, component_configuration in d.items():
             enforce(
                 component_id.public_id
                 in package_type_to_set[component_id.package_type],
                 f"Component {component_id} not declared in the agent configuration.",
+            )
+            from aea.configurations.loader import ConfigLoader  # pylint: disable=import-outside-toplevel,cyclic-import
+
+            ConfigLoader.validate_component_configuration(
+                component_id, component_configuration
             )
         self._component_configurations = d
 

--- a/aea/configurations/loader.py
+++ b/aea/configurations/loader.py
@@ -210,7 +210,7 @@ class ConfigLoader(Generic[T], BaseConfigLoader):
                 component_id = self._split_component_id_and_config(
                     idx, component_configuration_json
                 )
-                self._validate_component_configuration(
+                self.validate_component_configuration(
                     component_id, component_configuration_json
                 )
 
@@ -354,7 +354,7 @@ class ConfigLoader(Generic[T], BaseConfigLoader):
         component_id = self._split_component_id_and_config(
             component_index, component_configuration_json
         )
-        self._validate_component_configuration(
+        self.validate_component_configuration(
             component_id, component_configuration_json
         )
         return component_id
@@ -390,7 +390,7 @@ class ConfigLoader(Generic[T], BaseConfigLoader):
         return component_id
 
     @staticmethod
-    def _validate_component_configuration(
+    def validate_component_configuration(
         component_id: ComponentId, configuration: Dict
     ) -> None:
         """

--- a/tests/test_configurations/test_base.py
+++ b/tests/test_configurations/test_base.py
@@ -279,7 +279,9 @@ class TestAgentConfigUpdate:
 
     def setup(self):
         """Set up the tests."""
-        self.aea_config_path = Path(CUR_PATH, "data", "dummy_aea", DEFAULT_AEA_CONFIG_FILE)
+        self.aea_config_path = Path(
+            CUR_PATH, "data", "dummy_aea", DEFAULT_AEA_CONFIG_FILE
+        )
         self.loader = ConfigLoaders.from_package_type(PackageType.AGENT)
         self.aea_config: AgentConfig = self.loader.load(self.aea_config_path.open())
         self.dummy_skill_component_id = ComponentId(
@@ -304,9 +306,13 @@ class TestAgentConfigUpdate:
         """Test component configuration setter with wrong configurations."""
         assert self.aea_config.component_configurations == {}
         new_component_configurations = {
-            self.dummy_skill_component_id: {"handlers": {"dummy": {"class_name": "SomeClass"}}}
+            self.dummy_skill_component_id: {
+                "handlers": {"dummy": {"class_name": "SomeClass"}}
+            }
         }
-        with pytest.raises(ValueError, match=r"Configuration of component .* is not valid.*"):
+        with pytest.raises(
+            ValueError, match=r"Configuration of component .* is not valid.*"
+        ):
             self.aea_config.component_configurations = new_component_configurations
 
     def test_update(self):
@@ -329,7 +335,8 @@ class TestAgentConfigUpdate:
             == self.new_dummy_skill_config
         )
         assert (
-            dict(self.aea_config.private_key_paths.read_all()) == expected_private_key_paths
+            dict(self.aea_config.private_key_paths.read_all())
+            == expected_private_key_paths
         )
         assert (
             dict(self.aea_config.connection_private_key_paths.read_all())


### PR DESCRIPTION
## Proposed changes

Add validation of component configurations in agent config setter.

## Fixes

Partially addresses #1702.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a