### PR TITLE
AEA-1613 fix: validate aea_version when loading configuration (#2519)

### DIFF
--- a/aea/cli/utils/context.py
+++ b/aea/cli/utils/context.py
@@ -78,29 +78,51 @@ class Context:
         )
 
     @property
+    def skip_aea_validation(self) -> bool:
+        """
+        Get the 'skip_aea_validation' flag.
+
+        If true, validation of the AEA version for loaded configuration
+        file is skipped.
+
+        :return: the 'skip_aea_validation'
+        """
+        return self.config.get("skip_aea_validation", True)
+
+    @property
     def agent_loader(self) -> ConfigLoader:
         """Get the agent loader."""
-        return ConfigLoader.from_configuration_type(PackageType.AGENT)
+        return ConfigLoader.from_configuration_type(
+            PackageType.AGENT, skip_aea_validation=self.skip_aea_validation
+        )
 
     @property
     def protocol_loader(self) -> ConfigLoader:
         """Get the protocol loader."""
-        return ConfigLoader.from_configuration_type(PackageType.PROTOCOL)
+        return ConfigLoader.from_configuration_type(
+            PackageType.PROTOCOL, skip_aea_validation=self.skip_aea_validation
+        )
 
     @property
     def connection_loader(self) -> ConfigLoader:
         """Get the connection loader."""
-        return ConfigLoader.from_configuration_type(PackageType.CONNECTION)
+        return ConfigLoader.from_configuration_type(
+            PackageType.CONNECTION, skip_aea_validation=self.skip_aea_validation
+        )
 
     @property
     def skill_loader(self) -> ConfigLoader:
         """Get the skill loader."""
-        return ConfigLoader.from_configuration_type(PackageType.SKILL)
+        return ConfigLoader.from_configuration_type(
+            PackageType.SKILL, skip_aea_validation=self.skip_aea_validation
+        )
 
     @property
     def contract_loader(self) -> ConfigLoader:
         """Get the contract loader."""
-        return ConfigLoader.from_configuration_type(PackageType.CONTRACT)
+        return ConfigLoader.from_configuration_type(
+            PackageType.CONTRACT, skip_aea_validation=self.skip_aea_validation
+        )
 
     def set_config(self, key: str, value: Any) -> None:
         """

--- a/aea/configurations/base.py
+++ b/aea/configurations/base.py
@@ -263,7 +263,7 @@ class PackageConfiguration(Configuration, ABC):
         )
         self.build_entrypoint = build_entrypoint
         self._aea_version = aea_version if aea_version != "" else __aea_version__
-        self._aea_version_specifiers = self._parse_aea_version_specifier(aea_version)
+        self._aea_version_specifiers = self.parse_aea_version_specifier(aea_version)
 
         self._directory = None  # type: Optional[Path]
 
@@ -295,9 +295,7 @@ class PackageConfiguration(Configuration, ABC):
     @aea_version.setter
     def aea_version(self, new_aea_version: str) -> None:
         """Set the 'aea_version' attribute."""
-        self._aea_version_specifiers = self._parse_aea_version_specifier(
-            new_aea_version
-        )
+        self._aea_version_specifiers = self.parse_aea_version_specifier(new_aea_version)
         self._aea_version = new_aea_version
 
     def check_aea_version(self) -> None:
@@ -326,7 +324,16 @@ class PackageConfiguration(Configuration, ABC):
         return PackageId(package_type=self.package_type, public_id=self.public_id)
 
     @staticmethod
-    def _parse_aea_version_specifier(aea_version_specifiers: str) -> SpecifierSet:
+    def parse_aea_version_specifier(aea_version_specifiers: str) -> SpecifierSet:
+        """
+        Parse an 'aea_version' field.
+
+        If 'aea_version' is a version, then output the specifier set "==${version}"
+        Else, interpret it as specifier set.
+
+        :param aea_version_specifiers: the AEA version, or a specifier set.
+        :return: A specifier set object.
+        """
         try:
             Version(aea_version_specifiers)
             return SpecifierSet("==" + aea_version_specifiers)

--- a/aea/configurations/loader.py
+++ b/aea/configurations/loader.py
@@ -18,7 +18,7 @@
 # ------------------------------------------------------------------------------
 """Implementation of the parser for configuration file."""
 from pathlib import Path
-from typing import Dict, Generic, List, TextIO, Type, TypeVar, Union, cast
+from typing import Any, Dict, Generic, List, TextIO, Type, TypeVar, Union, cast
 
 import yaml
 
@@ -44,7 +44,6 @@ from aea.helpers.yaml_utils import yaml_dump, yaml_dump_all, yaml_load, yaml_loa
 
 
 _STARTING_INDEX_CUSTOM_CONFIGS = 1
-
 
 _ = make_jsonschema_base_uri  # for tests compatibility
 
@@ -96,15 +95,22 @@ class BaseConfigLoader:
 class ConfigLoader(Generic[T], BaseConfigLoader):
     """Parsing, serialization and validation for package configuration files."""
 
-    def __init__(self, schema_filename: str, configuration_class: Type[T]) -> None:
+    def __init__(
+        self,
+        schema_filename: str,
+        configuration_class: Type[T],
+        skip_aea_validation: bool = True,
+    ) -> None:
         """
         Initialize the parser for configuration files.
 
         :param schema_filename: the path to the JSON-schema file in 'aea/configurations/schemas'.
         :param configuration_class: the configuration class (e.g. AgentConfig, SkillConfig etc.)
