### PR TITLE
Fix bug in RegexConstrainedString and regexes in schemas

### DIFF
--- a/aea/configurations/schemas/definitions.json
+++ b/aea/configurations/schemas/definitions.json
@@ -33,7 +33,7 @@
     },
     "resource_name": {
       "type": "string",
-      "pattern": "[a-zA-Z_][a-zA-Z0-9_]{0,127}"
+      "pattern": "^[a-zA-Z_][a-zA-Z0-9_]{0,127}$"
     },
     "component_type": {
       "type": "string",
@@ -56,7 +56,7 @@
     },
     "author": {
       "type": "string",
-      "pattern": "[a-zA-Z_][a-zA-Z0-9_]{0,127}"
+      "pattern": "^[a-zA-Z_][a-zA-Z0-9_]{0,127}$"
     },
     "package_version": {
       "$ref": "definitions.json#/definitions/semantic_version"
@@ -94,7 +94,7 @@
     "class_name": {
       "type": "string",
       "description": "The class name of a skill component.",
-      "pattern": "[A-Za-z_][A-Za-z0-9_]{0,127}"
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]{0,127}$"
     },
     "fingerprint_ignore_patterns": {
       "type": "array",

--- a/aea/helpers/base.py
+++ b/aea/helpers/base.py
@@ -212,7 +212,7 @@ class RegexConstrainedString(UserString):
         """Initialize a regex constrained string."""
         super().__init__(seq)
 
-        if not self.REGEX.match(self.data):
+        if not self.REGEX.fullmatch(self.data):
             self._handle_no_match()
 
     def _handle_no_match(self) -> None:
@@ -242,6 +242,11 @@ class SimpleId(RegexConstrainedString):
     Traceback (most recent call last):
     ...
     ValueError: Value 0an_identifier does not match the regular expression re.compile('[a-zA-Z_][a-zA-Z0-9_]{0,127}')
+
+    >>> SimpleId("an identifier")
+    Traceback (most recent call last):
+    ...
+    ValueError: Value an identifier does not match the regular expression re.compile('[a-zA-Z_][a-zA-Z0-9_]{0,127}')
 
     >>> SimpleId("")
     Traceback (most recent call last):

--- a/aea/test_tools/test_cases.py
+++ b/aea/test_tools/test_cases.py
@@ -951,7 +951,7 @@ class AEATestCaseEmpty(BaseAEATestCase):
     def setup_class(cls) -> None:
         """Set up the test class."""
         super(AEATestCaseEmpty, cls).setup_class()
-        cls.agent_name = "agent-" + "".join(random.choices(string.ascii_lowercase, k=5))
+        cls.agent_name = "agent_" + "".join(random.choices(string.ascii_lowercase, k=5))
         cls.create_agents(cls.agent_name, is_local=cls.IS_LOCAL, is_empty=cls.IS_EMPTY)
         cls.set_agent_context(cls.agent_name)
 

--- a/tests/test_cli/test_interact.py
+++ b/tests/test_cli/test_interact.py
@@ -160,7 +160,7 @@ class ProcessEnvelopesTestCase(TestCase):
         """Test _process_envelopes method for positive result."""
         agent_name = "agent_name"
         identity_stub = mock.Mock()
-        identity_stub.name = "identity-stub-name"
+        identity_stub.name = "identity_stub_name"
         inbox = mock.Mock()
         inbox.empty = lambda: False
         inbox.get_nowait = lambda: "Not None"
@@ -193,7 +193,7 @@ class ProcessEnvelopesTestCase(TestCase):
         """Test _process_envelopes for couldn't recover envelope result."""
         agent_name = "agent_name"
         identity_stub = mock.Mock()
-        identity_stub.name = "identity-stub-name"
+        identity_stub.name = "identity_stub_name"
         inbox = mock.Mock()
         inbox.empty = lambda: False
         inbox.get_nowait = lambda: None

--- a/tests/test_cli/test_registry/test_publish.py
+++ b/tests/test_cli/test_registry/test_publish.py
@@ -55,7 +55,7 @@ class PublishAgentTestCase(TestCase):
             "POST",
             "/agents/create",
             data={
-                "name": "agent-name",
+                "name": "agent_name",
                 "description": description,
                 "version": version,
                 "connections": [],
@@ -80,7 +80,7 @@ class PublishAgentTestCase(TestCase):
             "POST",
             "/agents/create",
             data={
-                "name": "agent-name",
+                "name": "agent_name",
                 "description": description,
                 "version": version,
                 "connections": [],

--- a/tests/test_cli/test_registry/test_push.py
+++ b/tests/test_cli/test_registry/test_push.py
@@ -45,8 +45,8 @@ from tests.test_cli.tools_for_testing import ContextMock, PublicIdMock
     return_value={
         "description": "some-description",
         "version": PublicIdMock.DEFAULT_VERSION,
-        "author": "some-author",
-        "name": "some-name",
+        "author": "some_author",
+        "name": "some_name",
         "protocols": ["protocol_id"],
     },
 )
@@ -71,8 +71,8 @@ class PushItemTestCase(TestCase):
     ):
         """Test for push_item positive result."""
         public_id = PublicIdMock(
-            name="some-name",
-            author="some-author",
+            name="some_name",
+            author="some_author",
             version="{}".format(PublicIdMock.DEFAULT_VERSION),
         )
         push_item(ContextMock(), "some-type", public_id)
@@ -80,7 +80,7 @@ class PushItemTestCase(TestCase):
             "POST",
             "/some-types/create",
             data={
-                "name": "some-name",
+                "name": "some_name",
                 "description": "some-description",
                 "version": PublicIdMock.DEFAULT_VERSION,
                 "protocols": ["protocol_id"],
@@ -96,8 +96,8 @@ class PushItemTestCase(TestCase):
     ):
         """Test for push_item without readme positive result."""
         public_id = PublicIdMock(
-            name="some-name",
-            author="some-author",
+            name="some_name",
+            author="some_author",
             version="{}".format(PublicIdMock.DEFAULT_VERSION),
         )
         push_item(ContextMock(), "some-type", public_id)
@@ -105,7 +105,7 @@ class PushItemTestCase(TestCase):
             "POST",
             "/some-types/create",
             data={
-                "name": "some-name",
+                "name": "some_name",
                 "description": "some-description",
                 "version": PublicIdMock.DEFAULT_VERSION,
                 "protocols": ["protocol_id"],

--- a/tests/test_cli/test_transfer.py
+++ b/tests/test_cli/test_transfer.py
@@ -51,7 +51,7 @@ class TestCliTransferFetchAINetwork(AEATestCaseEmpty):
     def setup_class(cls):
         """Set up the test class."""
         super(TestCliTransferFetchAINetwork, cls).setup_class()
-        cls.agent_name2 = "agent-" + "".join(
+        cls.agent_name2 = "agent_" + "".join(
             random.choices(string.ascii_lowercase, k=5)
         )
         cls.create_agents(cls.agent_name2)

--- a/tests/test_cli/test_upgrade.py
+++ b/tests/test_cli/test_upgrade.py
@@ -349,7 +349,7 @@ class TestUpgradeProject(BaseAEATestCase, BaseTestCase):
         """Set up test case."""
         super(TestUpgradeProject, cls).setup()
         cls.change_directory(Path(".."))
-        cls.agent_name = "generic_buyer_0.18.0"
+        cls.agent_name = "generic_buyer"
         cls.latest_agent_name = "generic_buyer_latest"
         cls.run_cli_command(
             "--skip-consistency-check",
@@ -434,7 +434,7 @@ class TestNonVendorProject(BaseAEATestCase, BaseTestCase):
         """Set up test case."""
         super(TestNonVendorProject, cls).setup()
         cls.change_directory(Path(".."))
-        cls.agent_name = "generic_buyer_0.12.0"
+        cls.agent_name = "generic_buyer"
         cls.run_cli_command(
             "fetch", "fetchai/generic_buyer:0.22.0", "--alias", cls.agent_name
         )

--- a/tests/test_cli/test_utils/test_utils.py
+++ b/tests/test_cli/test_utils/test_utils.py
@@ -88,7 +88,7 @@ class FormatItemsTestCase(TestCase):
         items = [
             {
                 "public_id": "author/name:version",
-                "name": "obj-name",
+                "name": "obj_name",
                 "description": "Some description",
                 "author": "author",
                 "version": "1.0",
@@ -98,7 +98,7 @@ class FormatItemsTestCase(TestCase):
         expected_result = (
             "------------------------------\n"
             "Public ID: author/name:version\n"
-            "Name: obj-name\n"
+            "Name: obj_name\n"
             "Description: Some description\n"
             "Author: author\n"
             "Version: 1.0\n"
@@ -114,20 +114,20 @@ class TryGetItemSourcePathTestCase(TestCase):
     @mock.patch("aea.cli.utils.package_utils.os.path.exists", return_value=True)
     def test_get_item_source_path_positive(self, exists_mock, join_mock):
         """Test for get_item_source_path positive result."""
-        result = try_get_item_source_path("cwd", AUTHOR, "skills", "skill-name")
+        result = try_get_item_source_path("cwd", AUTHOR, "skills", "skill_name")
         expected_result = "some-path"
         self.assertEqual(result, expected_result)
-        join_mock.assert_called_once_with("cwd", AUTHOR, "skills", "skill-name")
+        join_mock.assert_called_once_with("cwd", AUTHOR, "skills", "skill_name")
         exists_mock.assert_called_once_with("some-path")
 
-        result = try_get_item_source_path("cwd", None, "skills", "skill-name")
+        result = try_get_item_source_path("cwd", None, "skills", "skill_name")
         self.assertEqual(result, expected_result)
 
     @mock.patch("aea.cli.utils.package_utils.os.path.exists", return_value=False)
     def test_get_item_source_path_not_exists(self, exists_mock, join_mock):
         """Test for get_item_source_path item already exists."""
         with self.assertRaises(ClickException):
-            try_get_item_source_path("cwd", AUTHOR, "skills", "skill-name")
+            try_get_item_source_path("cwd", AUTHOR, "skills", "skill_name")
 
 
 @mock.patch("aea.cli.utils.package_utils.os.path.join", return_value="some-path")
@@ -137,17 +137,17 @@ class TryGetItemTargetPathTestCase(TestCase):
     @mock.patch("aea.cli.utils.package_utils.os.path.exists", return_value=False)
     def test_get_item_target_path_positive(self, exists_mock, join_mock):
         """Test for get_item_source_path positive result."""
-        result = try_get_item_target_path("packages", AUTHOR, "skills", "skill-name")
+        result = try_get_item_target_path("packages", AUTHOR, "skills", "skill_name")
         expected_result = "some-path"
         self.assertEqual(result, expected_result)
-        join_mock.assert_called_once_with("packages", AUTHOR, "skills", "skill-name")
+        join_mock.assert_called_once_with("packages", AUTHOR, "skills", "skill_name")
         exists_mock.assert_called_once_with("some-path")
 
     @mock.patch("aea.cli.utils.package_utils.os.path.exists", return_value=True)
     def test_get_item_target_path_already_exists(self, exists_mock, join_mock):
         """Test for get_item_target_path item already exists."""
         with self.assertRaises(ClickException):
-            try_get_item_target_path("skills", AUTHOR, "skill-name", "packages_path")
+            try_get_item_target_path("skills", AUTHOR, "skill_name", "packages_path")
 
 
 class PublicIdParameterTestCase(TestCase):

--- a/tests/test_cli/tools_for_testing.py
+++ b/tests/test_cli/tools_for_testing.py
@@ -52,7 +52,7 @@ class AgentConfigMock:
         self.version: str = kwargs.get("version", "")
         self.protocols: List[str] = kwargs.get("protocols", [])
         self.skills: List[str] = kwargs.get("skills", [])
-        self.agent_name: str = kwargs.get("agent_name", "agent-name")
+        self.agent_name: str = kwargs.get("agent_name", "agent_name")
         self.author: str = AUTHOR
         private_key_paths = kwargs.get("private_key_paths", [])
         self.private_key_paths = Mock()


### PR DESCRIPTION
## Proposed changes

- RegexConstrainedString should have used re.fullmatch instead of re.match
- JSON schema regexes should have "^" and "$" because they are not full-matched by default.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a