### PR TITLE
AEA-173 cli password promting improved

### DIFF
--- a/aea/cli/add_key.py
+++ b/aea/cli/add_key.py
@@ -16,14 +16,13 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-
 """Implementation of the 'aea add_key' subcommand."""
-
 import os
 from typing import Optional, cast
 
 import click
 
+from aea.cli.utils.click_utils import password_option
 from aea.cli.utils.context import Context
 from aea.cli.utils.decorators import check_aea_project
 from aea.configurations.constants import (
@@ -50,16 +49,18 @@ key_file_argument = click.Path(
 @click.argument(
     "file", metavar="FILE", type=key_file_argument, required=False,
 )
-@click.argument(
-    "password", metavar="PASSWORD", type=str, default=None, required=False,
-)
+@password_option()
 @click.option(
     "--connection", is_flag=True, help="For adding a private key for connections."
 )
 @click.pass_context
 @check_aea_project
 def add_key(
-    click_context: click.Context, type_: str, file: str, password: str, connection: bool
+    click_context: click.Context,
+    type_: str,
+    file: str,
+    password: Optional[str],
+    connection: bool,
 ) -> None:
     """Add a private key to the wallet of the agent."""
     _add_private_key(click_context, type_, file, password, connection)

--- a/aea/cli/generate_key.py
+++ b/aea/cli/generate_key.py
@@ -16,7 +16,6 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-
 """Implementation of the 'aea generate_key' subcommand."""
 
 from pathlib import Path
@@ -24,6 +23,7 @@ from typing import Optional
 
 import click
 
+from aea.cli.utils.click_utils import password_option
 from aea.configurations.constants import PRIVATE_KEY_PATH_SCHEMA
 from aea.crypto.helpers import create_private_key
 from aea.crypto.registries import crypto_registry
@@ -42,10 +42,8 @@ from aea.crypto.registries import crypto_registry
     type=click.Path(exists=False, file_okay=True, dir_okay=False, readable=True),
     required=False,
 )
-@click.argument(
-    "password", metavar="PASSWORD", type=str, default=None, required=False,
-)
-def generate_key(type_: str, file: str, password: str) -> None:
+@password_option(confirmation_prompt=True)
+def generate_key(type_: str, file: str, password: Optional[str]) -> None:
     """Generate a private key and place it in a file."""
     _generate_private_key(type_, file, password)
 

--- a/aea/cli/generate_wealth.py
+++ b/aea/cli/generate_wealth.py
@@ -16,13 +16,12 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-
 """Implementation of the 'aea generate_wealth' subcommand."""
-
 from typing import Optional, cast
 
 import click
 
+from aea.cli.utils.click_utils import password_option
 from aea.cli.utils.context import Context
 from aea.cli.utils.decorators import check_aea_project
 from aea.cli.utils.package_utils import get_wallet_from_context
@@ -38,16 +37,18 @@ from aea.crypto.registries import faucet_apis_registry, make_faucet_api_cls
     required=True,
 )
 @click.argument("url", metavar="URL", type=str, required=False, default=None)
-@click.argument(
-    "password", metavar="PASSWORD", type=str, default=None, required=False,
-)
+@password_option()
 @click.option(
     "--sync", is_flag=True, help="For waiting till the faucet has released the funds."
 )
 @click.pass_context
 @check_aea_project
 def generate_wealth(
-    click_context: click.Context, type_: str, url: str, password: str, sync: bool
+    click_context: click.Context,
+    type_: str,
+    url: str,
+    password: Optional[str],
+    sync: bool,
 ) -> None:
     """Generate wealth for the agent on a test network."""
     ctx = cast(Context, click_context.obj)

--- a/aea/cli/get_address.py
+++ b/aea/cli/get_address.py
@@ -17,12 +17,13 @@
 #
 # ------------------------------------------------------------------------------
 
-"""Implementation of the 'aea get_address' subcommand."""
 
+"""Implementation of the 'aea get_address' subcommand."""
 from typing import Optional, cast
 
 import click
 
+from aea.cli.utils.click_utils import password_option
 from aea.cli.utils.context import Context
 from aea.cli.utils.decorators import check_aea_project
 from aea.cli.utils.package_utils import get_wallet_from_context
@@ -36,12 +37,12 @@ from aea.crypto.registries import crypto_registry
     type=click.Choice(list(crypto_registry.supported_ids)),
     required=True,
 )
-@click.argument(
-    "password", metavar="PASSWORD", type=str, default=None, required=False,
-)
+@password_option()
 @click.pass_context
 @check_aea_project
