### PR TITLE
Use mixed mode to retrieve latest public id in `aea upgrade`

### DIFF
--- a/tests/test_cli/test_upgrade.py
+++ b/tests/test_cli/test_upgrade.py
@@ -921,4 +921,7 @@ class TestNothingToUpgrade(AEATestCaseEmpty):
     def test_nothing_to_upgrade(self):
         """Test nothing to upgrade."""
         result = self.run_cli_command("upgrade", cwd=self._get_cwd())
-        assert result.stdout == "Starting project upgrade...\n"
+        assert (
+            result.stdout
+            == "Starting project upgrade...\nEverything is already up to date!\n"
+        )


### PR DESCRIPTION
## Proposed changes

Use mixed mode to retrieve latest public id (in 'aea upgrade'). This wasn't the case before this PR.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a