### PR TITLE
AEA-1360 Add builder test for dependencies, add protocol spec id as required

### DIFF
--- a/aea/cli/upgrade.py
+++ b/aea/cli/upgrade.py
@@ -518,7 +518,7 @@ class InteractiveEjectHelper:
                     package_id.public_id.to_latest(),
                     aea_version=self._current_aea_version,
                 )
-            except click.ClickException:
+            except click.ClickException:  # pragma: nocover
                 continue
             if package_id.public_id.version == new_item.version:
                 continue

--- a/aea/configurations/schemas/protocol-config_schema.json
+++ b/aea/configurations/schemas/protocol-config_schema.json
@@ -13,7 +13,8 @@
     "fingerprint",
     "fingerprint_ignore_patterns",
     "description",
-    "dependencies"
+    "dependencies",
+    "protocol_specification_id"
   ],
   "properties": {
     "name": {

--- a/tests/test_aea_builder.py
+++ b/tests/test_aea_builder.py
@@ -906,3 +906,17 @@ def test_set_default_connection_and_routing():
         match="Protocol bad/protocol:0.1.0 specified in `default_routing` is not a project dependency!",
     ):
         builder.set_default_routing({bad_protocol.public_id: good_connection.public_id})
+
+
+def test_builder_pypi_dependencies():
+    """Test getter for PyPI dependencies."""
+    dummy_aea_path = Path(CUR_PATH, "data", "dummy_aea")
+    builder = AEABuilder.from_aea_project(dummy_aea_path)
+    dependencies = builder._package_dependency_manager.pypi_dependencies
+    assert set(dependencies.keys()) == {
+        "protobuf",
+        "vyper",
+        "aea-ledger-fetchai",
+        "aea-ledger-ethereum",
+        "aea-ledger-cosmos",
+    }

--- a/tests/test_cli/test_upgrade.py
+++ b/tests/test_cli/test_upgrade.py
@@ -304,9 +304,9 @@ class TestUpgradeSharedDependencies(AEATestCaseEmpty):
     """
 
     IS_EMPTY = True
-    OLD_SOEF_ID = PublicId.from_str("fetchai/soef:0.11.0")
-    OLD_OEF_SEARCH_ID = PublicId.from_str("fetchai/oef_search:0.9.0")
-    OLD_OEF_ID = PublicId.from_str("fetchai/oef:0.12.0")
+    OLD_SOEF_ID = PublicId.from_str("fetchai/soef:0.16.0")
+    OLD_OEF_SEARCH_ID = PublicId.from_str("fetchai/oef_search:0.13.0")
+    OLD_OEF_ID = PublicId.from_str("fetchai/oef:0.16.0")
 
     @classmethod
     def setup_class(cls):
@@ -739,8 +739,8 @@ class TestUpgradeNonVendorDependencies(AEATestCaseEmpty):
 
     The test works as follows:
     - scaffold a package, one for each possible package type;
-    - add the protocol "fetchai/default:0.11.0" as dependency to each of them.
-    - add the skill "fetchai/error:0.11.0"; this will also add the default protocol.
+    - add the protocol "fetchai/default:0.12.0" as dependency to each of them.
+    - add the skill "fetchai/error:0.12.0"; this will also add the default protocol.
       add it also as dependency of non-vendor skill.
     - run 'aea upgrade'
     - check that the reference to "fetchai/default" in each scaffolded package
@@ -750,10 +750,10 @@ class TestUpgradeNonVendorDependencies(AEATestCaseEmpty):
     capture_log = True
     IS_EMPTY = True
     old_default_protocol_id = PublicId(
-        DefaultMessage.protocol_id.author, DefaultMessage.protocol_id.name, "0.11.0"
+        DefaultMessage.protocol_id.author, DefaultMessage.protocol_id.name, "0.12.0"
     )
     old_error_skill_id = PublicId(
-        ERROR_SKILL_PUBLIC_ID.author, ERROR_SKILL_PUBLIC_ID.name, "0.11.0"
+        ERROR_SKILL_PUBLIC_ID.author, ERROR_SKILL_PUBLIC_ID.name, "0.12.0"
     )
     old_aea_version_range = compute_specifier_from_version(Version("0.1.0"))
 
@@ -857,18 +857,18 @@ class TestUpdateReferences(AEATestCaseEmpty):
     In particular, 'default_routing', 'default_connection' and custom component configurations in AEA configuration.
 
     How the test works:
-    - add fetchai/error:0.11.0, that requires fetchai/default:0.11.0
-    - add fetchai/stub:0.15.0
-    - add 'fetchai/default:0.11.0: fetchai/stub:0.15.0' to default routing
+    - add fetchai/error:0.12.0, that requires fetchai/default:0.12.0
+    - add fetchai/stub:0.16.0
+    - add 'fetchai/default:0.12.0: fetchai/stub:0.16.0' to default routing
     - add custom configuration to stub connection.
     - run 'aea upgrade'. This will upgrade `stub` connection and `error` skill, and in turn `default` protocol.
     """
 
     IS_EMPTY = True
 
-    OLD_DEFAULT_PROTOCOL_PUBLIC_ID = PublicId.from_str("fetchai/default:0.11.0")
-    OLD_ERROR_SKILL_PUBLIC_ID = PublicId.from_str("fetchai/error:0.11.0")
-    OLD_STUB_CONNECTION_PUBLIC_ID = PublicId.from_str("fetchai/stub:0.15.0")
+    OLD_DEFAULT_PROTOCOL_PUBLIC_ID = PublicId.from_str("fetchai/default:0.12.0")
+    OLD_ERROR_SKILL_PUBLIC_ID = PublicId.from_str("fetchai/error:0.12.0")
+    OLD_STUB_CONNECTION_PUBLIC_ID = PublicId.from_str("fetchai/stub:0.16.0")
 
     @classmethod
     def setup_class(cls):
@@ -985,7 +985,7 @@ class TestWrongAEAVersion(AEATestCaseEmpty):
         super().setup_class()
 
         # this is an old version of the package, just to trigger an upgrade.
-        cls.add_item("protocol", "fetchai/default:0.10.0", local=False)
+        cls.add_item("protocol", "fetchai/default:0.12.0", local=False)
 
         # change aea version of the AEA project
         agent_config = cls.load_agent_config(cls.current_agent_context)
@@ -1135,7 +1135,7 @@ class TestUpgradeWithEjectAccept(BaseTestUpgradeWithEject):
 class BaseTestUpgradeProject(AEATestCaseEmpty):
     """Base test class for testing project upgrader."""
 
-    OLD_AGENT_PUBLIC_ID = PublicId.from_str("fetchai/weather_station:0.19.0")
+    OLD_AGENT_PUBLIC_ID = PublicId.from_str("fetchai/weather_station:0.21.0")
     EXPECTED_NEW_AGENT_PUBLIC_ID = OLD_AGENT_PUBLIC_ID.to_latest()
     EXPECTED = "expected_agent"
 
@@ -1162,7 +1162,7 @@ class BaseTestUpgradeProject(AEATestCaseEmpty):
         shutil.rmtree(self.current_agent_context)
 
 
-@mock.patch.object(aea, "__version__", "0.10.0")
+@mock.patch.object(aea, "__version__", "0.11.0")
 @mock.patch("click.confirm")
 class TestUpgradeProjectWithNewerVersion(BaseTestUpgradeProject):
     """Test upgrade project with newer version available."""
@@ -1186,21 +1186,7 @@ class TestUpgradeProjectWithNewerVersion(BaseTestUpgradeProject):
             self.current_agent_context, self.EXPECTED, ignore=ignore
         )
         _left_only, _right_only, diff = dircmp_recursive(dircmp)
