### PR TITLE
AEA-1387 Allow to explicitly declare behaviours that are registered programmatically. 

### DIFF
--- a/aea/skills/base.py
+++ b/aea/skills/base.py
@@ -1011,7 +1011,7 @@ class _SkillComponentLoader:
         class_index: Dict[
             str, Dict[_SKILL_COMPONENT_TYPES, Set[Type[SkillComponent]]]
         ] = {}
-        used_classes = set()
+        used_classes: Set[Type[SkillComponent]] = set()
         not_resolved_configurations: Dict[
             Tuple[_SKILL_COMPONENT_TYPES, str], SkillComponentConfiguration
         ] = {}
@@ -1099,7 +1099,38 @@ class _SkillComponentLoader:
             )
             used_classes.add(not_used_class)
 
+        self._print_warning_message_for_unused_classes(
+            component_classes_by_path, used_classes
+        )
         return result
+
+    def _print_warning_message_for_unused_classes(
+        self,
+        component_classes_by_path: Dict[Path, Set[Tuple[str, Type[SkillComponent]]]],
+        used_classes: Set[Type[SkillComponent]],
+    ) -> None:
+        """
+        Print warning message for every unused class.
+
+        :param component_classes_by_path: the component classes by path.
+        :param used_classes: the classes used.
+        :return: None
+        """
+        for path, set_of_class_name_pairs in component_classes_by_path.items():
+            # take only classes, not class names
+            set_of_classes = {pair[1] for pair in set_of_class_name_pairs}
+            set_of_unused_classes = set(
+                filter(lambda x: x not in used_classes, set_of_classes)
+            )
+            if len(set_of_unused_classes) != 0:
+                for unused_class in set_of_unused_classes:
+                    _print_warning_message_for_non_declared_skill_components(
+                        self.skill_context,
+                        {unused_class.__name__},
+                        set(),
+                        self._type_to_str(self._get_skill_component_type(unused_class)),
+                        str(path),
+                    )
 
     @classmethod
     def _type_to_str(cls, component_type: _SKILL_COMPONENT_TYPES) -> str:

--- a/tests/test_skills/test_base.py
+++ b/tests/test_skills/test_base.py
@@ -17,6 +17,7 @@
 #
 # ------------------------------------------------------------------------------
 """This module contains the tests for the base classes for the skills."""
+import shutil
 import unittest.mock
 from pathlib import Path
 from queue import Queue
@@ -54,7 +55,7 @@ from aea.skills.base import (
     _SkillComponentLoader,
     _print_warning_message_for_non_declared_skill_components,
 )
-from aea.test_tools.test_cases import AEATestCase
+from aea.test_tools.test_cases import BaseAEATestCase
 
 from tests.conftest import (
     CUR_PATH,
@@ -712,7 +713,7 @@ def test_setup_teardown_methods():
     mock_teardown.assert_called_once()
 
 
-class TestSkillLoadingWarningMessages(AEATestCase):
+class TestSkillLoadingWarningMessages(BaseAEATestCase):
     """
     Test warning message in case undeclared skill are found.
 
@@ -724,7 +725,7 @@ class TestSkillLoadingWarningMessages(AEATestCase):
     - test that we have a warning message only from the first.
     """
 
-    path_to_aea: Path = Path(CUR_PATH, "data", "dummy_aea")
+    agent_name = "dummy_aea"
 
     cli_log_options = ["-v", "DEBUG"]
     _TEST_HANDLER_CLASS_NAME = "TestHandler"
@@ -763,6 +764,8 @@ class TestSkillLoadingWarningMessages(AEATestCase):
     def setup_class(cls):
         """Set up the test."""
         super().setup_class()
+        path_to_aea = Path(CUR_PATH, "data", "dummy_aea")
+        shutil.copytree(path_to_aea, cls.t / cls.agent_name)
 
         # add a module in 'dummy' skill with a Handler and a Behaviour
         dummy_skill_path = cls.t / cls.agent_name / "skills" / "dummy"

--- a/tests/test_skills/test_base.py
+++ b/tests/test_skills/test_base.py
@@ -713,7 +713,16 @@ def test_setup_teardown_methods():
 
 
 class TestSkillLoadingWarningMessages(AEATestCase):
-    """Test warning message in case undeclared skill are found."""
+    """
+    Test warning message in case undeclared skill are found.
+
+    That is:
+    - copy dummy_aea in a temporary directory
+    - add a skill module with two skill components
+      - one that has 'is_programmatically_defined' set to False
+      - one that has 'is_programmatically_defined' set to True
+    - test that we have a warning message only from the first.
+    """
 
     path_to_aea: Path = Path(CUR_PATH, "data", "dummy_aea")
 


### PR DESCRIPTION
## Proposed changes

Two changes:
- Reintroduce warning messages when a class not declared in config is found in a skill module (2f83384).
  - This was removed after #2319
- Allow to explicitly declare behaviours that are registered programmatically. (828c702, e29a98d)

## Fixes

Fix #1480

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a