-def get_address(click_context: click.Context, type_: str, password: str) -> None:
+def get_address(
+    click_context: click.Context, type_: str, password: Optional[str]
+) -> None:
     """Get the address associated with a private key of the agent."""
     ctx = cast(Context, click_context.obj)
     address = _try_get_address(ctx, type_, password)

--- a/aea/cli/get_multiaddress.py
+++ b/aea/cli/get_multiaddress.py
@@ -26,7 +26,7 @@ from typing import Optional, Tuple, cast
 import click
 from click import ClickException
 
-from aea.cli.utils.click_utils import PublicIdParameter
+from aea.cli.utils.click_utils import PublicIdParameter, password_option
 from aea.cli.utils.config import load_item_config
 from aea.cli.utils.context import Context
 from aea.cli.utils.decorators import check_aea_project
@@ -49,9 +49,7 @@ URI_REGEX = re.compile(r"(?:https?://)?(?P<host>[^:/ ]+):(?P<port>[0-9]*)")
     type=click.Choice(list(crypto_registry.supported_ids)),
     required=True,
 )
-@click.argument(
-    "password", metavar="PASSWORD", type=str, default=None, required=False,
-)
+@password_option()
 @click.option("-c", "--connection", is_flag=True)
 @click.option(
     "-i", "--connection-id", type=PublicIdParameter(), required=False, default=None,
@@ -70,7 +68,7 @@ URI_REGEX = re.compile(r"(?:https?://)?(?P<host>[^:/ ]+):(?P<port>[0-9]*)")
 def get_multiaddress(
     click_context: click.Context,
     ledger_id: str,
-    password: str,
+    password: Optional[str],
     connection: bool,
     connection_id: Optional[PublicId],
     host_field: str,

--- a/aea/cli/get_wealth.py
+++ b/aea/cli/get_wealth.py
@@ -23,6 +23,7 @@ from typing import Optional, cast
 
 import click
 
+from aea.cli.utils.click_utils import password_option
 from aea.cli.utils.context import Context
 from aea.cli.utils.decorators import check_aea_project
 from aea.cli.utils.package_utils import (
@@ -40,12 +41,12 @@ from aea.crypto.registries import ledger_apis_registry
     type=click.Choice(ledger_apis_registry.supported_ids),
     required=True,
 )
-@click.argument(
-    "password", metavar="PASSWORD", type=str, default=None, required=False,
-)
+@password_option()
 @click.pass_context
 @check_aea_project
-def get_wealth(click_context: click.Context, type_: str, password: str) -> None:
+def get_wealth(
+    click_context: click.Context, type_: str, password: Optional[str]
+) -> None:
     """Get the wealth associated with the private key of the agent."""
     ctx = cast(Context, click_context.obj)
     wealth = _try_get_wealth(ctx, type_, password)

--- a/aea/cli/issue_certificates.py
+++ b/aea/cli/issue_certificates.py
@@ -22,6 +22,7 @@ from typing import Dict, List, Optional, cast
 import click
 from click import ClickException
 
+from aea.cli.utils.click_utils import password_option
 from aea.cli.utils.context import Context
 from aea.cli.utils.decorators import check_aea_project
 from aea.cli.utils.loggers import logger
@@ -36,12 +37,10 @@ from aea.helpers.base import CertRequest, prepend_if_not_absolute
 
 
 @click.command()
-@click.argument(
-    "password", metavar="PASSWORD", type=str, default=None, required=False,
-)
+@password_option()
 @click.pass_context
 @check_aea_project
-def issue_certificates(click_context: click.Context, password: str) -> None:
+def issue_certificates(click_context: click.Context, password: Optional[str]) -> None:
     """Issue certificates for connections that require them."""
     ctx = cast(Context, click_context.obj)
     agent_config_manager = AgentConfigManager.load(ctx.cwd)

--- a/aea/cli/launch.py
+++ b/aea/cli/launch.py
@@ -25,7 +25,7 @@ from typing import List, Optional, cast
 
 import click
 
-from aea.cli.utils.click_utils import AgentDirectory
+from aea.cli.utils.click_utils import AgentDirectory, password_option
 from aea.cli.utils.context import Context
 from aea.cli.utils.loggers import logger
 from aea.helpers.multiple_executor import ExecutorExceptionPolicies
@@ -34,13 +34,14 @@ from aea.launcher import AEALauncher
 
 @click.command()
 @click.argument("agents", nargs=-1, type=AgentDirectory())
-@click.option(
-    "--password", metavar="PASSWORD", type=str, default=None, required=False,
-)
+@password_option()
 @click.option("--multithreaded", is_flag=True)
 @click.pass_context
 def launch(
-    click_context: click.Context, agents: List[str], password: str, multithreaded: bool
+    click_context: click.Context,
+    agents: List[str],
+    password: Optional[str],
+    multithreaded: bool,
 ) -> None:
     """Launch many agents at the same time."""
     _launch_agents(click_context, agents, multithreaded, password)

--- a/aea/cli/run.py
+++ b/aea/cli/run.py
@@ -27,7 +27,7 @@ from aea import __version__
 from aea.aea import AEA
 from aea.aea_builder import AEABuilder, DEFAULT_ENV_DOTFILE
 from aea.cli.install import do_install
-from aea.cli.utils.click_utils import ConnectionsOption
+from aea.cli.utils.click_utils import ConnectionsOption, password_option
 from aea.cli.utils.constants import AEA_LOGO, REQUIREMENTS
 from aea.cli.utils.context import Context
 from aea.cli.utils.decorators import check_aea_project
@@ -42,9 +42,7 @@ from aea.skills.base import Behaviour, Handler, Model, Skill
 
 
 @click.command()
-@click.argument(
-    "password", metavar="PASSWORD", type=str, default=None, required=False,
-)
+@password_option()
 @click.option(
     "--connections",
     "connection_ids",

--- a/aea/cli/transfer.py
+++ b/aea/cli/transfer.py
@@ -24,6 +24,7 @@ from typing import Optional, cast
 import click
 
 from aea.cli.get_address import _try_get_address
+from aea.cli.utils.click_utils import password_option
 from aea.cli.utils.context import Context
 from aea.cli.utils.decorators import check_aea_project
 from aea.cli.utils.package_utils import (
@@ -53,9 +54,7 @@ DEFAULT_SETTLE_TIMEOUT = 60
     "amount", type=int, required=True,
 )
 @click.argument("fee", type=int, required=False, default=100)
-@click.argument(
-    "password", metavar="PASSWORD", type=str, default=None, required=False,
-)
+@password_option()
 @click.option("-y", "--yes", type=bool, is_flag=True, default=False)
 @click.option("--settle-timeout", type=int, default=DEFAULT_SETTLE_TIMEOUT)
 @click.option("--sync", type=bool, is_flag=True, default=False)
@@ -67,7 +66,7 @@ def transfer(
     address: str,
     amount: int,
     fee: int,
-    password: str,
+    password: Optional[str],
     yes: bool,
     settle_timeout: int,
     sync: bool,

--- a/aea/cli/utils/click_utils.py
+++ b/aea/cli/utils/click_utils.py
@@ -217,7 +217,7 @@ def password_option(confirmation_prompt: bool = False, **kwargs) -> Callable:  #
             type=bool,
             callback=callback,
             expose_value=False,
-            help="Ask for password interactivly",
+            help="Ask for password interactively",
         )(
             click.option(
                 "--password",

--- a/aea/cli/utils/click_utils.py
+++ b/aea/cli/utils/click_utils.py
@@ -204,7 +204,7 @@ def password_option(confirmation_prompt: bool = False, **kwargs) -> Callable:  #
     def callback(ctx, _, value: bool) -> bool:  # type: ignore
         if value is True:
             ctx.params["password"] = ctx.params.get("password") or click.prompt(
-                "Enter password please",
+                "Enter password",
                 hide_input=True,
                 confirmation_prompt=confirmation_prompt,
             )

--- a/aea/cli/utils/click_utils.py
+++ b/aea/cli/utils/click_utils.py
@@ -196,3 +196,37 @@ class MutuallyExclusiveOption(Option):
             )
 
         return super().handle_parse_result(ctx, opts, args)
+
+
+def password_option(confirmation_prompt: bool = False, **kwargs) -> Callable:  # type: ignore
+    """Decorator to ask for input if -p flag was provided or use --password to set password value in command line."""
+
+    def callback(ctx, _, value: bool) -> bool:  # type: ignore
+        if value is True:
+            ctx.params["password"] = ctx.params.get("password") or click.prompt(
+                "Enter password please",
+                hide_input=True,
+                confirmation_prompt=confirmation_prompt,
+            )
+        return value
+
+    def wrap(fn):  # type: ignore
+        return click.option(
+            "-p",
+            is_flag=True,
+            type=bool,
+            callback=callback,
+            expose_value=False,
+            help="Ask for password interactivly",
+        )(
+            click.option(
+                "--password",
+                **kwargs,
+                type=str,
+                is_eager=True,
+                metavar="PASSWORD",
+                help="Set password for key encryption/decryption",
+            )(fn)
+        )  # type: ignore
+
+    return wrap


### PR DESCRIPTION
## Proposed changes

reusable password_option decorator provided
it adds two options
-p flag to ask password interactively
--password to set password with command line
(can not combine it, cause one flag and another is option requires argument)

if -p and --password specified same time, password will be asked interactively
we can change priority and --password value will be used.

## Fixes


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
