### PR TITLE
[AEA-1035] Improve bump aea version script

### DIFF
--- a/scripts/bump_aea_version.py
+++ b/scripts/bump_aea_version.py
@@ -23,10 +23,8 @@
 import argparse
 import re
 import sys
-from operator import methodcaller
 from pathlib import Path
 
-from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 from aea.configurations.constants import (
@@ -56,6 +54,8 @@ CONFIGURATION_FILENAME_REGEX = re.compile(
         ]
     )
 )
+
+IGNORE_DIRS = [Path(".git")]
 
 
 def update_version_for_files(current_version: str, new_version: str) -> None:
@@ -153,7 +153,14 @@ def update_aea_version_specifiers(old_version: Version, new_version: Version) ->
         print("Not updating version specifier - they haven't changed.")
         return False
     for file in filter(lambda p: not p.is_dir(), Path(".").rglob("*")):
-        print(f"Replacing {old_specifier_set} with {new_specifier_set} in {file}...")
+        dir_root = Path(file.parts[0])
+        if dir_root in IGNORE_DIRS:
+            print(f"Skipping '{file}'...")
+            continue
+        print(
+            f"Replacing '{old_specifier_set}' with '{new_specifier_set}' in '{file}'... ",
+            end="",
+        )
         try:
             content = file.read_text()
         except UnicodeDecodeError as e:


### PR DESCRIPTION
## Proposed changes

Improve `bump _aea_version` script.
Now it also updates the specifier sets.

Say the old version if `0.7.4` and the new one is `1.0.0`; the script looks for occurrences in the whole codebase for specifier sets like `>=0.7.0,<0.8.0` and replace it with >=1.0.0,<1.1.0

since many replacements will occur in `packages/` , we also run the computation of hashes.

## Fixes

Partially addresses #1854

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a