### PR TITLE
AEA-1610 fix: add check consistency of package versions (#2459)

### DIFF
--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -70,6 +70,7 @@ from aea.configurations.constants import (
     STATE_UPDATE_PROTOCOL,
     _FETCHAI_IDENTIFIER,
 )
+from aea.configurations.data_types import PackageIdPrefix
 from aea.configurations.loader import ConfigLoader, load_component_configuration
 from aea.configurations.manager import (
     AgentConfigManager,
@@ -116,9 +117,7 @@ class _DependenciesManager:
         self._all_dependencies_by_type = (
             {}
         )  # type: Dict[ComponentType, Dict[ComponentId, ComponentConfiguration]]
-        self._prefix_to_components = (
-            {}
-        )  # type: Dict[Tuple[ComponentType, str, str], Set[ComponentId]]
+        self._prefix_to_components = {}  # type: Dict[PackageIdPrefix, Set[ComponentId]]
         self._inverse_dependency_graph = {}  # type: Dict[ComponentId, Set[ComponentId]]
 
         self.agent_pypi_dependencies: Dependencies = {}

--- a/aea/configurations/data_types.py
+++ b/aea/configurations/data_types.py
@@ -202,6 +202,9 @@ class ComponentType(Enum):
         return str(self.value)
 
 
+PackageIdPrefix = Tuple[ComponentType, str, str]
+
+
 class PublicId(JSONSerializable):
     """This class implement a public identifier.
 
@@ -604,7 +607,7 @@ class ComponentId(PackageId):
         return ComponentType(self.package_type.value)
 
     @property
-    def component_prefix(self) -> Tuple[ComponentType, str, str]:
+    def component_prefix(self) -> PackageIdPrefix:
         """Get the component identifier without the version."""
         package_prefix = super().package_prefix
         package_type, author, name = package_prefix

--- a/aea/configurations/manager.py
+++ b/aea/configurations/manager.py
@@ -43,7 +43,7 @@ from aea.configurations.constants import (
     SKILLS,
     VENDOR,
 )
-from aea.configurations.data_types import ComponentType, PublicId
+from aea.configurations.data_types import ComponentType, PackageIdPrefix, PublicId
 from aea.configurations.loader import ConfigLoader, load_component_configuration
 from aea.configurations.validation import SAME_MARK, filter_data
 from aea.exceptions import AEAException, enforce
@@ -113,7 +113,7 @@ def _try_get_configuration_object_from_aea_config(
 
 
 def _try_get_component_id_from_prefix(
-    component_ids: Set[ComponentId], component_prefix: Tuple[ComponentType, str, str]
+    component_ids: Set[ComponentId], component_prefix: PackageIdPrefix
 ) -> Optional[ComponentId]:
     """
     Find the component id matching a component prefix.

--- a/aea/configurations/utils.py
+++ b/aea/configurations/utils.py
@@ -19,7 +19,7 @@
 
 """AEA configuration utils."""
 from functools import singledispatch
-from typing import Dict, Optional, Set, Tuple
+from typing import Dict, Optional, Set
 
 from aea.configurations.base import (
     AgentConfig,
@@ -32,6 +32,7 @@ from aea.configurations.base import (
     PublicId,
     SkillConfig,
 )
+from aea.configurations.data_types import PackageIdPrefix
 
 
 @singledispatch
@@ -182,7 +183,7 @@ def _replace_component_id(
 
 
 def get_latest_component_id_from_prefix(
-    agent_config: AgentConfig, component_prefix: Tuple[ComponentType, str, str]
+    agent_config: AgentConfig, component_prefix: PackageIdPrefix
 ) -> Optional[ComponentId]:
     """
     Get component id with the greatest version in an agent configuration given its prefix.

--- a/aea/manager/manager.py
+++ b/aea/manager/manager.py
@@ -28,9 +28,11 @@ from threading import Thread
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from aea.aea import AEA
+from aea.configurations.base import AgentConfig
 from aea.configurations.constants import AEA_MANAGER_DATA_DIRNAME, DEFAULT_REGISTRY_NAME
-from aea.configurations.data_types import PublicId
+from aea.configurations.data_types import PackageIdPrefix, PublicId
 from aea.crypto.plugin import load_all_plugins
+from aea.exceptions import enforce
 from aea.helpers.io import open_file
 from aea.manager.project import AgentAlias, Project
 
@@ -46,6 +48,38 @@ class ProjectCheckError(ValueError):
         """Init exception."""
         super().__init__(msg)
         self.source_exception = source_exception
+
+
+class ProjectPackageConsistencyCheckError(ValueError):
+    """Check consistency of package versions against already added project."""
+
+    def __init__(
+        self,
+        agent_project_id: PublicId,
+        conflicting_packages: List[Tuple[PackageIdPrefix, str, str, Set[PublicId]]],
+    ):
+        """
+        Initialize the exception.
+
+        :param agent_project_id: the agent project id whose addition has failed.
+        :param conflicting_packages: the conflicting packages.
+        """
+        self.agent_project_id = agent_project_id
+        self.conflicting_packages = conflicting_packages
+        super().__init__(self._build_error_message())
+
+    def _build_error_message(self) -> str:
+        """Build the error message."""
+        conflicting_packages = sorted(self.conflicting_packages, key=str)
+        message = f"cannot add project '{self.agent_project_id}': the following AEA dependencies have conflicts with previously added projects:\n"
+        for (
+            (type_, author, name),
+            existing_version,
+            new_version,
+            agents,
+        ) in conflicting_packages:
+            message += f"- '{author}/{name}' of type {type_}: the new version '{new_version}' conflicts with existing version '{existing_version}' of the same package required by agents: {list(agents)}\n"
+        return message
 
 
 class AgentRunAsyncTask:
@@ -207,6 +241,15 @@ class MultiAgentManager:
         # this flags will control whether we have already printed the warning message
         # for a certain agent
         self._warning_message_printed_for_agent: Dict[str, bool] = {}
+
+        # the dictionary keeps track of the AEA packages used across
+        # AEA projects in the same MAM.
+        # It maps package prefixes to a pair: (version, agent_ids)
+        # where agent_ids is the set of agent ids whose projects
+        # have the package in the key at the specific version.
+        self._package_id_prefix_to_version: Dict[
+            PackageIdPrefix, Tuple[str, Set[PublicId]]
+        ] = {}
 
     @property
     def data_dir(self) -> str:
@@ -416,6 +459,8 @@ class MultiAgentManager:
             load_all_plugins(is_raising_exception=False)
             project.build()
 
+        self._check_version_consistency(project.agent_config)
+
         try:
             project.check()
         except Exception as e:
@@ -424,6 +469,7 @@ class MultiAgentManager:
                 f"Failed to load project: {public_id} Error: {str(e)}", e
             )
 
+        self._add_new_package_versions(project.agent_config)
         self._versionless_projects_set.add(public_id.to_any())
         self._projects[public_id] = project
         return self
@@ -441,6 +487,7 @@ class MultiAgentManager:
             )
 
         project = self._projects.pop(public_id)
+        self._remove_package_versions(project.agent_config)
         self._versionless_projects_set.remove(public_id.to_any())
         if not keep_files:
             project.remove()
@@ -835,7 +882,6 @@ class MultiAgentManager:
                 break
 
             for agent_settings in agents_settings:
-
                 self.add_agent_with_config(
                     public_id=PublicId.from_str(agent_settings["public_id"]),
                     agent_name=agent_settings["agent_name"],
@@ -883,3 +929,100 @@ class MultiAgentManager:
             "\nHowever, since no error callback was found the exception is handled silently. Please "
             "add an error callback using the method 'add_error_callback' of the MultiAgentManager instance.",
         )
+
+    def _check_version_consistency(self, agent_config: AgentConfig) -> None:
+        """
+        Check that the agent dependencies in input are consistent with the other projects.
+
+        :param agent_config: the agent configuration we are going to add.
+        :return: None
+        :raises ProjectPackageConsistencyCheckError: if a version conflict is detected.
+        """
+        existing_packages = set(self._package_id_prefix_to_version.keys())
+        prefix_to_version = {
+            component_id.component_prefix: component_id.version
+            for component_id in agent_config.package_dependencies
+        }
+        component_prefixes_to_be_added = set(prefix_to_version.keys())
+
+        potentially_conflicting_packages = existing_packages.intersection(
+            component_prefixes_to_be_added
+        )
+        if len(potentially_conflicting_packages) == 0:
+            return
+
+        # conflicting_packages is a list of tuples whose elements are:
+        # - package id prefix: the triple (component type, author, name)
+        # - current_version: the version currently present in the MAM, across all projects
+        # - new_version: the version of the package in the new project
+        # - agents: the set of agents in the MAM that have the package;
+        #           used to provide a better error message
+        conflicting_packages: List[Tuple[PackageIdPrefix, str, str, Set[PublicId]]] = []
+        for package_prefix in potentially_conflicting_packages:
+            existing_version, agents = self._package_id_prefix_to_version[
+                package_prefix
+            ]
+            new_version = prefix_to_version[package_prefix]
+            if existing_version != new_version:
+                conflicting_packages.append(
+                    (package_prefix, existing_version, new_version, agents)
+                )
+
+        if len(conflicting_packages) == 0:
+            return
+
+        raise ProjectPackageConsistencyCheckError(
+            agent_config.public_id, conflicting_packages
+        )
+
+    def _add_new_package_versions(self, agent_config: AgentConfig) -> None:
+        """
+        Add new package versions.
+
+        This method is called whenever a project agent is added.
+        It updates an internal data structure that it is used to
+        check inconsistencies of AEA package versions across projects.
+        In particular, all the AEA packages with the same "prefix" must
+        be of the same version.
+
+        :param agent_config: the agent configuration.
+        """
+        for component_id in agent_config.package_dependencies:
+            if component_id.component_prefix not in self._package_id_prefix_to_version:
+                self._package_id_prefix_to_version[component_id.component_prefix] = (
+                    component_id.version,
+                    set(),
+                )
+            version, agents = self._package_id_prefix_to_version[
+                component_id.component_prefix
+            ]
+            enforce(
+                version == component_id.version,
+                f"internal consistency error: expected version '{version}', found {component_id.version}",
+            )
+            agents.add(agent_config.public_id)
+
+    def _remove_package_versions(self, agent_config: AgentConfig) -> None:
+        """
+        Remove package versions.
+
+        This method is called whenever a project agent is removed.
+        It updates an internal data structure that it is used to
+        check inconsistencies of AEA package versions across projects.
+        In particular, all the AEA packages with the same "prefix" must
+        be of the same version.
+
+        :param agent_config: the agent configuration.
+        """
+        package_prefix_to_remove = set()
+        for (
+            package_prefix,
+            (_version, agents),
+        ) in self._package_id_prefix_to_version.items():
+            if agent_config.public_id in agents:
+                agents.remove(agent_config.public_id)
+                if len(agents) == 0:
+                    package_prefix_to_remove.add(package_prefix)
+
+        for package_prefix in package_prefix_to_remove:
+            self._package_id_prefix_to_version.pop(package_prefix)

--- a/aea/manager/project.py
+++ b/aea/manager/project.py
@@ -133,9 +133,14 @@ class Project(_Base):
         rmtree(self.path)
 
     @property
+    def agent_config(self) -> AgentConfig:
+        """Get the agent configuration."""
+        return self._get_agent_config(self.path)
+
+    @property
     def builder(self) -> AEABuilder:
         """Get builder instance."""
-        return self._get_builder(self._get_agent_config(self.path), self.path)
+        return self._get_builder(self.agent_config, self.path)
 
     def check(self) -> None:
         """Check we can still construct an AEA from the project with builder.build."""

--- a/tests/test_manager/test_manager.py
+++ b/tests/test_manager/test_manager.py
@@ -25,6 +25,7 @@ from contextlib import suppress
 from pathlib import Path
 from shutil import rmtree
 from tempfile import TemporaryDirectory
+from textwrap import dedent
 from typing import Optional
 from unittest.case import TestCase
 from unittest.mock import Mock, patch
@@ -37,6 +38,7 @@ from aea.crypto.plugin import load_all_plugins
 from aea.crypto.registries import crypto_registry
 from aea.helpers.install_dependency import run_install_subprocess
 from aea.manager import MultiAgentManager
+from aea.manager.manager import ProjectPackageConsistencyCheckError
 
 from packages.fetchai.connections.stub.connection import StubConnection
 from packages.fetchai.skills.echo import PUBLIC_ID as ECHO_SKILL_PUBLIC_ID
@@ -583,6 +585,75 @@ class TestMultiAgentManagerThreadedModeWithPassword(BaseTestMultiAgentManager):
 
     MODE = "threaded"
     PASSWORD = "password"  # nosec
+
+
+class TestMultiAgentManagerPackageConsistencyError:
+    """
+    Test that the MultiAgentManager (MAM) raises an error on package version inconsistency.
+
+    In particular, an invariant to keep for the MAM state is that
+    there are no two AEA package dependencies across all the projects
+    that have different versions. This is due to a known limitation
+    in the package loading system.
+
+    This test checks that when the invariant is violated when
+    the method "add_project" is called, the framework raises an
+    exception with a descriptive error message.
+    """
+
+    EXPECTED_ERROR_MESSAGE = dedent(
+        """    cannot add project 'fetchai/weather_client:0.27.0': the following AEA dependencies have conflicts with previously added projects:
+    - 'fetchai/ledger' of type connection: the new version '0.17.0' conflicts with existing version '0.18.0' of the same package required by agents: [<fetchai/weather_station:0.27.0>]
+    - 'fetchai/p2p_libp2p' of type connection: the new version '0.20.0' conflicts with existing version '0.21.0' of the same package required by agents: [<fetchai/weather_station:0.27.0>]
+    - 'fetchai/soef' of type connection: the new version '0.21.0' conflicts with existing version '0.22.0' of the same package required by agents: [<fetchai/weather_station:0.27.0>]
+    - 'fetchai/contract_api' of type protocol: the new version '0.14.0' conflicts with existing version '1.0.0' of the same package required by agents: [<fetchai/weather_station:0.27.0>]
+    - 'fetchai/default' of type protocol: the new version '0.15.0' conflicts with existing version '1.0.0' of the same package required by agents: [<fetchai/weather_station:0.27.0>]
+    - 'fetchai/fipa' of type protocol: the new version '0.16.0' conflicts with existing version '1.0.0' of the same package required by agents: [<fetchai/weather_station:0.27.0>]
+    - 'fetchai/ledger_api' of type protocol: the new version '0.13.0' conflicts with existing version '1.0.0' of the same package required by agents: [<fetchai/weather_station:0.27.0>]
+    - 'fetchai/oef_search' of type protocol: the new version '0.16.0' conflicts with existing version '1.0.0' of the same package required by agents: [<fetchai/weather_station:0.27.0>]
+    - 'fetchai/signing' of type protocol: the new version '0.13.0' conflicts with existing version '1.0.0' of the same package required by agents: [<fetchai/weather_station:0.27.0>]
+    - 'fetchai/state_update' of type protocol: the new version '0.13.0' conflicts with existing version '1.0.0' of the same package required by agents: [<fetchai/weather_station:0.27.0>]
+    """
+    )
+
+    def setup(self):
+        """Set up the test case."""
+        self.project_public_id = MY_FIRST_AEA_PUBLIC_ID
+        self.tmp_dir = TemporaryDirectory()
+        self.working_dir = os.path.join(self.tmp_dir.name, "MultiAgentManager_dir")
+        self.project_path = os.path.join(
+            self.working_dir, self.project_public_id.author, self.project_public_id.name
+        )
+        assert not os.path.exists(self.working_dir)
+        self.manager = MultiAgentManager(self.working_dir)
+
+    def test_run(self):
+        """
+        Run the test.
+
+        First add agent project "fetchai/weather_station:0.27.0",
+        and then add "fetchai/weather_client:0.27.0".
+        The second addition will fail because the projects
+        contain conflicting AEA package versions.
+        """
+        self.manager.start_manager()
+        weather_station_id = PublicId.from_str("fetchai/weather_station:0.27.0")
+        self.manager.add_project(weather_station_id)
+        weather_client_id = PublicId.from_str("fetchai/weather_client:0.27.0")
+        with pytest.raises(
+            ProjectPackageConsistencyCheckError,
+            match=re.escape(self.EXPECTED_ERROR_MESSAGE),
+        ):
+            self.manager.add_project(weather_client_id)
+
+    def teardown(self):
+        """Tear down test case."""
+        try:
+            self.manager.stop_manager()
+            if os.path.exists(self.working_dir):
+                rmtree(self.working_dir)
+        finally:
+            self.tmp_dir.cleanup()
 
 
 def test_project_auto_added_removed():


### PR DESCRIPTION
## Proposed changes

Add consistency of package versions in MAM.

MAM should track all versions of packages and raise an exception when incompatible versions of any packages are added. Otherwise, this can lead to problems at runtime (with whatever version being loaded last being in memory).

This PR addresses the above issue.

## Fixes

Fix #2459 

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a