### PR TITLE
AEA-1223 Add prompt in "aea upgrade" in case project is on registry with newer version

### DIFF
--- a/aea/helpers/base.py
+++ b/aea/helpers/base.py
@@ -25,6 +25,7 @@ import logging
 import os
 import platform
 import re
+import shutil
 import signal
 import subprocess  # nosec
 import sys
@@ -863,3 +864,13 @@ def decorator_with_optional_params(decorator):
         return final_decorator
 
     return new_decorator
+
+
+def delete_directory_contents(directory: Path):
+    """Delete the content of a directory, without deleting it."""
+    enforce(directory.is_dir(), f"Path '{directory}' must be a directory.")
+    for filename in directory.iterdir():
+        if filename.is_file() or filename.is_symlink():
+            filename.unlink()
+        elif filename.is_dir():
+            shutil.rmtree(str(filename), ignore_errors=False)

--- a/tests/common/mocks.py
+++ b/tests/common/mocks.py
@@ -47,7 +47,7 @@ class RegexComparator(str):
         """Check equality."""
         regex = re.compile(str(self), re.MULTILINE | re.DOTALL)
         s = str(other)
-        return bool(regex.match(s))
+        return bool(regex.search(s))
 
 
 @contextmanager

--- a/tests/test_cli/test_upgrade.py
+++ b/tests/test_cli/test_upgrade.py
@@ -22,6 +22,7 @@ import os
 import shutil
 import tempfile
 from contextlib import contextmanager
+from filecmp import dircmp
 from pathlib import Path
 from typing import List, Set, cast
 from unittest import mock
@@ -62,6 +63,7 @@ from packages.fetchai.protocols.oef_search.message import OefSearchMessage
 from packages.fetchai.skills.echo import PUBLIC_ID as ECHO_SKILL_PUBLIC_ID
 from packages.fetchai.skills.error import PUBLIC_ID as ERROR_SKILL_PUBLIC_ID
 
+from tests.common.mocks import RegexComparator
 from tests.common.utils import are_dirs_equal
 from tests.conftest import AUTHOR, CLI_LOG_OPTION, CUR_PATH, CliRunner
 
@@ -930,19 +932,27 @@ class TestUpdateReferences(AEATestCaseEmpty):
         assert result.stdout == "True\n"
 
 
+@mock.patch("click.echo")
 class TestNothingToUpgrade(AEATestCaseEmpty):
     """Test the upgrade command when there's nothing t upgrade."""
 
-    def test_nothing_to_upgrade(self):
+    def test_nothing_to_upgrade(self, mock_click_echo):
         """Test nothing to upgrade."""
+        agent_config = self.load_agent_config(self.agent_name)
         result = self.run_cli_command("upgrade", cwd=self._get_cwd())
-        assert (
-            result.stdout
-            == "Starting project upgrade...\nEverything is already up to date!\n"
+        assert result.exit_code == 0
+        mock_click_echo.assert_any_call("Starting project upgrade...")
+        mock_click_echo.assert_any_call(
+            f"Checking if there is a newer remote version of agent package '{agent_config.public_id}'..."
         )
+        mock_click_echo.assert_any_call(
+            "Package not found, continuing with normal upgrade."
+        )
+        mock_click_echo.assert_any_call("Everything is already up to date!")
 
 
 @pytest.mark.integration
+@mock.patch("click.echo")
 class TestWrongAEAVersion(AEATestCaseEmpty):
     """
     Test consistency check ignores AEA version fields.
@@ -977,12 +987,13 @@ class TestWrongAEAVersion(AEATestCaseEmpty):
             cls.nested_set_config(dotted_path, cls.AEA_VERSION_SPECIFIER)
             cls.run_cli_command("fingerprint", "by-path", path, cwd=cls._get_cwd())
 
-    def test_nothing_to_upgrade(self):
+    def test_nothing_to_upgrade(self, mock_click_echo):
         """Test nothing to upgrade, and additionally, that 'aea_version' is correct."""
         result = self.run_cli_command("upgrade", cwd=self._get_cwd())
-        assert (
-            "Starting project upgrade...\nUpdating AEA version specifier from ==0.1.0 to >=0.9.0, <0.10.0."
-            in result.stdout
+        assert result.exit_code == 0
+        mock_click_echo.assert_any_call("Starting project upgrade...")
+        mock_click_echo.assert_any_call(
+            "Updating AEA version specifier from ==0.1.0 to >=0.9.0, <0.10.0."
         )
 
         # test 'aea_version' of agent configuration is upgraded
@@ -995,6 +1006,9 @@ class TestWrongAEAVersion(AEATestCaseEmpty):
         assert agent_config.version == DEFAULT_VERSION
 
 
+@mock.patch("click.echo")
+@mock.patch("click.confirm")
+@mock.patch("aea.cli.upgrade.get_latest_version_available_in_registry")
 class BaseTestUpgradeWithEject(AEATestCaseEmpty):
     """
     Base test class to test 'aea upgrade' with request for ejection.
@@ -1010,6 +1024,10 @@ class BaseTestUpgradeWithEject(AEATestCaseEmpty):
         ComponentType.SKILL, PublicId.from_str("fetchai/generic_seller:0.18.0")
     )
     unmocked = get_latest_version_available_in_registry
