### PR TITLE
AEA-948 fix bug on import order computation in the 'AEABuilder'

### DIFF
--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -1282,7 +1282,8 @@ class AEABuilder(WithLogger):  # pylint: disable=too-many-public-methods
                 ),
             )
 
-            dependency_to_supported_dependencies[skill_id] = set()
+            if skill_id not in dependency_to_supported_dependencies:
+                dependency_to_supported_dependencies[skill_id] = set()
             for dependency in configuration.skills:
                 dependency_to_supported_dependencies[
                     ComponentId(ComponentType.SKILL, dependency)


### PR DESCRIPTION
## Proposed changes

The bug has been introduced by #1822. The problem was due to wrong computation of the input to provide to the topological order algorithm.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a