### PR TITLE
AEA-1229 aea clie add-key file not found small fix

### DIFF
--- a/aea/cli/add_key.py
+++ b/aea/cli/add_key.py
@@ -34,6 +34,11 @@ from aea.crypto.helpers import try_validate_private_key_path
 from aea.crypto.registries import crypto_registry
 
 
+key_file_argument = click.Path(
+    exists=True, file_okay=True, dir_okay=False, readable=True
+)
+
+
 @click.command()
 @click.argument(
     "type_",
@@ -42,10 +47,7 @@ from aea.crypto.registries import crypto_registry
     required=True,
 )
 @click.argument(
-    "file",
-    metavar="FILE",
-    type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True),
-    required=False,
+    "file", metavar="FILE", type=key_file_argument, required=False,
 )
 @click.option(
     "--connection", is_flag=True, help="For adding a private key for connections."
@@ -76,6 +78,9 @@ def _add_private_key(
     ctx = cast(Context, click_context.obj)
     if file is None:
         file = PRIVATE_KEY_PATH_SCHEMA.format(type_)
+
+    key_file_argument.convert(file, None, click_context)
+
     try_validate_private_key_path(type_, file)
     _try_add_key(ctx, type_, file, connection)
 

--- a/tests/test_cli/test_add_key.py
+++ b/tests/test_cli/test_add_key.py
@@ -16,7 +16,6 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-
 """This test module contains the tests for the `aea add-key` sub-command."""
 import os
 import shutil
@@ -24,7 +23,9 @@ import tempfile
 from pathlib import Path
 from unittest import TestCase, mock
 
+import pytest
 import yaml
+from click.exceptions import BadParameter
 
 import aea
 from aea.cli import cli
@@ -358,3 +359,40 @@ class AddKeyCommandTestCase(TestCase):
             standalone_mode=False,
         )
         self.assertEqual(result.exit_code, 0)
+
+
+@mock.patch("aea.cli.utils.decorators.try_to_load_agent_config")
+@mock.patch("aea.cli.add_key.try_validate_private_key_path")
+@mock.patch("aea.cli.add_key._try_add_key")
+class CheckFileNotExistsTestCase(TestCase):
+    """Test case for CLI add_key command."""
+
+    def setUp(self):
+        """Set it up."""
+        self.runner = CliRunner()
+
+    def test_file_specified_does_not_exist(self, *mocks):
+        """Test for CLI add_key fails on file not exists."""
+        with pytest.raises(BadParameter, match=r"File '.*' does not exist."):
+            self.runner.invoke(
+                cli,
+                [
+                    *CLI_LOG_OPTION,
+                    "--skip-consistency-check",
+                    "add-key",
+                    FETCHAI,
+                    "somefile",
+                ],
+                standalone_mode=False,
+                catch_exceptions=False,
+            )
+
+    def test_file_not_specified_does_not_exist(self, *mocks):
+        """Test for CLI add_key fails on file not exists."""
+        with pytest.raises(BadParameter, match=r"File '.*' does not exist."):
+            self.runner.invoke(
+                cli,
+                [*CLI_LOG_OPTION, "--skip-consistency-check", "add-key", FETCHAI],
+                standalone_mode=False,
+                catch_exceptions=False,
+            )


### PR DESCRIPTION
## Proposed changes

fix for err message on file not found for aea cli add-key with no file specified

## Fixes

https://github.com/fetchai/agents-aea/issues/2161

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
