### PR TITLE
feat: bound version of dependencies by next major

### DIFF
--- a/plugins/aea-cli-ipfs/setup.py
+++ b/plugins/aea-cli-ipfs/setup.py
@@ -33,7 +33,7 @@ setup(
     description="CLI extension for AEA framework wrapping IPFS functionality.",
     packages=["aea_cli_ipfs"],
     entry_points={"aea.cli": ["ipfs_cli_command = aea_cli_ipfs.core:ipfs"]},
-    install_requires=["aea>=1.0.0, <2.0.0", "ipfshttpclient>=0.6.1"],
+    install_requires=["aea>=1.0.0, <2.0.0", "ipfshttpclient>=0.6.1,<0.8.0"],
     classifiers=[
         "Environment :: Console",
         "Environment :: Web Environment",

--- a/plugins/aea-ledger-cosmos/setup.py
+++ b/plugins/aea-ledger-cosmos/setup.py
@@ -32,9 +32,9 @@ setup(
     packages=find_packages(include=["aea_ledger_cosmos*"]),
     install_requires=[
         "aea>=1.0.0, <2.0.0",
-        "ecdsa>=0.15",
+        "ecdsa>=0.15,<0.17.0",
         "bech32==1.2.0",
-        "pycryptodome>=3.10.1",
+        "pycryptodome>=3.10.1,<4.0.0",
     ],
     tests_require=["pytest"],
     entry_points={

--- a/plugins/aea-ledger-fetchai/setup.py
+++ b/plugins/aea-ledger-fetchai/setup.py
@@ -37,9 +37,9 @@ setup(
     packages=find_packages(include=["aea_ledger_fetchai*"]),
     install_requires=[
         "aea>=1.0.0, <2.0.0",
-        "ecdsa>=0.15",
+        "ecdsa>=0.15,<0.17.0",
         "bech32==1.2.0",
-        "pycryptodome>=3.10.1",
+        "pycryptodome>=3.10.1,<4.0.0",
     ],
     tests_require=["pytest"],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,10 @@ here = os.path.abspath(os.path.dirname(__file__))
 def get_all_extras() -> Dict:
 
     cli_deps = [
-        "click<8.0.0",
-        "pyyaml>=4.2b1",
-        "jsonschema>=3.0.0",
-        "packaging>=20.3",
+        "click>=7.0.0,<8.0.0",
+        "pyyaml>=4.2b1,<6.0",
+        "jsonschema>=3.0.0,<4.0.0",
+        "packaging>=20.3,<21.0",
     ]
 
     extras = {
@@ -49,16 +49,16 @@ def get_all_extras() -> Dict:
 all_extras = get_all_extras()
 
 base_deps = [
-    "base58>=1.0.3",
-    "jsonschema>=3.0.0",
-    "packaging>=20.3",
-    "semver>=2.9.1",
+    "base58>=1.0.3,<3.0.0",
+    "jsonschema>=3.0.0,<4.0.0",
+    "packaging>=20.3,<21.0",
+    "semver>=2.9.1,<3.0.0",
     "protobuf==3.13.0",
     "pymultihash==0.8.2",
-    "pyyaml>=4.2b1",
-    "requests>=2.22.0",
-    "python-dotenv>=0.14.0",
-    "ecdsa>=0.15"
+    "pyyaml>=4.2b1,<6.0",
+    "requests>=2.22.0,<3.0.0",
+    "python-dotenv>=0.14.0,<0.18.0",
+    "ecdsa>=0.15,<0.17.0"
 ]
 
 if os.name == "nt" or os.getenv("WIN_BUILD_WHEEL", None) == "1":


### PR DESCRIPTION
## Proposed changes

Versions of dependencies in setup.py are not bounded so far. This can lead to unexpected install issues if dependencies are updated. We now bound by the next major version. As long as dependencies follow semantic versioning this should solve the problem.

## Fixes

-

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

-