### PR TITLE
AEA-1519 fix: provide proper stdout messages when local registry not present

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,5 +7,4 @@ omit =
     packages/fetchai/skills/erc1155_client/*
     packages/fetchai/skills/erc1155_deploy/*
     packages/fetchai/skills/gym/*
-    packages/fetchai/skills/registration_aw1/*
     plugins/aea-ledger-cosmos/aea_ledger_cosmos/cosmos.py

--- a/aea/cli/add.py
+++ b/aea/cli/add.py
@@ -47,6 +47,7 @@ from aea.configurations.base import (
     SkillConfig,
 )
 from aea.configurations.constants import CONNECTION, CONTRACT, PROTOCOL, SKILL
+from aea.exceptions import enforce
 
 
 @click.group()
@@ -56,8 +57,18 @@ from aea.configurations.constants import CONNECTION, CONTRACT, PROTOCOL, SKILL
 def add(click_context: click.Context, local: bool, remote: bool) -> None:
     """Add a package to the agent."""
     ctx = cast(Context, click_context.obj)
+    enforce(
+        not (local and remote), "'local' and 'remote' options are mutually exclusive."
+    )
+    if not local and not remote:
+        try:
+            ctx.registry_path
+        except ValueError as e:
+            click.echo(f"{e}\nTrying remote registry (`--remote`).")
+            remote = True
+    is_mixed = not local and not remote
     ctx.set_config("is_local", local and not remote)
-    ctx.set_config("is_mixed", not local and not remote)
+    ctx.set_config("is_mixed", is_mixed)
 
 
 @add.command()

--- a/aea/cli/fetch.py
+++ b/aea/cli/fetch.py
@@ -89,6 +89,12 @@ def do_fetch(
     enforce(
         not (local and remote), "'local' and 'remote' options are mutually exclusive."
     )
+    if not local and not remote:
+        try:
+            ctx.registry_path
+        except ValueError as e:
+            click.echo(f"{e}\nTrying remote registry (`--remote`).")
+            remote = True
     is_mixed = not local and not remote
     ctx.set_config("is_local", local and not remote)
     ctx.set_config("is_mixed", is_mixed)
@@ -131,8 +137,13 @@ def fetch_agent_locally(
     :param target_dir: the target directory to which the agent is fetched.
     :return: None
     """
+    try:
+        registry_path = ctx.registry_path
+    except ValueError as e:
+        raise click.ClickException(str(e))
+
     source_path = try_get_item_source_path(
-        ctx.registry_path, public_id.author, AGENTS, public_id.name
+        registry_path, public_id.author, AGENTS, public_id.name
     )
     enforce(
         ctx.config.get("is_local") is True or ctx.config.get("is_mixed") is True,

--- a/aea/cli/publish.py
+++ b/aea/cli/publish.py
@@ -151,29 +151,26 @@ def _save_agent_locally(ctx: Context, is_mixed: bool = False) -> None:
 
     :return: None
     """
+    try:
+        registry_path = ctx.registry_path
+    except ValueError as e:  # pragma: nocover
+        raise click.ClickException(str(e))
     for item_type_plural in (CONNECTIONS, CONTRACTS, PROTOCOLS, SKILLS):
         dependencies = getattr(ctx.agent_config, item_type_plural)
         for public_id in dependencies:
             if is_mixed:
                 _check_is_item_in_registry_mixed(
-                    PublicId.from_str(str(public_id)),
-                    item_type_plural,
-                    ctx.registry_path,
+                    PublicId.from_str(str(public_id)), item_type_plural, registry_path,
                 )
             else:
                 _check_is_item_in_local_registry(
-                    PublicId.from_str(str(public_id)),
-                    item_type_plural,
-                    ctx.registry_path,
+                    PublicId.from_str(str(public_id)), item_type_plural, registry_path,
                 )
 
     item_type_plural = AGENTS
 
     target_dir = try_get_item_target_path(
-        ctx.registry_path,
-        ctx.agent_config.author,
-        item_type_plural,
-        ctx.agent_config.name,
+        registry_path, ctx.agent_config.author, item_type_plural, ctx.agent_config.name,
     )
     if not os.path.exists(target_dir):
         os.makedirs(target_dir, exist_ok=True)

--- a/aea/cli/push.py
+++ b/aea/cli/push.py
@@ -116,8 +116,12 @@ def _save_item_locally(ctx: Context, item_type: str, item_id: PublicId) -> None:
 
     check_package_public_id(source_path, item_type, item_id)
 
+    try:
+        registry_path = ctx.registry_path
+    except ValueError as e:  # pragma: nocover
+        raise click.ClickException(str(e))
     target_path = try_get_item_target_path(
-        ctx.registry_path, ctx.agent_config.author, item_type_plural, item_id.name,
+        registry_path, ctx.agent_config.author, item_type_plural, item_id.name,
     )
     copytree(source_path, target_path)
     click.echo(

--- a/aea/cli/search.py
+++ b/aea/cli/search.py
@@ -172,10 +172,14 @@ def _search_items_locally(ctx: Context, item_type_plural: str) -> List[Dict]:
             result,
         )
 
+    try:
+        registry_path = ctx.registry_path
+    except ValueError as e:  # pragma: nocover
+        raise click.ClickException(str(e))
     # look in packages dir for all other packages
     _get_details_from_dir(
         cast(ConfigLoader, configs[item_type_plural]["loader"]),
-        ctx.registry_path,
+        registry_path,
         "*/{}".format(item_type_plural),
         cast(str, configs[item_type_plural]["config_file"]),
         result,