+
+    EXPECTED_CLICK_ECHO_CALLS: List[str] = []
+    EXPECTED_CLICK_CONFIRM_CALLS: List[str] = []
+    CONFIRM_OUTPUT = [False, False]
 
     @classmethod
     def setup_class(cls):
@@ -1035,52 +1053,133 @@ class BaseTestUpgradeWithEject(AEATestCaseEmpty):
             side_effect=self.mock_get_latest_version_available_in_registry,
         )
 
-    def _assert_lines_in_stdout(self, lines: List[str], stdout: str):
+    def test_run(self, mock_get_latest_version, mock_click_confirm, mock_click_echo):
+        """Run the test."""
+        mock_get_latest_version.side_effect = (
+            self.mock_get_latest_version_available_in_registry
+        )
+        mock_click_confirm.side_effect = self.CONFIRM_OUTPUT
+        result = self.run_cli_command("upgrade", cwd=self._get_cwd())
+        assert result.exit_code == 0
+        self.mock_click_echo = mock_click_echo
+        self.mock_click_confirm = mock_click_confirm
+        self._assert_calls(self.EXPECTED_CLICK_ECHO_CALLS, mock_click_echo)
+        self._assert_calls(self.EXPECTED_CLICK_CONFIRM_CALLS, mock_click_confirm)
+
+    def _assert_calls(self, args: List, stdout_mock: MagicMock):
         """Assert lines are present in stdout."""
-        for expected_line in lines:
-            assert (
-                expected_line in stdout
-            ), f"Expected line {expected_line} not found in"
+        for expected_line in args:
+            stdout_mock.assert_any_call(expected_line)
 
 
 @pytest.mark.integration
 class TestUpgradeWithEjectAbort(BaseTestUpgradeWithEject):
     """Test 'aea upgrade' command with request for ejection, refused."""
 
-    def test_run(self):
-        """Run the test."""
-        with self._get_mock():
-            result = self.run_cli_command("upgrade", cwd=self._get_cwd())
-
-        expected_stdout_lines = [
-            "Skill fetchai/generic_seller:0.18.0 prevents the upgrade of the following vendor packages:",
-            "as there isn't a compatible version available on the AEA registry. Would you like to eject it? [y/N]:",
-            "Abort.",
-        ]
-        self._assert_lines_in_stdout(expected_stdout_lines, result.stdout)
+    EXPECTED_CLICK_ECHO_CALLS = ["Abort."]
+    EXPECTED_CLICK_CONFIRM_CALLS = [
+        RegexComparator(
+            r"Skill fetchai/generic_seller:0.18.0 prevents the upgrade of the following vendor packages:.*as there isn't a compatible version available on the AEA registry\. Would you like to eject it\?"
+        )
+    ]
 
 
 @pytest.mark.integration
 class TestUpgradeWithEjectAccept(BaseTestUpgradeWithEject):
     """Test 'aea upgrade' command with request for ejection, accepted by the user."""
 