+        :param skip_aea_validation: if True, the validation of the AEA version is skipped.
         """
         super().__init__(schema_filename)
         self._configuration_class = configuration_class  # type: Type[T]
+        self._skip_aea_validation = skip_aea_validation
 
     @property
     def configuration_class(self) -> Type[T]:
@@ -120,14 +126,15 @@ class ConfigLoader(Generic[T], BaseConfigLoader):
 
         :param json_data: the JSON data.
         """
-        aea_version_specifier_set = AgentConfig.parse_aea_version_specifier(
-            json_data["aea_version"]
-        )
-        aea_version = aea.__version__
-        enforce(
-            aea_version_specifier_set.contains(aea_version),
-            f"AEA version in use '{aea_version}' is not compatible with the specifier set '{aea_version_specifier_set}'.",
-        )
+        if not self._skip_aea_validation:
+            aea_version_specifier_set = AgentConfig.parse_aea_version_specifier(
+                json_data["aea_version"]
+            )
+            aea_version = aea.__version__
+            enforce(
+                aea_version_specifier_set.contains(aea_version),
+                f"AEA version in use '{aea_version}' is not compatible with the specifier set '{aea_version_specifier_set}'.",
+            )
         super().validate(json_data)
 
     def load_protocol_specification(
@@ -195,11 +202,17 @@ class ConfigLoader(Generic[T], BaseConfigLoader):
 
     @classmethod
     def from_configuration_type(
-        cls, configuration_type: Union[PackageType, str]
+        cls, configuration_type: Union[PackageType, str], **kwargs: Any
     ) -> "ConfigLoader":
-        """Get the configuration loader from the type."""
+        """
+        Get the configuration loader from the type.
+
+        :param configuration_type: the type of configuration
+        :param kwargs: keyword arguments to the configuration loader constructor.
+        :return: the configuration loader
+        """
         configuration_type = PackageType(configuration_type)
-        return ConfigLoaders.from_package_type(configuration_type)
+        return ConfigLoaders.from_package_type(configuration_type, **kwargs)
 
     def _load_component_config(self, file_pointer: TextIO) -> T:
         """Load a component configuration."""
@@ -320,24 +333,26 @@ class ConfigLoaders:
 
     @classmethod
     def from_package_type(
-        cls, configuration_type: Union[PackageType, str]
+        cls, configuration_type: Union[PackageType, str], **kwargs: Any
     ) -> "ConfigLoader":
         """
         Get a config loader from the configuration type.
 
         :param configuration_type: the configuration type.
+        :param kwargs: keyword arguments to the configuration loader constructor.
         :return: configuration loader
         """
         config_class: Type[PackageConfiguration] = PACKAGE_TYPE_TO_CONFIG_CLASS[
             PackageType(configuration_type)
         ]
-        return ConfigLoader(config_class.schema, config_class)
+        return ConfigLoader(config_class.schema, config_class, **kwargs)
 
 
 def load_component_configuration(
     component_type: ComponentType,
     directory: Path,
     skip_consistency_check: bool = False,
+    skip_aea_validation: bool = True,
 ) -> ComponentConfiguration:
     """
     Load configuration and check that it is consistent against the directory.
@@ -345,18 +360,22 @@ def load_component_configuration(
     :param component_type: the component type.
     :param directory: the root of the package
     :param skip_consistency_check: if True, the consistency check are skipped.
+    :param skip_aea_validation: if True, the validation of the AEA version is skipped.
     :return: the configuration object.
     """
     package_type = component_type.to_package_type()
     configuration_object = load_package_configuration(
-        package_type, directory, skip_consistency_check
+        package_type, directory, skip_consistency_check, skip_aea_validation
     )
     configuration_object = cast(ComponentConfiguration, configuration_object)
     return configuration_object
 
 
 def load_package_configuration(
-    package_type: PackageType, directory: Path, skip_consistency_check: bool = False,
+    package_type: PackageType,
+    directory: Path,
+    skip_consistency_check: bool = False,
+    skip_aea_validation: bool = True,
 ) -> PackageConfiguration:
     """
     Load configuration and check that it is consistent against the directory.
@@ -364,9 +383,12 @@ def load_package_configuration(
     :param package_type: the package type.
     :param directory: the root of the package
     :param skip_consistency_check: if True, the consistency check are skipped.
+    :param skip_aea_validation: if True, the validation of the AEA version is skipped.
     :return: the configuration object.
     """
-    configuration_object = _load_configuration_object(package_type, directory)
+    configuration_object = _load_configuration_object(
+        package_type, directory, skip_aea_validation
+    )
     if not skip_consistency_check and isinstance(
         configuration_object, ComponentConfiguration
     ):
@@ -377,17 +399,20 @@ def load_package_configuration(
 
 
 def _load_configuration_object(
-    package_type: PackageType, directory: Path
+    package_type: PackageType, directory: Path, skip_aea_validation: bool = True
 ) -> PackageConfiguration:
     """
     Load the configuration object, without consistency checks.
 
     :param package_type: the package type.
     :param directory: the directory of the configuration.
+    :param skip_aea_validation: if True, the validation of the AEA version is skipped.
     :return: the configuration object.
     :raises FileNotFoundError: if the configuration file is not found.
     """
-    configuration_loader = ConfigLoader.from_configuration_type(package_type)
+    configuration_loader = ConfigLoader.from_configuration_type(
+        package_type, skip_aea_validation=skip_aea_validation
+    )
     configuration_filename = (
         configuration_loader.configuration_class.default_configuration_filename
     )

--- a/aea/manager/manager.py
+++ b/aea/manager/manager.py
@@ -409,6 +409,7 @@ class MultiAgentManager:
             remote,
             registry_path=self.registry_path,
             is_restore=restore,
+            skip_aea_validation=False,
         )
 
         if not restore:

--- a/aea/manager/project.py
+++ b/aea/manager/project.py
@@ -98,7 +98,7 @@ class Project(_Base):
         cli_verbosity: str = "INFO",
         registry_path: str = DEFAULT_REGISTRY_NAME,
         skip_consistency_check: bool = False,
-        skip_aea_validation: bool = True,
+        skip_aea_validation: bool = False,
     ) -> "Project":
         """
         Load project with given public_id to working_dir.

--- a/aea/manager/project.py
+++ b/aea/manager/project.py
@@ -98,6 +98,7 @@ class Project(_Base):
         cli_verbosity: str = "INFO",
         registry_path: str = DEFAULT_REGISTRY_NAME,
         skip_consistency_check: bool = False,
+        skip_aea_validation: bool = True,
     ) -> "Project":
         """
         Load project with given public_id to working_dir.
