### PR TITLE
Change public dht dns from sandbox to prod for ip class test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,6 +187,10 @@ PUBLIC_DHT_P2P_MADDR_1 = "/dns4/agents-p2p-dht.sandbox.fetch-ai.com/tcp/9000/p2p
 PUBLIC_DHT_P2P_MADDR_2 = "/dns4/agents-p2p-dht.sandbox.fetch-ai.com/tcp/9001/p2p/16Uiu2HAmVWnopQAqq4pniYLw44VRvYxBUoRHqjz1Hh2SoCyjbyRW"
 PUBLIC_DHT_DELEGATE_URI_1 = "agents-p2p-dht.sandbox.fetch-ai.com:11000"
 PUBLIC_DHT_DELEGATE_URI_2 = "agents-p2p-dht.sandbox.fetch-ai.com:11001"
+PUBLIC_DHT_P2P_MADDR_1_PROD = "/dns4/agents-p2p-dht.prod.fetch-ai.com/tcp/9000/p2p/16Uiu2HAkw1ypeQYQbRFV5hKUxGRHocwU5ohmVmCnyJNg36tnPFdx"
+PUBLIC_DHT_P2P_MADDR_2_PROD = "/dns4/agents-p2p-dht.prod.fetch-ai.com/tcp/9001/p2p/16Uiu2HAmVWnopQAqq4pniYLw44VRvYxBUoRHqjz1Hh2SoCyjbyRW"
+PUBLIC_DHT_DELEGATE_URI_1_PROD = "agents-p2p-dht.prod.fetch-ai.com:11000"
+PUBLIC_DHT_DELEGATE_URI_2_PROD = "agents-p2p-dht.prod.fetch-ai.com:11001"
 
 # testnets
 COSMOS_TESTNET_CONFIG = {"address": COSMOS_DEFAULT_ADDRESS}

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_errors.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_errors.py
@@ -228,8 +228,6 @@ def test_libp2pconnection_mixed_ip_address():
     assert _ip_all_private_or_all_public(["fetch.ai", "127.0.0.1"]) is False
     assert _ip_all_private_or_all_public(["104.26.2.97", "127.0.0.1"]) is False
     assert (
-        _ip_all_private_or_all_public(
-            ["fetch.ai", "agents-p2p-dht.prod.fetch-ai.com"]
-        )
+        _ip_all_private_or_all_public(["fetch.ai", "agents-p2p-dht.prod.fetch-ai.com"])
         is True
     )

--- a/tests/test_packages/test_connections/test_p2p_libp2p/test_errors.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p/test_errors.py
@@ -229,7 +229,7 @@ def test_libp2pconnection_mixed_ip_address():
     assert _ip_all_private_or_all_public(["104.26.2.97", "127.0.0.1"]) is False
     assert (
         _ip_all_private_or_all_public(
-            ["fetch.ai", "agents-p2p-dht.sandbox.fetch-ai.com"]
+            ["fetch.ai", "agents-p2p-dht.prod.fetch-ai.com"]
         )
         is True
     )


### PR DESCRIPTION
## Proposed changes

This should fix failing tests with 

```python
addrs = ['fetch.ai', 'agents-p2p-dht.sandbox.fetch-ai.com']
    def _ip_all_private_or_all_public(addrs: List[str]) -> bool:
        if len(addrs) == 0:
            return True
        is_private = ip_address(gethostbyname(addrs[0])).is_private
        is_loopback = ip_address(gethostbyname(addrs[0])).is_loopback
        for addr in addrs:
>           if ip_address(gethostbyname(addr)).is_private != is_private:
E           socket.gaierror: [Errno 8] nodename nor servname provided, or not known
```