-    def test_run(self):
+    CONFIRM_OUTPUT = [True, True]
+
+    EXPECTED_CLICK_ECHO_CALLS = [
+        "Ejecting (skill, fetchai/generic_seller:0.18.0)...",
+        "Ejecting item skill fetchai/generic_seller:0.18.0",
+        "Fingerprinting skill components of 'default_author/generic_seller:0.1.0' ...",
+        "Successfully ejected skill fetchai/generic_seller:0.18.0 to ./skills/generic_seller as default_author/generic_seller:0.1.0.",
+    ]
+    EXPECTED_CLICK_CONFIRM_CALLS = [
+        RegexComparator(
+            "Skill fetchai/generic_seller:0.18.0 prevents the upgrade of the following vendor packages:"
+        ),
+        RegexComparator(
+            "as there isn't a compatible version available on the AEA registry. Would you like to eject it?"
+        ),
+    ]
+
+    def test_run(self, *mocks):
         """Run the test."""
-        with self._get_mock():
-            result = self.run_cli_command("upgrade", cwd=self._get_cwd(), input="y\n")
-
-        expected_stdout_lines = [
-            "Skill fetchai/generic_seller:0.18.0 prevents the upgrade of the following vendor packages:",
-            "as there isn't a compatible version available on the AEA registry. Would you like to eject it? [y/N]: y",
-            "Ejecting (skill, fetchai/generic_seller:0.18.0)...",
-            "Ejecting item skill fetchai/generic_seller:0.18.0",
-            "Fingerprinting skill components of 'default_author/generic_seller:0.1.0' ...",
-            "Successfully ejected skill fetchai/generic_seller:0.18.0 to ./skills/generic_seller as default_author/generic_seller:0.1.0.",
-        ]
-        self._assert_lines_in_stdout(expected_stdout_lines, result.stdout)
-
+        super().test_run(*mocks)
         ejected_package_path = Path(
             self.t, self.current_agent_context, "skills", "generic_seller"
         )
         assert ejected_package_path.exists()
         assert ejected_package_path.is_dir()
+
+
+class BaseTestUpgradeProject(AEATestCaseEmpty):
+    """Base test class for testing project upgrader."""
+
+    OLD_AGENT_PUBLIC_ID = PublicId.from_str("fetchai/weather_station:0.19.0")
+    EXPECTED = "expected_agent"
+
+    @classmethod
+    def setup_class(cls):
+        """Set up the test."""
+        super().setup_class()
+        cls.run_cli_command(
+            "--skip-consistency-check",
+            "fetch",
+            str(cls.OLD_AGENT_PUBLIC_ID.to_latest()),
+            "--alias",
+            cls.EXPECTED,
+        )
+
+    def setup(self):
+        """Set up the class."""
+        self.run_cli_command("fetch", str(self.OLD_AGENT_PUBLIC_ID))
+        self.set_agent_context(self.OLD_AGENT_PUBLIC_ID.name)
+
+    def teardown(self):
+        """Tear down class."""
+        shutil.rmtree(self.current_agent_context)
+
+
+@mock.patch("click.confirm")
+class TestUpgradeProjectWithNewerVersion(BaseTestUpgradeProject):
+    """Test upgrade project with newer version available."""
+
+    @pytest.mark.parametrize("confirm", [True, False])
+    def test_upgrade(self, mock_confirm, confirm):
+        """Test upgrade."""
+        mock_confirm.return_value = confirm
+        result = self.run_cli_command("upgrade", cwd=self._get_cwd())
+        assert result.exit_code == 0
+
+        mock_confirm.assert_any_call(
+            RegexComparator(
+                r"Found a newer version of this project:.*Would you like to replace this project with it\?.*Warning: the content in the current directory.*will be removed"
+            )
+        )
+
+        # compare with latest fetched agent.
+        assert dircmp(self.current_agent_context, self.EXPECTED)
+
+
+@mock.patch("aea.cli.upgrade.get_latest_version_available_in_registry")
+@mock.patch("click.echo")
+class TestUpgradeProjectWithoutNewerVersion(BaseTestUpgradeProject):
+    """Test upgrade project without newer version available (but available on registry)."""
+
+    def test_run(self, mock_click_echo, mock_get_latest_version):
+        """Run the test."""
+        fake_old_public_id = self.OLD_AGENT_PUBLIC_ID
+        mock_get_latest_version.return_value = fake_old_public_id
+        result = self.run_cli_command("upgrade", cwd=self._get_cwd())
+        assert result.exit_code == 0
+
+        version_str = str(self.OLD_AGENT_PUBLIC_ID.version)
+        mock_click_echo.assert_any_call(
+            f"Latest version found is '{version_str}' which is smaller or equal than current version '{version_str}'. Continuing..."
+        )
+
+        # compare with latest fetched agent.
+        assert dircmp(self.current_agent_context, self.EXPECTED)

