### PR TITLE
[AEA-1222] add aea version compatibility in 'aea upgrade'

### DIFF
--- a/aea/cli/registry/utils.py
+++ b/aea/cli/registry/utils.py
@@ -21,6 +21,7 @@
 import os
 import tarfile
 from json.decoder import JSONDecodeError
+from typing import Optional
 
 import click
 
@@ -219,22 +220,31 @@ def is_auth_token_present():
     return get_auth_token() is not None
 
 
-def get_package_meta(obj_type: str, public_id: PublicId) -> dict:
+def get_package_meta(
+    obj_type: str, public_id: PublicId, aea_version: Optional[str] = None
+) -> dict:
     """
     Get package meta data from remote registry.
 
+    Optionally filter by AEA version.
+
     :param obj_type: str. component type
     :param public_id: component public id
+    :param aea_version: the AEA version (e.g. "0.1.0") or None.
 
     :return: dict with package details
     """
+    params = dict(aea_version=aea_version) if aea_version else {}
     api_path = f"/{obj_type}s/{public_id.author}/{public_id.name}/{public_id.version}"
-    resp = request_api("GET", api_path)
+    resp = request_api("GET", api_path, params=params)
     return resp
 
 
 def get_latest_public_id_mixed(
-    ctx: Context, item_type: str, item_public_id: PublicId,
+    ctx: Context,
+    item_type: str,
+    item_public_id: PublicId,
+    aea_version: Optional[str] = None,
 ) -> PublicId:
     """
     Get latest public id of the message, mixed mode.
@@ -245,6 +255,7 @@ def get_latest_public_id_mixed(
     :param ctx: the CLI context.
     :param item_type: the item type.
     :param item_public_id: the item public id.
+    :param aea_version: the AEA version constraint, or None
     :return: the path to the found package.
     """
     try:
@@ -255,20 +266,28 @@ def get_latest_public_id_mixed(
             "Get latest public id from local registry failed, trying remote registry..."
         )
         # the following might raise exception, but we don't catch it this time
-        package_meta = get_package_meta(item_type, item_public_id)
+        package_meta = get_package_meta(
+            item_type, item_public_id, aea_version=aea_version
+        )
         latest_item_public_id = PublicId.from_str(package_meta["public_id"])
     return latest_item_public_id
 
 
 def get_latest_version_available_in_registry(
-    ctx: Context, item_type: str, item_public_id: PublicId
+    ctx: Context,
+    item_type: str,
+    item_public_id: PublicId,
+    aea_version: Optional[str] = None,
 ) -> PublicId:
     """
     Get latest available package version public id.
 
+    Optionally consider AEA version through the `aea_version` parameter.
+
     :param ctx: Context object.
     :param item_type: the item type.
     :param item_public_id: the item public id.
+    :param aea_version: the AEA version (e.g. "0.1.0") or None.
     :return: the latest public id.
     """
     is_local = ctx.config.get("is_local")
