### PR TITLE
[AEA-910, AEA-666] Add k8s files and scripts

### DIFF
--- a/scripts/acn/Dockerfile.dev
+++ b/scripts/acn/Dockerfile.dev
@@ -1,0 +1,35 @@
+FROM ubuntu:18.04
+
+USER root
+
+RUN apt-get update && apt-get upgrade -y
+
+RUN apt install -y python3 python3-pip
+
+# utils
+RUN apt install -y wget
+
+# golang
+RUN wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz && \
+  tar -xzvf go1.13.8.linux-amd64.tar.gz -C /usr/local && \
+  export PATH=$PATH:/usr/local/go/bin && echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && \
+  mkdir $HOME/go
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+
+# deployment scripts deps: needed only if configuration checks are enabled
+RUN python3 -m pip install pymultihash ecdsa base58
+
+WORKDIR /acn/
+
+# get node source code
+COPY ./packages/fetchai/connections/p2p_libp2p /acn/node
+
+# get deployment script
+COPY ./scripts/acn/run_acn_node_standalone.py /acn/
+
+# build node
+RUN cd /acn/node && go build
+
+ENTRYPOINT [ "python3", "-u", "/acn/run_acn_node_standalone.py", "/acn/node/libp2p_node"]
+

--- a/scripts/acn/README.md
+++ b/scripts/acn/README.md
@@ -1,0 +1,43 @@
+# The agent communication network (acn) kubernetes deployment script
+
+The `k8s_deploy_acn_node.py` script provides a configurable, reproducible, and verifiable deployment of the acn node to a kubernetes cluster.
+Configuration of the acn node, docker image, and kubernetes is passed through command-line interface. The script will then verify it, generate the
+corresponding yaml deployment file and finally deploy it. 
+The script can also delete a deployment by appending `--delete` to the cli arguments used to create the deployment.
+
+The generated yaml deployment file includes:
+- a statefulSet to persist acn node log file across runs
+- a service for restarting the node (pod) in case of failure
+- a DNSEndpoint to expose public port
+- a secret to safely upload the node's private key 
+
+The generated yaml deployment file can be saved for future re-deployments by using cli option `--from-file`. 
+Options `--from-file` and `--delete` can be combined as quick way to delete a previous deployment from kubernetes cluster.
+Option `--generate-only` can be used to generate the deployment file without submitting it to the cluster.
+
+To reduce the number of cli arguments to pass, the script offers defaults for docker and kubnernetes configuration
+that can be used by setting `--k8s-fetchai-defaults`, `--docker-fetchai-defaults` or `--docker-fetchai-defaults-dev`.
+
+## Usage examples
+
+
+- deploy a node using cli options
+  ```bash
+  python3 scripts/acn/k8s_deploy_acn_node.py --acn-key-file fet_key_test_1.txt --acn-port 9009 --acn-port-delegate 11009 --acn-port-monitoring 8080 --k8s-fetchai-defaults --docker-fetchai-defaults-dev
+  ```
+
+- delete deployment using cli options
+  ```bash
+  python3 scripts/acn/k8s_deploy_acn_node.py --acn-key-file fet_key_test_1.txt --acn-port 9009 --acn-port-delegate 11009 --acn-port-monitoring 8080 --k8s-fetchai-defaults --docker-fetchai-defaults-dev --delete
+  ```
+
+- redeploy using the generated deployment file
+  ```bash
+  python3 scripts/acn/k8s_deploy_acn_node.py --from-file .acn_deployment.yaml
+  ```
+
+- delete deployment using the generated deployment file
+  ```bash
+  python3 scripts/acn/k8s_deploy_acn_node.py  --from-file .acn_deployment.yaml --delete
+  ```
+

--- a/scripts/acn/k8s/deployment.yaml
+++ b/scripts/acn/k8s/deployment.yaml
@@ -83,7 +83,7 @@ spec:
           - name: AEA_P2P_ENTRY_URIS
             value: ph-node-entry-peers-list-here
           - name: ACN_LOG_FILE
