### PR TITLE
Fix test for 'aea upgrade' by adding 'skip-consistency-checks'

### DIFF
--- a/tests/test_cli/test_upgrade.py
+++ b/tests/test_cli/test_upgrade.py
@@ -373,7 +373,10 @@ class TestNonVendorProject(BaseAEATestCase, BaseTestCase):
             )
 
             self.runner.invoke(  # pylint: disable=no-member
-                cli, ["upgrade"], standalone_mode=False, catch_exceptions=False
+                cli,
+                ["--skip-consistency-check", "upgrade"],
+                standalone_mode=False,
+                catch_exceptions=False,
             )
             agent_items = set(
                 ItemRemoveHelper(self.load_config())


### PR DESCRIPTION
## Proposed changes

The 'TestNonVendorProject' fails because the minor version number of the framework has been upgraded to 0.7.0 on 'develop'. Using the flag '--skip-consistency-check' we avoid failing for that reason.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