-        if confirm:
-            # temporary: due to change in deps
-            assert _right_only == {"vendor/fetchai/connections/p2p_libp2p/libp2p_node"}
-            assert _left_only == {
-                "vendor/fetchai/connections/p2p_libp2p/go.sum",
-                "vendor/fetchai/connections/p2p_libp2p/libp2p_node.go",
-                "vendor/fetchai/connections/p2p_libp2p/utils",
-                "vendor/fetchai/connections/p2p_libp2p/aea",
-                "vendor/fetchai/connections/p2p_libp2p/dht",
-                "vendor/fetchai/connections/p2p_libp2p/go.mod",
-            }
-        else:
-            assert diff == _right_only == set()
-            # temporary: due to change in deps
-            assert _left_only == {"vendor/fetchai/skills/error"}
+        assert diff == _right_only == _left_only == set()
 
 
 @mock.patch("aea.cli.upgrade.get_latest_version_available_in_registry")
@@ -1226,11 +1212,10 @@ class TestUpgradeProjectWithoutNewerVersion(BaseTestUpgradeProject):
             self.current_agent_context, self.EXPECTED, ignore=ignore
         )
         _left_only, _right_only, diff = dircmp_recursive(dircmp)
-        assert _left_only == {"vendor/fetchai/skills/error"}
-        assert diff == _right_only == set()
+        assert diff == _right_only == _left_only == set()
 
 
-@mock.patch.object(aea, "__version__", "0.8.0")
+@mock.patch.object(aea, "__version__", "0.10.0")
 class TestUpgradeAEACompatibility(BaseTestUpgradeProject):
     """
     Test 'aea upgrade' takes into account the current aea version.
@@ -1238,8 +1223,8 @@ class TestUpgradeAEACompatibility(BaseTestUpgradeProject):
     The test works as follows:
     """
 
-    OLD_AGENT_PUBLIC_ID = PublicId.from_str("fetchai/weather_station:0.19.0")
-    EXPECTED_NEW_AGENT_PUBLIC_ID = PublicId.from_str("fetchai/weather_station:0.19.0")
+    OLD_AGENT_PUBLIC_ID = PublicId.from_str("fetchai/weather_station:0.21.0")
+    EXPECTED_NEW_AGENT_PUBLIC_ID = PublicId.from_str("fetchai/weather_station:0.22.0")
 
     def test_upgrade(self):
         """Test upgrade."""


### PR DESCRIPTION
## Proposed changes

This PR adds a simple test for the dependencies in AEA Builder and addresses #2261

## Fixes

#2261

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have checked that the documentation about the `aea cli` tool works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

-