### PR TITLE
AEA-1221 Make multi-agent manager fetch in mixed mode by default

### DIFF
--- a/aea/cli/fetch.py
+++ b/aea/cli/fetch.py
@@ -76,7 +76,7 @@ def do_fetch(
     :param local: whether to fetch from local
     :param remote whether to fetch from remote
     :param alias: the agent alias.
-    :param alias: the target directory, in case fetching locally.
+    :param target_dir: the target directory, in case fetching locally.
     :return: None
     """
     enforce(
@@ -86,11 +86,11 @@ def do_fetch(
     ctx.set_config("is_local", local and not remote)
     ctx.set_config("is_mixed", is_mixed)
     if remote:
-        fetch_agent(ctx, public_id, alias)
+        fetch_agent(ctx, public_id, alias=alias, target_dir=target_dir)
     elif local:
-        fetch_agent_locally(ctx, public_id, alias, target_dir=target_dir)
+        fetch_agent_locally(ctx, public_id, alias=alias, target_dir=target_dir)
     else:
-        fetch_mixed(ctx, public_id, alias)
+        fetch_mixed(ctx, public_id, alias=alias, target_dir=target_dir)
 
 
 def _is_version_correct(ctx: Context, agent_public_id: PublicId) -> bool:

--- a/aea/cli/fetch.py
+++ b/aea/cli/fetch.py
@@ -57,13 +57,38 @@ from aea.exceptions import enforce
 def fetch(click_context, public_id, alias, local, remote):
     """Fetch an agent from the registry."""
     ctx = cast(Context, click_context.obj)
+    do_fetch(ctx, public_id, local, remote, alias)
+
+
+def do_fetch(
+    ctx: Context,
+    public_id: PublicId,
+    local: bool,
+    remote: bool,
+    alias: Optional[str] = None,
+    target_dir: Optional[str] = None,
+):
+    """
+    Run the Fetch command.
+
+    :param ctx: the CLI context.
+    :param public_id: the public id.
+    :param local: whether to fetch from local
+    :param remote whether to fetch from remote
+    :param alias: the agent alias.
+    :param alias: the target directory, in case fetching locally.
+    :return: None
+    """
+    enforce(
+        not (local and remote), "'local' and 'remote' options are mutually exclusive."
+    )
     is_mixed = not local and not remote
     ctx.set_config("is_local", local and not remote)
     ctx.set_config("is_mixed", is_mixed)
     if remote:
         fetch_agent(ctx, public_id, alias)
     elif local:
-        fetch_agent_locally(ctx, public_id, alias)
+        fetch_agent_locally(ctx, public_id, alias, target_dir=target_dir)
     else:
         fetch_mixed(ctx, public_id, alias)
 

--- a/aea/manager/manager.py
+++ b/aea/manager/manager.py
@@ -233,7 +233,17 @@ class MultiAgentManager:
     def start_manager(
         self, local: bool = False, remote: bool = False
     ) -> "MultiAgentManager":
-        """Start manager."""
+        """
+        Start manager.
+
+        If local = False and remote = False, then the packages
+        are fetched in mixed mode (i.e. first try from local
+        registry, and then from remote registry in case of failure).
+
+        :param local: whether or not to fetch from local registry.
+        :param remote: whether or not to fetch from remote registry.
+        :return: the MultiAgentManager instance.
+        """
         if self._is_running:
             return self
 
@@ -310,6 +320,10 @@ class MultiAgentManager:
     ) -> "MultiAgentManager":
         """
         Fetch agent project and all dependencies to working_dir.
+
+        If local = False and remote = False, then the packages
+        are fetched in mixed mode (i.e. first try from local
+        registry, and then from remote registry in case of failure).
 
         :param public_id: the public if of the agent project.
         :param local: whether or not to fetch from local registry.
@@ -673,8 +687,14 @@ class MultiAgentManager:
         """
         Load saved state from file.
 
-        :param local: bool is local project and agents re-creation.
-        :param remote: bool if it is a remote project.
+        Fetch agent project and all dependencies to working_dir.
+
+        If local = False and remote = False, then the packages
+        are fetched in mixed mode (i.e. first try from local
+        registry, and then from remote registry in case of failure).
+
+        :param local: whether or not to fetch from local registry.
+        :param remote: whether or not to fetch from remote registry.
 
         :return: None
         :raises: ValueError if failed to load state.

--- a/aea/manager/manager.py
+++ b/aea/manager/manager.py
@@ -230,13 +230,15 @@ class MultiAgentManager:
         """Add error callback to call on error raised."""
         self._error_callbacks.append(error_callback)
 
-    def start_manager(self, local: bool = True) -> "MultiAgentManager":
+    def start_manager(
+        self, local: bool = False, remote: bool = False
+    ) -> "MultiAgentManager":
         """Start manager."""
         if self._is_running:
             return self
 
         self._ensure_working_dir()
-        self._load_state(local=local)
+        self._load_state(local=local, remote=remote)
 
         self._started_event.clear()
         self._is_running = True
@@ -300,13 +302,18 @@ class MultiAgentManager:
                 rmtree(self.working_dir)
 
     def add_project(
-        self, public_id: PublicId, local: bool = True, restore: bool = False
+        self,
+        public_id: PublicId,
+        local: bool = False,
+        remote: bool = False,
+        restore: bool = False,
     ) -> "MultiAgentManager":
         """
         Fetch agent project and all dependencies to working_dir.
 
         :param public_id: the public if of the agent project.
         :param local: whether or not to fetch from local registry.
+        :param remote: whether or not to fetch from remote registry.
         :param restore: bool flag for restoring already fetched agent.
         """
         if public_id.to_any() in self._versionless_projects_set:
@@ -320,6 +327,7 @@ class MultiAgentManager:
             self.working_dir,
             public_id,
             local,
+            remote,
             registry_path=self.registry_path,
             is_restore=restore,
         )
@@ -661,11 +669,12 @@ class MultiAgentManager:
         if not os.path.exists(self.certs_dir):
             os.makedirs(self.certs_dir)
 
-    def _load_state(self, local: bool) -> None:
+    def _load_state(self, local: bool, remote: bool) -> None:
         """
         Load saved state from file.
 
         :param local: bool is local project and agents re-creation.
+        :param remote: bool if it is a remote project.
 
         :return: None
         :raises: ValueError if failed to load state.
@@ -683,7 +692,10 @@ class MultiAgentManager:
         try:
             for public_id in save_json["projects"]:
                 self.add_project(
-                    PublicId.from_str(public_id), local=local, restore=True
+                    PublicId.from_str(public_id),
+                    local=local,
+                    remote=remote,
+                    restore=True,
                 )
 
             for agent_settings in save_json["agents"]:

--- a/aea/manager/project.py
+++ b/aea/manager/project.py
@@ -96,6 +96,10 @@ class Project(_Base):
         """
         Load project with given public_id to working_dir.
 
+        If local = False and remote = False, then the packages
+        are fetched in mixed mode (i.e. first try from local
+        registry, and then from remote registry in case of failure).
+
         :param working_dir: the working directory
         :param public_id: the public id
         :param is_local: whether to fetch from local

--- a/aea/manager/project.py
+++ b/aea/manager/project.py
@@ -25,9 +25,8 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from aea.aea import AEA
 from aea.aea_builder import AEABuilder
-from aea.cli.fetch import fetch_agent_locally
+from aea.cli.fetch import do_fetch
 from aea.cli.issue_certificates import issue_certificates_
-from aea.cli.registry.fetch import fetch_agent
 from aea.cli.utils.context import Context
 from aea.configurations.base import AgentConfig, PublicId
 from aea.configurations.constants import DEFAULT_REGISTRY_NAME
@@ -89,6 +88,7 @@ class Project(_Base):
         working_dir: str,
         public_id: PublicId,
         is_local: bool = False,
+        is_remote: bool = False,
         is_restore: bool = False,
         registry_path: str = DEFAULT_REGISTRY_NAME,
         skip_consistency_check: bool = False,
@@ -98,7 +98,8 @@ class Project(_Base):
 
         :param working_dir: the working directory
         :param public_id: the public id
-        :param is_local: whether to fetch from local or remote
+        :param is_local: whether to fetch from local
+        :param is_remote whether to fetch from remote
         :param registry_path: the path to the registry locally
         :param skip_consistency_check: consistency checks flag
         """
@@ -109,12 +110,7 @@ class Project(_Base):
         target_dir = os.path.join(public_id.author, public_id.name)
 
         if not is_restore and not os.path.exists(target_dir):
-            if is_local:
-                ctx.set_config("is_local", True)
-                fetch_agent_locally(ctx, public_id, target_dir=target_dir)
-            else:
-                fetch_agent(ctx, public_id, target_dir=target_dir)  # pragma: nocover
-
+            do_fetch(ctx, public_id, is_local, is_remote, target_dir=target_dir)
         return cls(public_id, path)
 
     def remove(self) -> None:


### PR DESCRIPTION
## Proposed changes

Make the multi-agent manager fetch in mixed mode by default.

It involved minor refactoring in `aea.cli.fetch` and in the agent manager APIs (added `remote` flag alongside `local`).

## Fixes

Fixes #2155 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
n/a