### PR TITLE
Test: update libp2p test after new ack mechanism (#2435)

### DIFF
--- a/tests/test_packages/test_connections/test_p2p_libp2p_client/test_communication.py
+++ b/tests/test_packages/test_connections/test_p2p_libp2p_client/test_communication.py
@@ -779,7 +779,6 @@ class TestLibp2pClientReconnectionReceiveEnvelope(BaseTestLibp2pClientSamePeer):
                 RegexComparator("Connection error:.*Try to reconnect and read again")
             )
         # proceed as usual. Now we expect the connection to have reconnected successfully
-        self.multiplexer_client_2.put(envelope)
         delivered_envelope = self.multiplexer_client_1.get(block=True, timeout=20)
 
         assert delivered_envelope is not None


### PR DESCRIPTION
## Proposed changes

The test involved was in a temporary state, waiting for improvements on the libp2p implementation. Now we do not need to resend the envelope, as it will be retransmitted by the connection logic.

## Fixes

Fix #2435

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a