-            value: "/acn_data/libp2p_node.log"
+            value: ph-node-log-file-path-here
 
       restartPolicy: Always
 

--- a/scripts/acn/k8s/deployment.yaml
+++ b/scripts/acn/k8s/deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: ph-deployment-name-here
+  namespace: ph-deployment-namespace-here
+  labels:
+    app: ph-deployment-name-here
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ph-deployment-name-here 
+  template:
+    metadata:
+      labels:
+        app: ph-deployment-name-here
+
+    spec:
+      initContainers:
+      - name: check-entry-peer
+        image: subfuzion/netcat
+        command: ['sh', '-c', 
+          'if [ -z "${LATEST_ENTRY_PEER_HOST}" ]; then exit 0; fi; until nc -w 2 -zv ${LATEST_ENTRY_PEER_HOST} ${LATEST_ENTRY_PEER_PORT}; do echo waiting for ${LATEST_ENTRY_PEER_HOST}:${LATEST_ENTRY_PEER_PORT} ; sleep 2; done;']
+        env:
+          - name: LATEST_ENTRY_PEER_HOST
+            value: ph-latest-entry-peer-host-here
+          - name: LATEST_ENTRY_PEER_PORT
+            value: ph-latest-entry-peer-port-here
+     
+      containers:
+      - image: ph-gcr-image-with-tag-here
+        name: acn-node
+        args: ["--config-from-env"]
+        ports:
+        - containerPort: ph-node-port-number-here
+        - containerPort: ph-node-delegate-port-number-here
+
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "150m"
+          limits:
+            memory: "4000Mi"
+            cpu: "2000m"
+        
+        env:
+          - name: AEA_P2P_ID 
+            valueFrom:
+              secretKeyRef:
+                name: ph-node-priv-key-name-here
+                key: priv-key
+          - name: AEA_P2P_URI_PUBLIC
+            value: ph-node-external-uri-here
+          - name: AEA_P2P_URI
+            value: ph-node-local-uri-here
+          - name: AEA_P2P_DELEGATE_URI
+            value: ph-node-delegate-uri-here
+          - name: AEA_P2P_URI_MONITORING
+            value: ph-node-monitoring-uri-here
+          - name: AEA_P2P_ENTRY_URIS
+            value: ph-node-entry-peers-list-here
+
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ph-deployment-name-here
+  namespace: ph-deployment-namespace-here
+spec:
+  selector:
+    app: ph-deployment-name-here
+  ports:
+    - name: libp2p 
+      protocol: TCP
+      port: ph-node-port-number-here
+      targetPort: ph-node-port-number-here
+    - name: tcp
+      protocol: TCP
+      port: ph-node-delegate-port-number-here
+      targetPort: ph-node-delegate-port-number-here

--- a/scripts/acn/k8s/deployment.yaml
+++ b/scripts/acn/k8s/deployment.yaml
@@ -1,11 +1,30 @@
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: v1
+kind: Service
+metadata:
+  name: ph-deployment-name-here
+  namespace: ph-deployment-namespace-here
+spec:
+  selector:
+    app: ph-deployment-name-here
+  ports:
+    - name: libp2p 
+      protocol: TCP
+      port: ph-node-port-number-here
+      targetPort: ph-node-port-number-here
+    - name: tcp
+      protocol: TCP
+      port: ph-node-delegate-port-number-here
+      targetPort: ph-node-delegate-port-number-here
+---
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: ph-deployment-name-here
   namespace: ph-deployment-namespace-here
   labels:
     app: ph-deployment-name-here
 spec:
+  serviceName: ph-deployment-name-here
   replicas: 1
   selector:
     matchLabels:
@@ -16,6 +35,7 @@ spec:
         app: ph-deployment-name-here
 
     spec:
+      terminationGracePeriodSeconds: 10
       initContainers:
       - name: check-entry-peer
         image: subfuzion/netcat
