### PR TITLE
add config set/get support for dict

### DIFF
--- a/aea/cli/config.py
+++ b/aea/cli/config.py
@@ -321,7 +321,7 @@ class ConfigGetSet:
                 parent_object[self.attr_name] = json.loads(value)
             else:
                 parent_object[self.attr_name] = type_(value)
-        except ValueError:  # pragma: no cover
+        except (ValueError, json.decoder.JSONDecodeError):  # pragma: no cover
             raise click.ClickException(
                 "Cannot convert {} to type {}".format(value, type_)
             )

--- a/aea/cli/utils/constants.py
+++ b/aea/cli/utils/constants.py
@@ -49,7 +49,7 @@ NOT_PERMITTED_AUTHORS = [
 ]
 
 
-FROM_STRING_TO_TYPE = dict(str=str, int=int, bool=bool, float=float)
+FROM_STRING_TO_TYPE = dict(str=str, int=int, bool=bool, float=float, dict=dict)
 
 ALLOWED_PATH_ROOTS = [
     "agent",

--- a/tests/test_cli/test_config.py
+++ b/tests/test_cli/test_config.py
@@ -62,6 +62,17 @@ class TestConfigGet:
         assert result.exit_code == 0
         assert result.output == "Agent0\n"
 
+    def test_get_agent_default_routing(self):
+        """Test getting the agent name."""
+        result = self.runner.invoke(
+            cli,
+            [*CLI_LOG_OPTION, "config", "get", "agent.default_routing"],
+            standalone_mode=False,
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert result.output == "{}\n"
+
     def test_get_skill_name(self):
         """Test getting the 'dummy' skill name."""
         result = self.runner.invoke(
@@ -153,16 +164,18 @@ class TestConfigGet:
         s = "Attribute 'non_existing_attribute' not found."
         assert result.exception.message == s
 
-    def test_get_fails_when_getting_non_primitive_type(self):
-        """Test that getting the 'dummy' skill behaviours fails because not a primitive type."""
+    def test_get_whole_dict(self):
+        """Test that getting the 'dummy' skill behaviours works."""
         result = self.runner.invoke(
             cli,
             [*CLI_LOG_OPTION, "config", "get", "skills.dummy.behaviours"],
             standalone_mode=False,
         )
-        assert result.exit_code == 1
-        s = "Attribute 'behaviours' is not of primitive type."
-        assert result.exception.message == s
+        assert result.exit_code == 0
+        assert (
+            result.output
+            == "{'dummy': {'args': {'behaviour_arg_1': 1, 'behaviour_arg_2': '2'}, 'class_name': 'DummyBehaviour'}}\n"
+        )
 
     def test_get_fails_when_getting_nested_object(self):
         """Test that getting a nested object in 'dummy' skill fails because path is not valid."""
@@ -296,6 +309,22 @@ class TestConfigSet:
                 "agent.logging_config.disable_existing_loggers",
                 "true",
                 "--type=bool",
+            ],
+            standalone_mode=False,
+        )
+        assert result.exit_code == 0
+
+    def test_set_type_dict(self):
+        """Test setting the default routing."""
+        result = self.runner.invoke(
+            cli,
+            [
+                *CLI_LOG_OPTION,
+                "config",
+                "set",
+                "agent.default_routing",
+                '{"fetchai/contract_api:any": "fetchai/ledger:any"}',
+                "--type=dict",
             ],
             standalone_mode=False,
         )


### PR DESCRIPTION
## Proposed changes

This PR adds support for setting and getting dict values in configs.

## Fixes

https://github.com/fetchai/agents-aea/issues/1881

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

-