### PR TITLE
Add option to return AEA logs in missing string check (AEA-1636)

### DIFF
--- a/aea/test_tools/test_cases.py
+++ b/aea/test_tools/test_cases.py
@@ -814,8 +814,7 @@ class BaseAEATestCase(ABC):  # pylint: disable=too-many-public-methods
         timeout: int = DEFAULT_PROCESS_TIMEOUT,
         period: int = 1,
         is_terminating: bool = True,
-        return_logs: bool = False,
-    ) -> Union[List[str], Tuple[List[str], str]]:
+    ) -> List[str]:
         """
         Check if strings are present in process output.
 
@@ -827,9 +826,8 @@ class BaseAEATestCase(ABC):  # pylint: disable=too-many-public-methods
         :param timeout: int amount of seconds before stopping check.
         :param period: int period of checking.
         :param is_terminating: whether or not the agents are terminated
-        :param return_logs: whether or not to return the agent logs
 
-        :return: list of missed strings and logs if requested.
+        :return: list of missed strings.
         """
         missing_strings = list(strings)
         end_time = time.time() + timeout
@@ -852,9 +850,6 @@ class BaseAEATestCase(ABC):  # pylint: disable=too-many-public-methods
                 "Non-empty missing strings, stdout:\n{}".format(cls.stdout[process.pid])
             )
             _default_logger.info("=====================")
-
-        if return_logs:
-            return (missing_strings, cls.stdout[process.pid])
         return missing_strings
 
     @classmethod

--- a/aea/test_tools/test_cases.py
+++ b/aea/test_tools/test_cases.py
@@ -814,7 +814,8 @@ class BaseAEATestCase(ABC):  # pylint: disable=too-many-public-methods
         timeout: int = DEFAULT_PROCESS_TIMEOUT,
         period: int = 1,
         is_terminating: bool = True,
-    ) -> List[str]:
+        return_logs: bool = False,
+    ) -> Union[List[str], Tuple[List[str], str]]:
         """
         Check if strings are present in process output.
 
@@ -826,8 +827,9 @@ class BaseAEATestCase(ABC):  # pylint: disable=too-many-public-methods
         :param timeout: int amount of seconds before stopping check.
         :param period: int period of checking.
         :param is_terminating: whether or not the agents are terminated
+        :param return_logs: whether or not to return the agent logs
 
-        :return: list of missed strings.
+        :return: list of missed strings and logs if requested.
         """
         missing_strings = list(strings)
         end_time = time.time() + timeout
@@ -850,6 +852,9 @@ class BaseAEATestCase(ABC):  # pylint: disable=too-many-public-methods
                 "Non-empty missing strings, stdout:\n{}".format(cls.stdout[process.pid])
             )
             _default_logger.info("=====================")
+
+        if return_logs:
+            return (missing_strings, cls.stdout[process.pid])
         return missing_strings
 
     @classmethod

--- a/tests/test_packages/test_skills_integration/test_simple_oracle.py
+++ b/tests/test_packages/test_skills_integration/test_simple_oracle.py
@@ -213,12 +213,18 @@ class TestOracleSkillsFetchAI(AEATestCaseManyFlaky, UseLocalFetchNode):
                 "Successfully connected to libp2p node!",
                 LIBP2P_SUCCESS_MESSAGE,
             )
-            missing_strings = self.missing_from_output(
-                oracle_aea_process, check_strings, timeout=30, is_terminating=False
+            missing_strings, aea_logs = self.missing_from_output(
+                oracle_aea_process,
+                check_strings,
+                timeout=60,
+                is_terminating=False,
+                return_logs=True,
             )
             assert (
                 missing_strings == []
-            ), "Strings {} didn't appear in deploy_aea output.".format(missing_strings)
+            ), "Strings {} didn't appear in aea output: \n{}".format(
+                missing_strings, aea_logs
+            )
 
             check_strings = (
                 "setting up HttpHandler",
@@ -232,12 +238,18 @@ class TestOracleSkillsFetchAI(AEATestCaseManyFlaky, UseLocalFetchNode):
                 "transaction was successfully settled. Transaction receipt=",
                 "Oracle value successfully updated!",
             )
-            missing_strings = self.missing_from_output(
-                oracle_aea_process, check_strings, timeout=60, is_terminating=False
+            missing_strings, aea_logs = self.missing_from_output(
+                oracle_aea_process,
+                check_strings,
+                timeout=60,
+                is_terminating=False,
+                return_logs=True,
             )
             assert (
                 missing_strings == []
-            ), "Strings {} didn't appear in deploy_aea output.".format(missing_strings)
+            ), "Strings {} didn't appear in aea output: \n{}".format(
+                missing_strings, aea_logs
+            )
 
             # Get oracle contract address from file
             with open(ORACLE_CONTRACT_ADDRESS_FILE) as file:
@@ -260,12 +272,18 @@ class TestOracleSkillsFetchAI(AEATestCaseManyFlaky, UseLocalFetchNode):
                 "transaction was successfully settled. Transaction receipt=",
                 "Oracle value successfully requested!",
             )
-            missing_strings = self.missing_from_output(
-                client_aea_process, check_strings, timeout=60, is_terminating=False
+            missing_strings, aea_logs = self.missing_from_output(
+                client_aea_process,
+                check_strings,
+                timeout=60,
+                is_terminating=False,
+                return_logs=True,
             )
             assert (
                 missing_strings == []
-            ), "Strings {} didn't appear in deploy_aea output.".format(missing_strings)
+            ), "Strings {} didn't appear in aea output: \n{}".format(
+                missing_strings, aea_logs
+            )
 
             self.terminate_agents(oracle_aea_process, client_aea_process)
             assert (
@@ -451,12 +469,18 @@ class TestOracleSkillsETH(AEATestCaseManyFlaky, UseGanache):
             "Successfully connected to libp2p node!",
             LIBP2P_SUCCESS_MESSAGE,
         )
-        missing_strings = self.missing_from_output(
-            oracle_aea_process, check_strings, timeout=30, is_terminating=False
+        missing_strings, aea_logs = self.missing_from_output(
+            oracle_aea_process,
+            check_strings,
+            timeout=60,
+            is_terminating=False,
+            return_logs=True,
         )
         assert (
             missing_strings == []
-        ), "Strings {} didn't appear in deploy_aea output.".format(missing_strings)
+        ), "Strings {} didn't appear in aea output: \n{}".format(
+            missing_strings, aea_logs
+        )
 
         check_strings = (
             "setting up HttpHandler",
@@ -470,12 +494,18 @@ class TestOracleSkillsETH(AEATestCaseManyFlaky, UseGanache):
             "transaction was successfully settled. Transaction receipt=",
             "Oracle value successfully updated!",
         )
-        missing_strings = self.missing_from_output(
-            oracle_aea_process, check_strings, timeout=60, is_terminating=False
+        missing_strings, aea_logs = self.missing_from_output(
+            oracle_aea_process,
+            check_strings,
+            timeout=60,
+            is_terminating=False,
+            return_logs=True,
         )
         assert (
             missing_strings == []
-        ), "Strings {} didn't appear in deploy_aea output.".format(missing_strings)
+        ), "Strings {} didn't appear in aea output: \n{}".format(
+            missing_strings, aea_logs
+        )
 
         if ledger_id == FetchAICrypto.identifier:
             # Get oracle contract address from file
@@ -499,12 +529,18 @@ class TestOracleSkillsETH(AEATestCaseManyFlaky, UseGanache):
             "transaction was successfully settled. Transaction receipt=",
             "Oracle value successfully requested!",
         )
-        missing_strings = self.missing_from_output(
-            client_aea_process, check_strings, timeout=60, is_terminating=False
+        missing_strings, aea_logs = self.missing_from_output(
+            client_aea_process,
+            check_strings,
+            timeout=60,
+            is_terminating=False,
+            return_logs=True,
         )
         assert (
             missing_strings == []
-        ), "Strings {} didn't appear in deploy_aea output.".format(missing_strings)
+        ), "Strings {} didn't appear in aea output: \n{}".format(
+            missing_strings, aea_logs
+        )
 
         self.terminate_agents(oracle_aea_process, client_aea_process)
         assert (

--- a/tests/test_packages/test_skills_integration/test_simple_oracle.py
+++ b/tests/test_packages/test_skills_integration/test_simple_oracle.py
@@ -213,17 +213,13 @@ class TestOracleSkillsFetchAI(AEATestCaseManyFlaky, UseLocalFetchNode):
                 "Successfully connected to libp2p node!",
                 LIBP2P_SUCCESS_MESSAGE,
             )