@@ -42,6 +62,9 @@ spec:
           limits:
             memory: "4000Mi"
             cpu: "2000m"
+        volumeMounts:
+        - name: acn-data
+          mountPath: /acn_data
         
         env:
           - name: AEA_P2P_ID 
@@ -59,23 +82,16 @@ spec:
             value: ph-node-monitoring-uri-here
           - name: AEA_P2P_ENTRY_URIS
             value: ph-node-entry-peers-list-here
+          - name: ACN_LOG_FILE
+            value: "/acn_data/libp2p_node.log"
 
       restartPolicy: Always
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: ph-deployment-name-here
-  namespace: ph-deployment-namespace-here
-spec:
-  selector:
-    app: ph-deployment-name-here
-  ports:
-    - name: libp2p 
-      protocol: TCP
-      port: ph-node-port-number-here
-      targetPort: ph-node-port-number-here
-    - name: tcp
-      protocol: TCP
-      port: ph-node-delegate-port-number-here
-      targetPort: ph-node-delegate-port-number-here
+
+  volumeClaimTemplates:
+  - metadata:
+      name: acn-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 2Gi

--- a/scripts/acn/k8s/dns.yaml
+++ b/scripts/acn/k8s/dns.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: ph-deployment-name-here 
+  namespace: ph-deployment-namespace-here
+spec:
+  endpoints:
+  - dnsName:  ph-deployment-dns-here
+    recordTTL: 180
+    recordType: CNAME
+    targets:
+    - fetchpub.sandbox.fetch-ai.com

--- a/scripts/acn/k8s/istio.yaml
+++ b/scripts/acn/k8s/istio.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: ph-deployment-name-here
+  namespace: ph-deployment-namespace-here
+spec:
+  selector:
+    app: istio-fetchpubig
+    istio: ingressgateway
+  servers:
+  - port:
+      name: libp2p
+      number: ph-node-port-number-here
+      protocol: TCP
+    hosts:
+    - ph-deployment-dns-here
+  - port:
+      name: tcp
+      number: ph-node-delegate-port-number-here
+      protocol: TCP
+    hosts:
+    - ph-deployment-dns-here
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ph-deployment-name-here
+  namespace: ph-deployment-namespace-here
+spec:
+  gateways:
+  - ph-deployment-name-here
+  hosts:
+  - ph-deployment-dns-here
+  tcp:
+  - match:
+    - port: ph-node-port-number-here
+    route:
+    - destination:
+        host: ph-deployment-name-here
+        port:
+          number: ph-node-port-number-here
+  - match:
+    - port: ph-node-delegate-port-number-here
+    route:
+    - destination:
+        host: ph-deployment-name-here
+        port:
+          number: ph-node-delegate-port-number-here

--- a/scripts/acn/k8s/secret.yaml
+++ b/scripts/acn/k8s/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ph-node-priv-key-name-here
+type: Opaque
+data:
+  priv-key: ph-base64-encoded-private-key-here

