### PR TITLE
Update 'generate_api_docs.py' script to include plugins apidocs

### DIFF
--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -41,6 +41,7 @@ DOCS_DIR = Path("docs/")
 API_DIR = DOCS_DIR / "api/"
 AEA_DIR = Path("aea")
 PACKAGES_DIR = Path(PACKAGES)
+PLUGIN_DIR = Path("plugins")
 FETCHAI_PACKAGES = PACKAGES_DIR / _FETCHAI_IDENTIFIER
 DEFAULT_PACKAGES = {
     (ComponentType.PROTOCOL, DEFAULT_PROTOCOL),
@@ -138,6 +139,24 @@ def _generate_apidocs_default_packages() -> None:
             make_pydoc(dotted_path, doc_file)
 
 
+def _generate_apidocs_plugins() -> None:
+    """Generate API docs for cyrpto plugins."""
+    for plugin in PLUGIN_DIR.iterdir():
+        plugin_name = plugin.name
+        plugin_module_name = plugin_name.replace("-", "_")
+        python_package_root = plugin / plugin_module_name
+        for module_path in python_package_root.rglob("*.py"):
+            print(f"Processing {module_path}...", end="")
+            if should_skip(module_path):
+                continue
+            # remove ".py"
+            relative_module_path = module_path.relative_to(python_package_root)
+            suffix = Path(str(relative_module_path)[:-3] + ".md")
+            dotted_path = ".".join(module_path.parts)[:-3]
+            doc_file = API_DIR / "plugins" / plugin_module_name / suffix
+            make_pydoc(dotted_path, doc_file)
+
+
 def make_pydoc(dotted_path: str, dest_file: Path) -> None:
     """Make a PyDoc file."""
     print(
@@ -176,6 +195,7 @@ def generate_api_docs() -> None:
     API_DIR.mkdir()
     _generate_apidocs_default_packages()
     _generate_apidocs_aea_modules()
+    _generate_apidocs_plugins()
 
 
 def install(package: str) -> int:


### PR DESCRIPTION
## Proposed changes

Update 'generate_api_docs.py' script to include plugins apidocs

This new version of the script adds plugin apidocs in docs/api/plugins/*, one folder for each package.

## Fixes

Fixes the missing generation of apidocs for plugins after #2112

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a