@@ -114,12 +115,14 @@ class Project(_Base):
         :param cli_verbosity: the logging verbosity of the CLI
         :param registry_path: the path to the registry locally
         :param skip_consistency_check: consistency checks flag
+        :param skip_aea_validation: aea validation flag
         :return: project
         """
         ctx = Context(
             cwd=working_dir, verbosity=cli_verbosity, registry_path=registry_path
         )
         ctx.set_config("skip_consistency_check", skip_consistency_check)
+        ctx.set_config("skip_aea_validation", skip_aea_validation)
 
         path = os.path.join(working_dir, public_id.author, public_id.name)
         target_dir = os.path.join(public_id.author, public_id.name)

--- a/tests/test_configurations/test_aea_config.py
+++ b/tests/test_configurations/test_aea_config.py
@@ -57,7 +57,7 @@ version: 0.1.0
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-aea_version: 0.3.0
+aea_version: '>=1.0.0, <2.0.0'
 description: ''
 connections: []
 contracts: []

--- a/tests/test_configurations/test_loader.py
+++ b/tests/test_configurations/test_loader.py
@@ -139,7 +139,9 @@ def test_load_protocol_specification_too_many_parts():
 @mock.patch.object(aea, "__version__", "0.1.0")
 def test_load_package_configuration_with_incompatible_aea_version(*_mocks):
     """Test that loading a package configuration with incompatible AEA version raises an error."""
-    config_loader = ConfigLoader.from_configuration_type(PackageType.PROTOCOL)
+    config_loader = ConfigLoader.from_configuration_type(
+        PackageType.PROTOCOL, skip_aea_validation=False
+    )
     specifier_set = "<2.0.0,>=1.0.0"
     file = StringIO(f"name: some_protocol\naea_version: '{specifier_set}'")
     with pytest.raises(


### PR DESCRIPTION
## Proposed changes

Validate aea_version when loading configuration.

That is, before validating the loaded YAML file against the schema, first check that `aea_version` is consistent with the current `aea` version being used.

It also introduces the `skip_aea_validation` flag in the `ConfigLoader` constructor (and factory methods/functions). This is useful to switch the behaviour of configuration loading in terms of `aea_version` validation.

As pointed out by @DavidMinarsch , sometime we don't want to validate the `aea_version`, e.g. we can fetch packages even if the current AEA version is incompatible with the fetched package; but we want such validation for the MAM.

## Fixes

#2519

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a