--- a/scripts/acn/k8s_deploy_acn_node.py
+++ b/scripts/acn/k8s_deploy_acn_node.py
@@ -1,0 +1,597 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+""" Deploy an ACN libp2p node to a kubernetes cluster """
+
+import argparse
+import base64
+import os
+import subprocess  # nosec
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Type
+
+SCRIPT_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
+
+sys.path.append(SCRIPT_DIR)
+from run_acn_node_standalone import AcnNodeConfig
+
+# docker defaults
+DOCKER_FETCHAI_DEFAULT_FILE = os.path.join(SCRIPT_DIR, "Dockerfile")
+DOCKER_FETCHAI_DEFAULT_CTX = SCRIPT_DIR
+DOCKER_FETCHAI_DEFAULT_IMG = "acn_node"
+DOCKER_FETCHAI_DEFAULT_REGISTRY = "gcr.io/fetch-ai-sandbox"
+
+# k8s defaults
+K8S_FETCHAI_DEFAULT_PUBLIC_HOST = "agents-p2p-dht.sandbox.fetch-ai.com"
+K8S_FETCHAI_DEFAULT_PUBLIC_TEMPLATE_DIR = os.path.join(SCRIPT_DIR, "k8s")
+K8S_FETCHAI_DEFAULT_NAMESPACE = "agents-p2p-dht"
+
+
+def _execute_cmd(cmd: List[str]) -> Tuple[str, bool]:
+    """
+    Run command as subprocess and wait for its termination
+
+    :param cmd: command with arguments to execute
+    :return: output of the command execution and execution success
+    """
+
+    print("-> Running: {}".format(cmd))
+    proc = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE)  # nosec
+    out, _ = proc.communicate()
+    success = False
+    try:
+        if proc.wait() == 0:
+            success = True
+    except Exception as e:
+        print("_excute_cmd caught exception: {}".format(str(e)))
+    print("-| Output :\n{}".format(out.decode("ascii")))
+    return out.decode("ascii"), success
+
+
+class DockerDeployment:
+    """Build and Publish a Dockerfile"""
+
+    def __init__(
+        self, dockerfile: str, context: str, image: str, tag: str, registry: str
+    ):
+        """
+        Initialize a DockerDeployment object
+
+        :param dockerfile: path to the Dockerfile
+        :param context: path to docker image context
+        :param image: built image name
+        :param tag: built image tag
+        :param registry: registry to publish the image to
+        """
+
+        self.dockerfile = dockerfile
+        self.context = context
+        self.image = image
+        self.tag = tag
+        self.registry = registry
+
+    def build_and_publish(self) -> bool:
+        """
+        Build the image and publich it to registry
+
+        :return: success of the operation
+        """
+
+        cmds: List[List[str]] = list()
+
+        cmds.append(
+            [
+                "docker",
+                "build",
+                "-t",
+                "{}:{}".format(self.image, self.tag),
+                "-f",
+                self.dockerfile,
+                self.context,
+            ]
+        )
+        cmds.append(
+            [
+                "docker",
+                "tag",
+                "{}:{}".format(self.image, self.tag),
+                "{}/{}:{}".format(self.registry, self.image, self.tag),
+            ]
+        )
+        cmds.append(
+            ["docker", "push", "{}/{}:{}".format(self.registry, self.image, self.tag)]
+        )
+
+        for cmd in cmds:
+            out, ok = _execute_cmd(cmd)
+            if not ok:
+                return False
+
+        return True
+
+
+class K8sPodDeployment:
+    """An application-agnostic deployment object"""
+
+    def __init__(
+        self,
+        deployments_files: List[Path],
+        docker_deployment: Optional[DockerDeployment],
+    ):
+        """
+        Initialize a K8sPodDeployment object
+
+        :param deployment_files: list of kubernetes yaml files to deploy
+        :param docker_deployment: optional DockerDeployment to build and publish
+        """
+
+        self.deployment_files = deployments_files
+        self.docker_deployment = docker_deployment
+
+    def deploy(self) -> bool:
+        """
+        Deploy to k8s cluster
+
+        :return: success of the operation
+        """
+
+        ok = True
+        if self.docker_deployment:
+            ok = self.docker_deployment.build_and_publish()
+            if not ok:
+                return ok
+        for yaml in self.deployment_files:
+            cmd = ["kubectl", "apply", "-f", str(yaml)]
+            out, ok = _execute_cmd(cmd)
+            print(out)
+            if not ok:
+                break
+        return ok
+
+    def delete(self) -> bool:
+        """
+        Delete deployment from k8s cluster
+
+        :return: success of the operation
+        """
+        ok = True
+        for yaml in self.deployment_files:
+            cmd = ["kubectl", "delete", "-f", str(yaml)]
+            out, ok = _execute_cmd(cmd)
+            print(out)
+            if not ok:
+                break
+        return ok
+
+
+class AcnK8sPodConfig:
+    """
+    Store, parse, and generate kubernetes deployment for an ACN node
+    """
+
+    K8S_DEPLOYMENT_NAME = "ph-deployment-name-here"
+    K8S_NAMESPACE = "ph-deployment-namespace-here"
+    K8S_PUBLIC_DNS = "ph-deployment-dns-here"
+
+    DOCKER_IMAGE_REMOTE_WITH_TAG = "ph-gcr-image-with-tag-here"
+
+    NODE_PORT = "ph-node-port-number-here"
+    NODE_PORT_DELEGATE = "ph-node-delegate-port-number-here"
+    NODE_PORT_MONITORING = "ph-node-monitoring-port-number-here"  # TODO
+    NODE_URI_EXTERNAL = "ph-node-external-uri-here"
+    NODE_URI = "ph-node-local-uri-here"
+    NODE_URI_DELEGATE = "ph-node-delegate-uri-here"
+    NODE_URI_MONITORING = "ph-node-monitoring-uri-here"
+    NODE_ENTRY_PEERS = "ph-node-entry-peers-list-here"
+    NODE_KEY_NAME = "ph-node-priv-key-name-here"
+    NODE_KEY_ENCODED = "ph-base64-encoded-private-key-here"
+    NODE_LAST_ENTRY_PEER_HOST = "ph-latest-entry-peer-host-here"
+    NODE_LAST_ENTRY_PEER_PORT = "ph-latest-entry-peer-port-here"
+
+    # class defaults
+    Defaults: Dict[str, str] = {
+        K8S_DEPLOYMENT_NAME: "acn-node",
+    }
+
+    def __init__(
+        self,
+        acn_key_file: str,
+        acn_port: int,
+        acn_delegate_port: int,
+        acn_monitoring_port: int,
+        acn_entry_peers: Optional[List[str]],
+        docker_file: str,
+        docker_context: str,
+        docker_image: str,
+        docker_registry: str,
+        k8s_public_hostname: str,
+        k8s_namespace: str,
+        k8s_template_files_dir: str,
+        enable_checks: bool = True,
+    ):
+        """
+        Initialize a AcnK8sPodConfig, populate the config dictionary
+
+        :param acn_key_file: path to the acn node private key
+        :param acn_port: acn node port number
+        :param acn_delegate_port: acn node delegate service port number
+        :param acn_monitoring_port: acn node monitoring service port number
+        :param acn_entry_peers: optional list of acn node entry peers multiaddresses
+        :param docker_file: path to Dockerfile
+        :param docker_context: path to Dockerfile context
+        :param docker_image: docker image name
+        :param docker_registry: url of remote docker registry to push image to
+        :param k8s_public_hostname: public dns for acn node's external uri
+        :param k8s_namespace: k8s namespace to deploy node to
+        :param k8s_template_files_dir: path to directory containing k8s yaml deployment templates
+        :param enable_checks: enable configuration checks
+        """
+
+        config: Dict[str, str] = dict()
+        cls: Type[AcnK8sPodConfig] = AcnK8sPodConfig
+
+        # acn node configuration
+        config[cls.NODE_KEY_NAME] = "node-priv-key-{}".format(acn_port)
+        config[cls.NODE_PORT] = acn_port
+        config[cls.NODE_PORT_DELEGATE] = acn_delegate_port
+        config[cls.NODE_PORT_MONITORING] = acn_monitoring_port
+        config[cls.NODE_ENTRY_PEERS] = (
+            ",".join(acn_entry_peers) if acn_entry_peers is not None else ""
+        )
+        config[cls.NODE_ENTRY_PEERS] = '"{}"'.format(config[cls.NODE_ENTRY_PEERS])
+        peer_host, peer_port = cls._uri_from_multiaddr(
+            acn_entry_peers[-1]
+            if acn_entry_peers is not None and len(acn_entry_peers) > 0
+            else ""
+        )
+        config[cls.NODE_LAST_ENTRY_PEER_HOST] = '"{}"'.format(peer_host)
+        config[cls.NODE_LAST_ENTRY_PEER_PORT] = '"{}"'.format(peer_port)
+
+        config[cls.NODE_URI] = "0.0.0.0:{}".format(acn_port)
+        config[cls.NODE_URI_DELEGATE] = "0.0.0.0:{}".format(acn_delegate_port)
+        config[cls.NODE_URI_MONITORING] = "0.0.0.0:{}".format(acn_monitoring_port)
+        config[cls.NODE_URI_EXTERNAL] = "{}:{}".format(k8s_public_hostname, acn_port)
+
+        with open(acn_key_file, "r") as f:
+            key = f.read().strip()
+            config[cls.NODE_KEY_ENCODED] = base64.b64encode(key.encode("ascii")).decode(
+                "ascii"
+            )
+
+        # k8s configuration
+        config[cls.K8S_DEPLOYMENT_NAME] = "{}-{}".format(
+            cls.Defaults[cls.K8S_DEPLOYMENT_NAME], str(acn_port)
+        )
+        config[cls.K8S_NAMESPACE] = k8s_namespace
+        config[cls.K8S_PUBLIC_DNS] = k8s_public_hostname
+
+        files: List[Path] = []
+        for path in [
+            Path(os.path.join(k8s_template_files_dir, p))
+            for p in os.listdir(k8s_template_files_dir)
+        ]:
+            if path.is_file() and path.suffix == ".yaml":
+                files.append(path)
+        assert (
+            len(files) > 0
+        ), f"Couldn't find any template deployment file at {k8s_template_files_dir}"
+
+        # docker configuration
+        cmd = ["git", "describe", "--no-match", "--always", "--dirty"]
+        docker_tag, ok = _execute_cmd(cmd)
+        if not ok:
+            docker_tag = datetime.now().strftime("%d-%m-%Y_%H-%M-%S")
+        else:
+            docker_tag = docker_tag.strip()
+        config[cls.DOCKER_IMAGE_REMOTE_WITH_TAG] = "{}/{}:{}".format(
+            docker_registry, docker_image, docker_tag.strip()
+        )
+
+        self.config = config
+        self.template_files = files
+        self.docker_deployment = DockerDeployment(
+            docker_file, docker_context, docker_image, docker_tag, docker_registry
+        )
+
+        if enable_checks:
+            cls.check_config(self.config)
+
+    @staticmethod
+    def _uri_from_multiaddr(maddr: str) -> Tuple[str, str]:
+        if maddr != "":
+            parts = maddr.split("/")
+            if len(parts) == 7:
+                return parts[2], parts[4]
+        return "", ""
+
+    @staticmethod
+    def check_config(config: Dict[str, str]) -> None:
+        AcnNodeConfig(
+            base64.b64decode(
+                config[AcnK8sPodConfig.NODE_KEY_ENCODED].encode("ascii")
+            ).decode("ascii"),
+            config[AcnK8sPodConfig.NODE_URI],
+            config[AcnK8sPodConfig.NODE_URI_EXTERNAL],
+            config[AcnK8sPodConfig.NODE_URI_DELEGATE],
+            config[AcnK8sPodConfig.NODE_URI_MONITORING],
+            config[AcnK8sPodConfig.NODE_ENTRY_PEERS].strip('"').split(','),
+            True,
+        )
+
+    def generate_deployment(self) -> K8sPodDeployment:
+        """
+        Generate deployment for the current configuration
+
+        :return: deployment object
+        """
+
+        deployment_file = ".acn_deployment.yaml"
+        out = open(deployment_file, "w")
+
+        for path in self.template_files:
+            with open(path, "r") as f:
+                content = f.read()
+
+            for placeholder, value in self.config.items():
+                content = content.replace(placeholder, value)
+
+            out.write(content)
+            out.write("\n---\n")
+
+        out.close()
+
+        return K8sPodDeployment([Path(deployment_file)], self.docker_deployment)
+
+
+def parse_commandline():
+    """ Parse script cl arguments """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--from-file",
+        action="store",
+        type=str,
+        dest="from_file",
+        required=False,
+        help="Use previously generated deployment",
+    )
+    parser.add_argument(
+        "--delete",
+        action="store_true",
+        dest="delete_deployment",
+        required=False,
+        help="Delete an already deployed node with the same configuration",
+    )
+    parser.add_argument(
+        "--acn-key-file",
+        action="store",
+        type=str,
+        dest="key",
+        required=False,
+        help="acn node's private key file",
+    )
+    parser.add_argument(
+        "--acn-port",
+        action="store",
+        type=str,
+        dest="port",
+        required=False,
+        help="acn node's port number (both local and external)",
+    )
+    parser.add_argument(
+        "--acn-port-delegate",
+        action="store",
+        type=str,
+        dest="delegate_port",
+        required=False,
+        help="acn node's delegate service port number (both local and external)",
+    )
+    parser.add_argument(
+        "--acn-port-monitoring",
+        action="store",
+        type=str,
+        dest="monitoring_port",
+        required=False,
+        help="acn node's monitoring service port number (local only)",
+    )
+    parser.add_argument(
+        "--acn-entry-peers-maddrs",
+        action="store",
+        nargs="*",
+        dest="entry_peers_maddrs",
+        help="acn node's entry peers in libp2p multiaddress format",
+    )
+    parser.add_argument(
+        "--k8s-fetchai-defaults",
+        action="store_true",
+        dest="k8s_fetchai_defaults",
+        required=False,
+        help="Use FetchAI defaults for k8s configuration",
+    )
+    parser.add_argument(
+        "--k8s-public-hostname",
+        action="store",
+        type=str,
+        dest="k8s_public_hostname",
+        required=False,
+        help="K8s public hostname to use for acn node's external uri",
+    )
+    parser.add_argument(
+        "--k8s-namespace",
+        action="store",
+        type=str,
+        dest="k8s_namespace",
+        required=False,
+        help="K8s deployment namespace",
+    )
+    parser.add_argument(
+        "--k8s-template-files-dir",
+        action="store",
+        type=str,
+        dest="k8s_template_files_dir",
+        required=False,
+        help="Directory containing k8s template yaml deployment files",
+    )
+
+    parser.add_argument(
+        "--docker-fetchai-defaults",
+        action="store_true",
+        dest="docker_fetchai_defaults",
+        required=False,
+        help="Use FetchAI defaults for docker configuration",
+    )
+    parser.add_argument(
+        "--docker-file",
+        action="store",
+        type=str,
+        dest="docker_file",
+        required=False,
+        help="Path to Dockerfile to build",
+    )
+    parser.add_argument(
+        "--docker-ctx",
+        action="store",
+        type=str,
+        dest="docker_ctx",
+        required=False,
+        help="Path to Dockerfile context",
+    )
+    parser.add_argument(
+        "--docker-image",
+        action="store",
+        type=str,
+        dest="docker_image",
+        required=False,
+        help="Docker image name",
+    )
+    parser.add_argument(
+        "--docker-registry",
+        action="store",
+        type=str,
+        dest="docker_registry",
+        required=False,
+        help="Docker remote registry",
+    )
+
+    args = parser.parse_args()
+
+    # checks
+    if args.from_file is None and (
+        args.key is None
+        or args.port is None
+        or args.delegate_port is None
+        or args.monitoring_port is None
+    ):
+        parser.error(
+            "--acn-key-file, --acn-port, --acn-port-delegate, --acn-port-monitoring are required when --from-file is not used"
+        )
+
+    if (
+        not args.from_file
+        and not args.k8s_fetchai_defaults
+        and (
+            args.k8s_public_hostname is None
+            or args.k8s_namespace is None
+            or args.k8s_template_files_dir is None
+        )
+    ):
+        parser.error(
+            "--k8s-public-hostname, --k8s-namespace, --k8s-template-files-dir are required when --k8s-fetchai-defaults is not set"
+        )
+
+    if (
+        not args.from_file
+        and not args.docker_fetchai_defaults
+        and (
+            args.docker_file is None
+            or args.docker_ctx is None
+            or args.docker_image is None
+            or args.docker_registry is None
+        )
+    ):
+        parser.error(
+            "--docker-file, --docker-ctx, --docker-image, --docker-registry are required when --docker-fetchai-defaults is not set"
+        )
+
+    return args
+
+
+if __name__ == "__main__":
+
+    args = parse_commandline()
+
+    pod_deployment: Optional[K8sPodDeployment] = None
+
+    if args.from_file:
+        pod_deployment = K8sPodDeployment([Path(args.from_file)], None)
+    else:
+        deployment_args: List[str] = [
+            args.key,
+            args.port,
+            args.delegate_port,
+            args.monitoring_port,
+            args.entry_peers_maddrs,
+        ]
+
+        docker_config : List[str] = []
+        if args.docker_fetchai_defaults:
+            docker_config = [
+                    DOCKER_FETCHAI_DEFAULT_FILE,
+                    DOCKER_FETCHAI_DEFAULT_CTX,
+                    DOCKER_FETCHAI_DEFAULT_IMG,
+                    DOCKER_FETCHAI_DEFAULT_REGISTRY,
+            ]
+        if args.docker_file is not None:
+            docker_config[0] = args.docker_file
+        if args.docker_ctx is not None:
+            docker_config[1] = args.docker_file
+        if args.docker_image is not None:
+            docker_config[2] = args.docker_image
+        if args.docker_registry is not None:
+            docker_config[3] = args.docker_registry
+
+        deployment_args.extend(docker_config)
+
+        k8s_config : List[str] = []
+        if args.k8s_fetchai_defaults:
+            k8s_config = [
+                    K8S_FETCHAI_DEFAULT_PUBLIC_HOST,
+                    K8S_FETCHAI_DEFAULT_NAMESPACE,
+                    K8S_FETCHAI_DEFAULT_PUBLIC_TEMPLATE_DIR,
+                ]
+        if args.k8s_public_hostname is not None:
+            k8s_config[0] = args.k8s_public_hostname
+        if args.k8s_namespace is not None:
+            k8s_config[1] = args.k8s_namespace
+        if args.k8s_template_files_dir is not None:
+            k8s_config[2] = args.k8s_template_files_dir
+
+        deployment_args.extend(k8s_config)
+        print(deployment_args)
+
+        pod_deployment = AcnK8sPodConfig(*deployment_args).generate_deployment()
+
+    try:
+        if args.delete_deployment:
+            pod_deployment.delete()
+        else:
+            pod_deployment.deploy()
+    except Exception as e:
+        raise e


### PR DESCRIPTION
## Proposed changes

Add script for reproducible deployment of an ACN node to kubernetes cluster.
Check self-review for more details.

## To test

``` bash
# deploy a node
python3 scripts/acn/k8s_deploy_acn_node.py --acn-key-file fet_key_test_1.txt --acn-port 9009 --acn-port-delegate 11009 --acn-port-monitoring 8080 --k8s-fetchai-defaults --docker-fetchai-defaults-dev
# delete the deployment
python3 scripts/acn/k8s_deploy_acn_node.py --acn-key-file fet_key_test_1.txt --acn-port 9009 --acn-port-delegate 11009 --acn-port-monitoring 8080 --k8s-fetchai-defaults --docker-fetchai-defaults-dev --delete
# redeploy
python3 scripts/acn/k8s_deploy_acn_node.py --from-file .acn_deployment.yaml 
# delete
python3 scripts/acn/k8s_deploy_acn_node.py  --from-file .acn_deployment.yaml --delete
```