@@ -276,13 +295,13 @@ def get_latest_version_available_in_registry(
     try:
         if is_mixed:
             latest_item_public_id = get_latest_public_id_mixed(
-                ctx, item_type, item_public_id
+                ctx, item_type, item_public_id, aea_version
             )
         elif is_local:
             _, item_config = find_item_locally(ctx, item_type, item_public_id)
             latest_item_public_id = item_config.public_id
         else:
-            package_meta = get_package_meta(item_type, item_public_id)
+            package_meta = get_package_meta(item_type, item_public_id, aea_version)
             latest_item_public_id = PublicId.from_str(package_meta["public_id"])
     except Exception:  # pylint: disable=broad-except
         raise click.ClickException(

--- a/aea/cli/registry/utils.py
+++ b/aea/cli/registry/utils.py
@@ -234,7 +234,7 @@ def get_package_meta(
 
     :return: dict with package details
     """
-    params = dict(aea_version=aea_version) if aea_version else {}
+    params = dict(aea_version=aea_version) if aea_version else None
     api_path = f"/{obj_type}s/{public_id.author}/{public_id.name}/{public_id.version}"
     resp = request_api("GET", api_path, params=params)
     return resp

--- a/aea/cli/upgrade.py
+++ b/aea/cli/upgrade.py
@@ -305,7 +305,7 @@ class ProjectUpgrader:
                 f"Cannot remote path {current_path}. Error: {str(e)}."
             )
 
-        fetch_agent(self.ctx, agent_package_id.public_id, alias=self._TEMP_ALIAS)
+        fetch_agent(self.ctx, new_item, alias=self._TEMP_ALIAS)
         self.ctx.cwd = str(current_path)
         self._unpack_fetched_agent()
         return True

--- a/aea/cli/upgrade.py
+++ b/aea/cli/upgrade.py
@@ -25,6 +25,7 @@ from typing import Dict, Iterable, List, Set, Tuple, cast
 
 import click
 
+import aea
 from aea.cli.add import add_item
 from aea.cli.eject import _eject_item
 from aea.cli.registry.fetch import fetch_agent
@@ -258,6 +259,8 @@ class ProjectUpgrader:
         self.ctx = ctx
         self.yes_by_default = yes_by_default
 
+        self._current_aea_version = aea.__version__
+
     def upgrade(self) -> bool:
         """
         Upgrade the project by fetching from remote registry.
@@ -274,6 +277,7 @@ class ProjectUpgrader:
                 self.ctx,
                 str(agent_package_id.package_type),
                 agent_package_id.public_id.to_latest(),
+                aea_version=self._current_aea_version,
             )
         except click.ClickException:
             click.echo("Package not found, continuing with normal upgrade.")
@@ -362,6 +366,8 @@ class ItemUpgrader:
         self.dependencies.update(self.deps_can_be_removed)
         self.dependencies.update(self.deps_can_not_be_removed)
 
+        self._current_aea_version = aea.__version__
+
     def get_current_item(self) -> PublicId:
         """Return public id of the item already presents in agent config."""
         self.check_item_present()
@@ -428,7 +434,10 @@ class ItemUpgrader:
             new_item = self.item_public_id
         else:
             new_item = get_latest_version_available_in_registry(
-                self.ctx, self.item_type, self.item_public_id
+                self.ctx,
+                self.item_type,
+                self.item_public_id,
+                aea_version=self._current_aea_version,
             )
 
         if self.current_item_public_id.version == new_item.version:
@@ -489,6 +498,7 @@ class InteractiveEjectHelper:
         self.adjacency_list = self._reverse_adjacency_list(self.inverse_adjacency_list)
         self.yes_by_default = yes_by_default
 
+        self._current_aea_version = aea.__version__
         self.to_eject: List[PackageId] = []
         self.item_to_new_version: Dict[PackageId, str] = {}
 
@@ -500,7 +510,10 @@ class InteractiveEjectHelper:
         """
         for package_id in self.adjacency_list.keys():
             new_item = get_latest_version_available_in_registry(
-                self.ctx, str(package_id.package_type), package_id.public_id.to_latest()
+                self.ctx,
+                str(package_id.package_type),
+                package_id.public_id.to_latest(),
+                aea_version=self._current_aea_version,
             )
             if package_id.public_id.version == new_item.version:
                 continue

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -24,9 +24,8 @@ import sys
 import time
 from contextlib import contextmanager
 from functools import wraps
-from pathlib import Path
 from threading import Thread
-from typing import Any, Callable, Tuple, Type, Union
+from typing import Any, Callable, List, Optional, Set, Tuple, Type, Union
 
 from aea.aea import AEA
 from aea.configurations.base import PublicId
@@ -299,10 +298,63 @@ def wait_for_condition(condition_checker, timeout=2, error_msg="Timeout", period
             raise TimeoutError(error_msg)
 
 
-def are_dirs_equal(dir1: Path, dir2: Path) -> bool:
-    """Compare the content of two directories, recursively."""
-    comparison = filecmp.dircmp(str(dir1), str(dir2))
-    return comparison.diff_files == []
+def are_dirs_equal(
+    dir1: Union[str, os.PathLike],
+    dir2: Union[str, os.PathLike],
+    ignore: Optional[List[str]] = None,
+) -> bool:
+    """
+    Compare the content of two directories, recursively.
+
+    :param dir1: the left operand.
+    :param dir2: the right operand.
+    :param ignore: is a list of names to ignore (see dircmp docs regarding 'ignore').
+    :return: True if the directories are equal, False otherwise.
+    """
+    ignore = ignore or None
+    left_only, right_only, diff = dircmp_recursive(
+        filecmp.dircmp(dir1, dir2, ignore=ignore)
+    )
+    return left_only == right_only == diff == set()
+
+
+def dircmp_recursive(dircmp_obj: filecmp.dircmp) -> Tuple[Set[str], Set[str], Set[str]]:
+    """
+    Compare the content of two directories, recursively.
+
+    :param dircmp_obj: the filecmp.dircmp object.
+    :return: three sets:
+     - the set of files that are only in the left operand
+     - the set of files that are only in the right operand
+     - the set of files in both operands, but that differ.
+    """
+
+    def _dircmp_recursive(
+        dircmp_obj: filecmp.dircmp, prefix: str = ""
+    ) -> Tuple[Set[str], Set[str], Set[str]]:
+        """
+        Helper private function that also accepts the 'prefix' parameter.
+
+        It is used to keep track of the path prefix during the recursive calls.
+        """
+
+        def join_with_prefix(suffix: str) -> str:
+            return os.path.join(prefix, suffix)
+
+        left_only: Set[str] = set(map(join_with_prefix, dircmp_obj.left_only))
+        right_only: Set[str] = set(map(join_with_prefix, dircmp_obj.right_only))
+        diff_files: Set[str] = set(map(join_with_prefix, dircmp_obj.diff_files))
+        for name, sub_dircmp_obj in dircmp_obj.subdirs.items():
+            subprefix = join_with_prefix(name)
+            subleft, subright, subdiff = _dircmp_recursive(
+                sub_dircmp_obj, prefix=subprefix
+            )
+            left_only.update(subleft)
+            right_only.update(subright)
+            diff_files.update(subdiff)
+        return left_only, right_only, diff_files
+
+    return _dircmp_recursive(dircmp_obj, "")
 
 
 def run_aea_subprocess(*args, cwd: str = ".") -> Tuple[subprocess.Popen, str, str]:

--- a/tests/test_cli/test_registry/test_add.py
+++ b/tests/test_cli/test_registry/test_add.py
@@ -41,6 +41,8 @@ class FetchPackageTestCase(TestCase):
         dest_path = os.path.join("dest", "path", "package_folder_name")
 
         fetch_package(obj_type, public_id, cwd, dest_path)
-        request_api_mock.assert_called_with("GET", "/connections/author/name/0.1.0")
+        request_api_mock.assert_called_with(
+            "GET", "/connections/author/name/0.1.0", params=None
+        )
         download_file_mock.assert_called_once_with("url", "cwd")
         extract_mock.assert_called_once_with("filepath", os.path.join("dest", "path"))

--- a/tests/test_cli/test_upgrade.py
+++ b/tests/test_cli/test_upgrade.py
@@ -1051,7 +1051,7 @@ class BaseTestUpgradeWithEject(AEATestCaseEmpty):
         cls.add_item("skill", str(cls.GENERIC_SELLER.public_id), local=False)
 
     @classmethod
-    def mock_get_latest_version_available_in_registry(cls, *args):
+    def mock_get_latest_version_available_in_registry(cls, *args, **kwargs):
         """Mock 'get_latest_version_available_in_registry' when called with generic_seller public key."""
         if (
             args[1] == str(cls.GENERIC_SELLER.package_type)
@@ -1059,7 +1059,7 @@ class BaseTestUpgradeWithEject(AEATestCaseEmpty):
         ):
             # return current version
             return cls.GENERIC_SELLER
-        return cls.unmocked(*args)
+        return cls.unmocked(*args, **kwargs)
 
     def _get_mock(self):
         """Get the mock of 'get_latest_version_available_in_registry'."""


### PR DESCRIPTION
## Proposed changes

Enable AEA version compatibility in `aea upgrade`, after https://github.com/fetchai/agents-registry/pull/275/
This means packages are searched among the one compatible with the `aea` version of the currently installed framework.


## Fixes

Fixes #2138 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a