### PR TITLE
fix for multiplexer setup connections replace

### DIFF
--- a/aea/multiplexer.py
+++ b/aea/multiplexer.py
@@ -612,7 +612,11 @@ class AsyncMultiplexer(Runnable, WithLogger):
         :return: None.
         """
         self.default_routing = default_routing or {}
+
+        # replace connections
         self._connections = []
+        self._id_to_connection = {}
+
         for c in connections:
             self.add_connection(c, c.public_id == default_connection)
 

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -809,3 +809,14 @@ class TestMultiplexerDisconnectsOnTermination:  # pylint: disable=attribute-defi
             shutil.rmtree(self.t)
         except (OSError, IOError):
             pass
+
+
+def test_multiplexer_setup_replaces_connections():
+    """Test proper connections reset on setup call."""
+    m = AsyncMultiplexer([MagicMock(), MagicMock(), MagicMock()])
+    assert len(m._id_to_connection) == 3
+    assert len(m._connections) == 3
+
+    m.setup([MagicMock()], MagicMock())
+    assert len(m._id_to_connection) == 1
+    assert len(m._connections) == 1


### PR DESCRIPTION
## Proposed changes

connection added twice in gym ex. caused cause unproper cleanup on multiplexer.setup

## Fixes

https://github.com/fetchai/agents-aea/issues/1846

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
