### PR TITLE
fix for overrides config

### DIFF
--- a/tests/test_configurations/test_manager.py
+++ b/tests/test_configurations/test_manager.py
@@ -241,6 +241,18 @@ def test_agent_attribute_get_overridables():
     assert "is_abstract" in list(component_overrides.values())[0]
 
 
+def test_agent_attribute_get_and_apply_overridables():
+    """Test AgentConfigManager.get_overridables and apply it."""
+    agent_config_manager = AgentConfigManager.load(DUMMY_AEA, substitude_env_vars=False)
+    initial_agent_config_json = agent_config_manager.json
+    agent_overrides, component_overrides = agent_config_manager.get_overridables()
+    agent_config_manager.update_config(agent_overrides)
+    assert initial_agent_config_json == agent_config_manager.json
+
+    agent_overrides["component_configurations"] = component_overrides
+    agent_config_manager.update_config(agent_overrides)
+
+
 def test_dump_config():
     """Test AgentConfigManager.dump_config."""
     agent_config_manager = AgentConfigManager.load(DUMMY_AEA, substitude_env_vars=False)

--- a/tests/test_manager/test_manager.py
+++ b/tests/test_manager/test_manager.py
@@ -396,7 +396,7 @@ class TestMultiAgentManagerAsyncMode(
             components_overridables,
         ) = self.manager.get_agent_overridables(self.agent_name)
         assert "default_ledger" in agent_overridables
-        assert "timeout" in agent_overridables
+        assert "execution_timeout" in agent_overridables
         assert "description" in agent_overridables
         assert len(components_overridables) == 3
         assert "is_abstract" in components_overridables[0]


### PR DESCRIPTION
## Proposed changes

add NOT_SET value support for overridables.

## Fixes

some issues on applying default overridables cause not set and turn to None this causes validation error with json schema check.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
