### PR TITLE
Protolint tests replacing pragma: no cover

### DIFF
--- a/aea/protocols/generator/base.py
+++ b/aea/protocols/generator/base.py
@@ -1981,9 +1981,7 @@ class ProtocolGenerator:
                 self.protocol_specification.name,
             )
             if not is_correctly_formatted and protolint_output != "":
-                protobuf_output = (
-                    "Protolint warnings:\n" + protolint_output
-                )  # pragma: no cover
+                protobuf_output = "Protolint warnings:\n" + protolint_output
 
         # Run black and isort formatting for python
         if language == PROTOCOL_LANGUAGE_PYTHON:
@@ -2064,9 +2062,7 @@ class ProtocolGenerator:
                 self.spec.all_custom_types, CUSTOM_TYPES_DOT_PY_FILE_NAME
             )
             if full_mode_output is not None:
-                full_mode_output += (
-                    incomplete_generation_warning_msg  # pragma: no cover
-                )
+                full_mode_output += incomplete_generation_warning_msg
             else:
                 full_mode_output = incomplete_generation_warning_msg
         return full_mode_output


### PR DESCRIPTION
Earlier, some code relating to protolint in the protocol generator was written in which 3 lines had no coverage and due to shortage of time these were removed from coverage report via `# pragma: no cover`. This PR adds coverage for those lines and adds them back to coverage report.

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have checked that the documentation about the `aea cli` tool works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules