### PR TITLE
AEA-1220 Move logging configuration loading in AEABuilder.build

### DIFF
--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -54,6 +54,7 @@ from aea.configurations.constants import (
     DEFAULT_CONNECTION,
     DEFAULT_ENV_DOTFILE,
     DEFAULT_LEDGER,
+    DEFAULT_LOGGING_CONFIG,
     DEFAULT_PROTOCOL,
     DEFAULT_REGISTRY_NAME,
 )
@@ -381,7 +382,7 @@ class AEABuilder(WithLogger):  # pylint: disable=too-many-public-methods
         self._runtime_mode: Optional[str] = None
         self._search_service_address: Optional[str] = None
         self._storage_uri: Optional[str] = None
-        self._logging_config: Dict = {}
+        self._logging_config: Dict = DEFAULT_LOGGING_CONFIG
 
         self._package_dependency_manager = _DependenciesManager()
         if self._with_default_packages:

--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -381,6 +381,7 @@ class AEABuilder(WithLogger):  # pylint: disable=too-many-public-methods
         self._runtime_mode: Optional[str] = None
         self._search_service_address: Optional[str] = None
         self._storage_uri: Optional[str] = None
+        self._logging_config: Dict = {}
 
         self._package_dependency_manager = _DependenciesManager()
         if self._with_default_packages:
@@ -560,6 +561,22 @@ class AEABuilder(WithLogger):  # pylint: disable=too-many-public-methods
         :return: self
         """
         self._storage_uri = storage_uri
+        return self
+
+    def set_logging_config(
+        self, logging_config: Dict
+    ) -> "AEABuilder":  # pragma: nocover
+        """
+        Set the logging configurations.
+
+        The dictionary must satisfy the following schema:
+
+          https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
+
+        :param logging_config: the logging configurations.
+        :return: self
+        """
+        self._logging_config = logging_config
         return self
 
     def set_search_service_address(
@@ -1100,6 +1117,7 @@ class AEABuilder(WithLogger):  # pylint: disable=too-many-public-methods
         :raises ValueError: if we cannot
         """
         self._check_we_can_build()
+        logging.config.dictConfig(self._logging_config)
         wallet = Wallet(
             copy(self.private_key_paths), copy(self.connection_private_key_paths)
         )
@@ -1454,6 +1472,7 @@ class AEABuilder(WithLogger):  # pylint: disable=too-many-public-methods
         self.set_loop_mode(agent_configuration.loop_mode)
         self.set_runtime_mode(agent_configuration.runtime_mode)
         self.set_storage_uri(agent_configuration.storage_uri)
+        self.set_logging_config(agent_configuration.logging_config)
 
         # load private keys
         for (
@@ -1561,7 +1580,6 @@ class AEABuilder(WithLogger):  # pylint: disable=too-many-public-methods
         """
         aea_project_path = Path(aea_project_path)
         cls.try_to_load_agent_configuration_file(aea_project_path)
-
         load_env_file(str(aea_project_path / DEFAULT_ENV_DOTFILE))
 
         # check and create missing, do not replace env variables. updates config

--- a/aea/cli/utils/config.py
+++ b/aea/cli/utils/config.py
@@ -35,8 +35,6 @@
 #
 # ------------------------------------------------------------------------------
 """A module with config tools of the aea cli."""
-import logging
-import logging.config
 import os
 from pathlib import Path
 from typing import Dict, Set
@@ -81,7 +79,6 @@ def try_to_load_agent_config(
         with path.open(mode="r", encoding="utf-8") as fp:
             ctx.agent_config = ctx.agent_loader.load(fp)
             ctx.agent_config.directory = Path(agent_src_path)
-            logging.config.dictConfig(ctx.agent_config.logging_config)
     except FileNotFoundError:
         if is_exit_on_except:
             raise click.ClickException(

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -52,6 +52,7 @@ from aea.configurations.constants import (
     DEFAULT_CONTRACT_CONFIG_FILE,
     DEFAULT_FINGERPRINT_IGNORE_PATTERNS,
     DEFAULT_LICENSE,
+    DEFAULT_LOGGING_CONFIG,
     DEFAULT_PROTOCOL_CONFIG_FILE,
     DEFAULT_REGISTRY_NAME,
     DEFAULT_SKILL_CONFIG_FILE,
@@ -1140,7 +1141,7 @@ class AgentConfig(PackageConfiguration):
         self.private_key_paths = CRUDCollection[str]()
         self.connection_private_key_paths = CRUDCollection[str]()
 
-        self.logging_config = logging_config if logging_config is not None else {}
+        self.logging_config = logging_config or DEFAULT_LOGGING_CONFIG
         self.default_ledger = default_ledger
         self.currency_denominations = (
             currency_denominations if currency_denominations is not None else {}
@@ -1154,10 +1155,6 @@ class AgentConfig(PackageConfiguration):
         self.contracts = set()  # type: Set[PublicId]
         self.protocols = set()  # type: Set[PublicId]
         self.skills = set()  # type: Set[PublicId]
-
-        if self.logging_config == {}:
-            self.logging_config["version"] = 1
-            self.logging_config["disable_existing_loggers"] = False
 
         self.period: Optional[float] = period
         self.execution_timeout: Optional[float] = execution_timeout

--- a/aea/configurations/constants.py
+++ b/aea/configurations/constants.py
@@ -73,6 +73,7 @@ DEFAULT_FINGERPRINT_IGNORE_PATTERNS = [
 ]
 DEFAULT_PYPI_INDEX_URL = "https://pypi.org/simple"
 DEFAULT_GIT_REF = "master"
+DEFAULT_LOGGING_CONFIG = {"version": 1, "disable_existing_loggers": False}
 IMPORT_TEMPLATE_1 = "from packages.{author}.{type}.{name}"
 IMPORT_TEMPLATE_2 = "import packages.{author}.{type}.{name}"
 DEFAULT_ENV_DOTFILE = ".env"


### PR DESCRIPTION
## Proposed changes

Move logging configuration  loading  from `aea.cli.utils.config.try_to_load_agent_config` to ~AEABuilder.from_aea_project.~ `AEABuilder.build`. 

## Fixes

Fixes #2159

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a