-            missing_strings, aea_logs = self.missing_from_output(
-                oracle_aea_process,
-                check_strings,
-                timeout=60,
-                is_terminating=False,
-                return_logs=True,
+            missing_strings = self.missing_from_output(
+                oracle_aea_process, check_strings, timeout=60, is_terminating=False,
             )
             assert (
                 missing_strings == []
             ), "Strings {} didn't appear in aea output: \n{}".format(
-                missing_strings, aea_logs
+                missing_strings, self.stdout[oracle_aea_process.pid]
             )
 
             check_strings = (
@@ -238,17 +234,13 @@ class TestOracleSkillsFetchAI(AEATestCaseManyFlaky, UseLocalFetchNode):
                 "transaction was successfully settled. Transaction receipt=",
                 "Oracle value successfully updated!",
             )
-            missing_strings, aea_logs = self.missing_from_output(
-                oracle_aea_process,
-                check_strings,
-                timeout=60,
-                is_terminating=False,
-                return_logs=True,
+            missing_strings = self.missing_from_output(
+                oracle_aea_process, check_strings, timeout=60, is_terminating=False,
             )
             assert (
                 missing_strings == []
             ), "Strings {} didn't appear in aea output: \n{}".format(
-                missing_strings, aea_logs
+                missing_strings, self.stdout[oracle_aea_process.pid]
             )
 
             # Get oracle contract address from file
@@ -272,17 +264,13 @@ class TestOracleSkillsFetchAI(AEATestCaseManyFlaky, UseLocalFetchNode):
                 "transaction was successfully settled. Transaction receipt=",
                 "Oracle value successfully requested!",
             )
-            missing_strings, aea_logs = self.missing_from_output(
-                client_aea_process,
-                check_strings,
-                timeout=60,
-                is_terminating=False,
-                return_logs=True,
+            missing_strings = self.missing_from_output(
+                client_aea_process, check_strings, timeout=60, is_terminating=False,
             )
             assert (
                 missing_strings == []
             ), "Strings {} didn't appear in aea output: \n{}".format(
-                missing_strings, aea_logs
+                missing_strings, self.stdout[client_aea_process.pid]
             )
 
             self.terminate_agents(oracle_aea_process, client_aea_process)
@@ -469,17 +457,13 @@ class TestOracleSkillsETH(AEATestCaseManyFlaky, UseGanache):
             "Successfully connected to libp2p node!",
             LIBP2P_SUCCESS_MESSAGE,
         )
-        missing_strings, aea_logs = self.missing_from_output(
-            oracle_aea_process,
-            check_strings,
-            timeout=60,
-            is_terminating=False,
-            return_logs=True,
+        missing_strings = self.missing_from_output(
+            oracle_aea_process, check_strings, timeout=60, is_terminating=False,
         )
         assert (
             missing_strings == []
         ), "Strings {} didn't appear in aea output: \n{}".format(
-            missing_strings, aea_logs
+            missing_strings, self.stdout[oracle_aea_process.pid]
         )
 
         check_strings = (
@@ -494,17 +478,13 @@ class TestOracleSkillsETH(AEATestCaseManyFlaky, UseGanache):
             "transaction was successfully settled. Transaction receipt=",
             "Oracle value successfully updated!",
         )
-        missing_strings, aea_logs = self.missing_from_output(
-            oracle_aea_process,
-            check_strings,
-            timeout=60,
-            is_terminating=False,
-            return_logs=True,
+        missing_strings = self.missing_from_output(
+            oracle_aea_process, check_strings, timeout=60, is_terminating=False,
         )
         assert (
             missing_strings == []
         ), "Strings {} didn't appear in aea output: \n{}".format(
-            missing_strings, aea_logs
+            missing_strings, self.stdout[oracle_aea_process.pid]
         )
 
         if ledger_id == FetchAICrypto.identifier:
@@ -529,17 +509,13 @@ class TestOracleSkillsETH(AEATestCaseManyFlaky, UseGanache):
             "transaction was successfully settled. Transaction receipt=",
             "Oracle value successfully requested!",
         )
-        missing_strings, aea_logs = self.missing_from_output(
-            client_aea_process,
-            check_strings,
-            timeout=60,
-            is_terminating=False,
-            return_logs=True,
+        missing_strings = self.missing_from_output(
+            client_aea_process, check_strings, timeout=60, is_terminating=False,
         )
         assert (
             missing_strings == []
         ), "Strings {} didn't appear in aea output: \n{}".format(
-            missing_strings, aea_logs
+            missing_strings, self.stdout[client_aea_process.pid]
         )
 
         self.terminate_agents(oracle_aea_process, client_aea_process)


### PR DESCRIPTION
## Proposed changes

Currently it's hard to debug tests that fail only in CI because the AEA logs are not visible. This PR adds an option to return the AEA logs so they can be reported on test failures.

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules