### PR TITLE
DictProtobufStructSerializer.encode is deterministic now

### DIFF
--- a/aea/helpers/serializers.py
+++ b/aea/helpers/serializers.py
@@ -53,7 +53,7 @@ class DictProtobufStructSerializer:
         cls._patch_dict(patched_dict)
         pstruct = Struct()
         pstruct.update(patched_dict)  # pylint: disable=no-member
-        return pstruct.SerializeToString()
+        return pstruct.SerializeToString(deterministic=True)
 
     @classmethod
     def decode(cls, buffer: bytes) -> Dict[str, Any]:

--- a/tests/test_helpers/test_serializers.py
+++ b/tests/test_helpers/test_serializers.py
@@ -54,3 +54,11 @@ def test_encode_decode_ii():
     assert isinstance(encoded, bytes)
     decoded = DictProtobufStructSerializer.decode(encoded)
     assert case == decoded
+
+
+def test_encode_dict_is_deterministic():
+    """Check DictProtobufStructSerializer.encode result is the same for the same input data."""
+    data = dict(c=3, b=2, a=1)
+    assert DictProtobufStructSerializer.encode(
+        data
+    ) == DictProtobufStructSerializer.encode(data)


### PR DESCRIPTION
## Proposed changes

DictProtobufStructSerializer.encode is deterministic now

## Fixes

https://github.com/fetchai/agents-aea/issues/2598

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist


- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease.
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