--- a/tests/test_helpers/test_base.py
+++ b/tests/test_helpers/test_base.py
@@ -21,7 +21,9 @@ import datetime
 import os
 import platform
 import re
+import shutil
 import signal
+import tempfile
 import time
 from copy import copy
 from functools import wraps
@@ -53,7 +55,7 @@ from aea.helpers.base import (
     retry_decorator,
     send_control_c,
     try_decorator,
-    win_popen_kwargs,
+    win_popen_kwargs, cd, delete_directory_contents,
 )
 
 from packages.fetchai.connections.oef.connection import OEFConnection
@@ -639,3 +641,35 @@ def test_decorator_with_optional_params():
 
     assert hello_with_preamble("User") == "Computer says: Hello, User!"
     assert hello_from_commodore("User") == "Computer Commodore 64 says: Hello, User!"
+
+
+class TestDeleteDirectoryContents:
+    """Test utility 'delete_directory_contents'."""
+
+    def setup(self):
+        """Set up the test."""
+        self.root = Path(tempfile.mkdtemp())
+        # create a file
+        file_1 = (self.root / "file_1")
+        file_1.touch()
+
+        # create a symlink
+        (self.root / "symlink_1").symlink_to(file_1)
+
+        # create a subdirectory
+        subdir = (self.root / "directory")
+        subdir.mkdir()
+
+        # create a file in the directory
+        (subdir / "file").touch()
+
+    def test_main(self):
+        """Run the test."""
+        delete_directory_contents(self.root)
+
+        assert self.root.exists()
+        assert len(list(self.root.iterdir())) == 0
+
+    def teardown(self):
+        """Tear down the test."""
+        shutil.rmtree(str(self.root), ignore_errors=True)

--- a/tests/test_helpers/test_base.py
+++ b/tests/test_helpers/test_base.py
@@ -43,6 +43,7 @@ from aea.helpers.base import (
     RegexConstrainedString,
     compute_specifier_from_version,
     decorator_with_optional_params,
+    delete_directory_contents,
     dict_to_path_value,
     ensure_dir,
     exception_log_and_reraise,
@@ -55,7 +56,7 @@ from aea.helpers.base import (
     retry_decorator,
     send_control_c,
     try_decorator,
-    win_popen_kwargs, cd, delete_directory_contents,
+    win_popen_kwargs,
 )
 
 from packages.fetchai.connections.oef.connection import OEFConnection
@@ -650,14 +651,14 @@ class TestDeleteDirectoryContents:
         """Set up the test."""
         self.root = Path(tempfile.mkdtemp())
         # create a file
-        file_1 = (self.root / "file_1")
+        file_1 = self.root / "file_1"
         file_1.touch()
 
         # create a symlink
         (self.root / "symlink_1").symlink_to(file_1)
 
         # create a subdirectory
-        subdir = (self.root / "directory")
+        subdir = self.root / "directory"
         subdir.mkdir()
 
         # create a file in the directory


### PR DESCRIPTION
## Proposed changes

With this PR, at the beginning of `aea upgrade`, in case the project is on the registry with a newer version, the user has the option to download the latest version and replace the current project with the new one.

## Fixes

Fixes AEA-1223 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a