--- a/aea/cli/utils/context.py
+++ b/aea/cli/utils/context.py
@@ -74,7 +74,7 @@ class Context:
         if registry_path.is_dir():
             return str(registry_path)
         raise ValueError(
-            f"Registry path not provided and `{DEFAULT_REGISTRY_NAME}` not found in current ({self.cwd}) and parent directory."
+            f"Registry path not provided and local registry `{DEFAULT_REGISTRY_NAME}` not found in current ({self.cwd}) and parent directory."
         )
 
     @property

--- a/aea/cli/utils/package_utils.py
+++ b/aea/cli/utils/package_utils.py
@@ -302,9 +302,14 @@ def find_item_locally(
     item_type_plural = item_type + "s"
     item_name = item_public_id.name
 
+    try:
+        registry_path = ctx.registry_path
+    except ValueError as e:
+        raise click.ClickException(str(e))
+
     # check in registry
     package_path = Path(
-        ctx.registry_path, item_public_id.author, item_type_plural, item_name
+        registry_path, item_public_id.author, item_type_plural, item_name
     )
     config_file_name = _get_default_configuration_file_name_from_type(item_type)
     item_configuration_filepath = package_path / config_file_name

--- a/tests/test_cli/test_create.py
+++ b/tests/test_cli/test_create.py
@@ -84,7 +84,7 @@ class TestCreate:
         result = cls.runner.invoke(
             cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
         )
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.stdout
 
         cls.result = cls.runner.invoke(
             cli,

--- a/tests/test_cli/test_fetch.py
+++ b/tests/test_cli/test_fetch.py
@@ -295,6 +295,37 @@ class TestFetchAgentRemoteModeError(BaseTestFetchAgentError):
     MODE = "--remote"
 
 
+def test_fetch_mixed_no_local_registry():
+    """Test that mixed becomes remote when no local registry."""
+    with TemporaryDirectory() as tmp_dir:
+        with cd(tmp_dir):
+            name = "my_first_aea"
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["fetch", "fetchai/my_first_aea"], catch_exceptions=False,
+            )
+            assert result.exit_code == 0, result.stdout
+            assert os.path.exists(name)
+            assert "Trying remote registry (`--remote`)." in result.stdout
+
+
+def test_fetch_local_no_local_registry():
+    """Test that local fetch fails when no local registry."""
+    with TemporaryDirectory() as tmp_dir:
+        with cd(tmp_dir):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["fetch", "--local", "fetchai/my_first_aea"],
+                catch_exceptions=False,
+            )
+            assert result.exit_code == 1, result.stdout
+            assert (
+                "Registry path not provided and local registry `packages` not found in current (.) and parent directory."
+                in result.stdout
+            )
+
+
 def test_fetch_twice_locally():
     """Test fails on fetch if dir exists."""
     with TemporaryDirectory() as tmp_dir:

--- a/tests/test_cli/test_utils/test_utils.py
+++ b/tests/test_cli/test_utils/test_utils.py
@@ -612,6 +612,7 @@ def test_context_registry_path_does_not_exist():
     with TemporaryDirectory() as tmp_dir:
         with cd(tmp_dir):
             with pytest.raises(
-                ValueError, match="Registry path not provided and `packages` not found"
+                ValueError,
+                match="Registry path not provided and local registry `packages` not found",
             ):
                 Context(cwd=".", verbosity="", registry_path=None).registry_path

--- a/tests/test_packages/test_connections/test_p2p_libp2p_client/test_communication.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p_client/test_communication.py
@@ -767,7 +767,7 @@ class TestLibp2pClientReconnectionReceiveEnvelope(BaseTestLibp2pClientReconnecti
             # give time to reconnect
             time.sleep(2.0)
             _mock_logger.assert_called_with(
-                RegexComparator(f"Connection error:.*Try to reconnect and read again")
+                RegexComparator("Connection error:.*Try to reconnect and read again")
             )
         # proceed as usual. Now we expect the connection to have reconnected successfully
         self.multiplexer_client_2.put(envelope)


### PR DESCRIPTION
## Proposed changes

This PR addresses an issue with v1 whereby a missing local registry (`packages` folder) can lead to messy exceptions.

## Fixes

#2442

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

-