### PR TITLE
Detect conflicts in `aea install`

### DIFF
--- a/aea/aea_builder.py
+++ b/aea/aea_builder.py
@@ -76,7 +76,11 @@ from aea.configurations.manager import (
     AgentConfigManager,
     find_component_directory_from_component_id,
 )
-from aea.configurations.pypi import is_satisfiable, merge_dependencies
+from aea.configurations.pypi import (
+    is_satisfiable,
+    merge_dependencies,
+    merge_dependencies_list,
+)
 from aea.configurations.validation import ExtraPropertiesError
 from aea.crypto.helpers import private_key_verify
 from aea.crypto.ledger_apis import DEFAULT_CURRENCY_DENOMINATIONS
@@ -240,13 +244,12 @@ class _DependenciesManager:
 
         :return: the merged PyPI dependencies
         """
-        all_pypi_dependencies = {}  # type: Dependencies
-        for configuration in self._dependencies.values():
-            all_pypi_dependencies = merge_dependencies(
-                all_pypi_dependencies, configuration.pypi_dependencies
-            )
-        all_pypi_dependencies = merge_dependencies(
-            all_pypi_dependencies, self.agent_pypi_dependencies
+        all_pypi_dependencies = merge_dependencies_list(
+            self.agent_pypi_dependencies,
+            *[
+                configuration.pypi_dependencies
+                for configuration in self._dependencies.values()
+            ],
         )
         return all_pypi_dependencies
 

--- a/aea/configurations/pypi.py
+++ b/aea/configurations/pypi.py
@@ -19,19 +19,15 @@
 # ------------------------------------------------------------------------------
 
 """This module contains a checker for PyPI version consistency."""
-import operator
 from collections import defaultdict
+from copy import deepcopy
+from functools import reduce
 from typing import Dict, List, Set, cast
 
 from packaging.specifiers import Specifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
 from aea.configurations.base import Dependencies, Dependency
-
-
-def and_(s1: SpecifierSet, s2: SpecifierSet) -> SpecifierSet:
-    """Do the and between two specifier sets."""
-    return operator.and_(s1, s2)
 
 
 def _handle_compatibility_operator(
@@ -235,25 +231,47 @@ def merge_dependencies(dep1: Dependencies, dep2: Dependencies) -> Dependencies:
     """
     Merge two groups of dependencies.
 
-    If some of them are not "simple" (see above), we just filter them out.
+    If some of them are not "simple" (see above), and there is no risk
+      of conflict because there is no other package with the same name,
+      we leave them; otherwise we raise an error.
 
     :param dep1: the first operand
     :param dep2: the second operand.
     :return: the merged dependencies.
     """
     result: Dependencies
-    result = {pkg_name: info for pkg_name, info in dep1.items() if is_simple_dep(info)}
+    result = deepcopy(dep1)
 
     for pkg_name, info in dep2.items():
-        if not is_simple_dep(info):
+        old_dep = result.get(pkg_name)
+        old_dep_exists = old_dep is not None
+        new_dep_is_simple = is_simple_dep(info)
+        old_dep_is_simple = is_simple_dep(info) if old_dep_exists else False
+        # in case a dependency exists in both operands and one of them is not simple:
+        if (new_dep_is_simple and old_dep_exists and not old_dep_is_simple) or (
+            not new_dep_is_simple and old_dep_exists
+        ):
+            # we raise error because we can't trivially merge the specifier sets;
+            raise ValueError(
+                f"cannot trivially merge these two PyPI dependencies:\n- {pkg_name}: {old_dep}\n- {pkg_name}: {info}"
+            )
+
+        # if one of the operands does not have a dependency,
+        # we add it untouched to the final result and continue
+        if not old_dep_exists:
+            result[pkg_name] = info
             continue
+
+        # if we are here, it means both in the first and second operand
+        # there are two 'simple' dependencies with the same name
+        # therefore, we need to merge them
         new_specifier = SpecifierSet(info.version)
         old_specifier = (
             SpecifierSet(result[pkg_name].version)
             if pkg_name in result
             else SpecifierSet("")
         )
-        combined_specifier = and_(new_specifier, old_specifier)
+        combined_specifier = new_specifier & old_specifier
         new_info = Dependency(
             name=info.name,
             version=combined_specifier,
@@ -263,4 +281,15 @@ def merge_dependencies(dep1: Dependencies, dep2: Dependencies) -> Dependencies:
         )
         result[pkg_name] = new_info
 
+    return result
+
+
+def merge_dependencies_list(*deps: Dependencies) -> Dependencies:
+    """
+    Merge a list of dependencies.
+
+    :param deps: the list of dependencies
+    :return: the merged dependencies.
+    """
+    result: Dependencies = reduce(merge_dependencies, deps, {})
     return result

--- a/aea/configurations/pypi.py
+++ b/aea/configurations/pypi.py
@@ -19,6 +19,7 @@
 # ------------------------------------------------------------------------------
 
 """This module contains a checker for PyPI version consistency."""
+import operator
 from collections import defaultdict
 from copy import deepcopy
 from functools import reduce
@@ -28,6 +29,11 @@ from packaging.specifiers import Specifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
 from aea.configurations.base import Dependencies, Dependency
+
+
+def and_(s1: SpecifierSet, s2: SpecifierSet) -> SpecifierSet:
+    """Do the and between two specifier sets."""
+    return operator.and_(s1, s2)
 
 
 def _handle_compatibility_operator(

--- a/aea/helpers/install_dependency.py
+++ b/aea/helpers/install_dependency.py
@@ -47,9 +47,7 @@ def install_dependency(
         enforce(return_code == 0, "Return code != 0.")
     except Exception as e:
         raise AEAException(
-            "An error occurred while installing {}, {}: {}".format(
-                dependency_name, dependency, str(e)
-            )
+            f"An error occurred while installing {dependency_name}, {dependency}: {e}"
         )
 
 

--- a/tests/test_configurations/test_pypi.py
+++ b/tests/test_configurations/test_pypi.py
@@ -78,6 +78,8 @@ def test_merge_dependencies():
     expected_merged_dependencies = {
         "package_1": Dependency("package_1", "==0.1.0"),
         "package_2": Dependency("package_2", "==0.2.0,==0.3.0"),
+        "package_3": Dependency("package_3", "==0.2.0", "https://pypi.org"),
+        "package_4": Dependency("package_4", "==0.1.0", "https://pypi.org"),
     }
     assert expected_merged_dependencies == merge_dependencies(
         dependencies_a, dependencies_b


### PR DESCRIPTION
## Proposed changes

Detect conflicts in `aea install`.

before this change, the problem was that if there were two PyPI dependencies with the same package, one of them replaced the other in an unpredictable way.

Now instead we check upfront whether there are two dependencies with the same package name, and we also check whether they are conflicting or unsatisfiable.

This is not the final solution. A proper solution would require more efforts trying to understand how to merge dependencies in different PyPI indexes, different repository versions etc. But I think it is a good trade-off and covers a lot of use-cases.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a