### PR TITLE
feat: make registering author optional

### DIFF
--- a/aea/cli/init.py
+++ b/aea/cli/init.py
@@ -36,14 +36,16 @@ from aea.cli.utils.package_utils import validate_author_name
 @click.command()
 @click.option("--author", type=str, required=False)
 @click.option("--reset", is_flag=True, help="To reset the initialization.")
-@click.option("--local", is_flag=True, help="For init AEA locally.")
+@click.option(
+    "--register", is_flag=True, help="To register the author in the AEA registry."
+)
 @click.option("--no-subscribe", is_flag=True, help="For developers subscription.")
 @pass_ctx
 def init(  # pylint: disable=unused-argument
-    ctx: Context, author: str, reset: bool, local: bool, no_subscribe: bool
+    ctx: Context, author: str, reset: bool, register: bool, no_subscribe: bool
 ) -> None:
     """Initialize your AEA configurations."""
-    do_init(author, reset, not local, no_subscribe)
+    do_init(author, reset, register, no_subscribe)
 
 
 def do_init(author: str, reset: bool, registry: bool, no_subscribe: bool) -> None:

--- a/aea/test_tools/test_cases.py
+++ b/aea/test_tools/test_cases.py
@@ -466,7 +466,7 @@ class BaseAEATestCase(ABC):  # pylint: disable=too-many-public-methods
     @classmethod
     def initialize_aea(cls, author: str) -> None:
         """Initialize AEA locally with author name."""
-        cls.run_cli_command("init", "--local", "--author", author, cwd=cls._get_cwd())
+        cls.run_cli_command("init", "--author", author, cwd=cls._get_cwd())
 
     @classmethod
     def add_item(cls, item_type: str, public_id: str, local: bool = True) -> Result:

--- a/docs/generic-skills-step-by-step.md
+++ b/docs/generic-skills-step-by-step.md
@@ -29,7 +29,7 @@ cd ..
 To keep file paths consistent with the reference code, we suggest you initialize your local author as `fetchai` for the purpose of this demo only:
 
 ``` bash
-aea init --reset --local --author fetchai
+aea init --reset --author fetchai
 ```
 
 ## Generic Seller AEA

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -143,11 +143,16 @@ If the installation steps fail, it might be a dependency issue. Make sure you ha
 
 ## Setup author name
 
-AEAs are composed from components. AEAs and AEA components can be developed by anyone and pushed to the <a href="https://aea-registry.fetch.ai" target="_blank">AEA registry</a> for others to use. To use the registry, we need to register an author name.
-
 You can set up your author name using the `init` command:
 ``` bash
 aea init
+```
+
+## Register as an AEA author (optional)
+
+AEAs are composed from components. AEAs and AEA components can be developed by anyone and pushed to the <a href="https://aea-registry.fetch.ai" target="_blank">AEA registry</a> for others to use. To publish packages to the registry, we need to register an author name:
+``` bash
+aea register
 ```
 
 This is your unique author (or developer) name in the AEA ecosystem.
@@ -167,7 +172,7 @@ Confirm password:
  / ___ \ | |___  / ___ \
 /_/   \_\|_____|/_/   \_\
 
-v1.1.1
+v1.2.2
 
 AEA configurations successfully initialized: {'author': 'fetchai'}
 ```

--- a/tests/test_cli/test_add/test_connection.py
+++ b/tests/test_cli/test_add/test_connection.py
@@ -70,7 +70,7 @@ class TestAddConnectionFailsWhenConnectionAlreadyExists:
         os.chdir(cls.t)
         result = cls.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR],
+            [*CLI_LOG_OPTION, "init", "--author", AUTHOR],
             standalone_mode=False,
         )
 
@@ -162,7 +162,7 @@ class TestAddConnectionFailsWhenConnectionWithSameAuthorAndNameButDifferentVersi
         os.chdir(cls.t)
         result = cls.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR],
+            [*CLI_LOG_OPTION, "init", "--author", AUTHOR],
             standalone_mode=False,
         )
 
@@ -245,7 +245,7 @@ class TestAddConnectionFailsWhenConnectionNotInRegistry:
         os.chdir(cls.t)
         result = cls.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR],
+            [*CLI_LOG_OPTION, "init", "--author", AUTHOR],
             standalone_mode=False,
         )
 
@@ -303,7 +303,7 @@ class TestAddConnectionFailsWhenDifferentPublicId:
         os.chdir(cls.t)
         result = cls.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR],
+            [*CLI_LOG_OPTION, "init", "--author", AUTHOR],
             standalone_mode=False,
         )
 
@@ -358,7 +358,7 @@ class TestAddConnectionFailsWhenConfigFileIsNotCompliant:
         os.chdir(cls.t)
         result = cls.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR],
+            [*CLI_LOG_OPTION, "init", "--author", AUTHOR],
             standalone_mode=False,
         )
 
@@ -426,7 +426,7 @@ class TestAddConnectionFailsWhenDirectoryAlreadyExists:
         os.chdir(cls.t)
         result = cls.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR],
+            [*CLI_LOG_OPTION, "init", "--author", AUTHOR],
             standalone_mode=False,
         )
 
@@ -530,7 +530,7 @@ class TestAddConnectionMixedWhenNoLocalRegistryExists:
         os.chdir(cls.t)
         result = cls.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR],
+            [*CLI_LOG_OPTION, "init", "--author", AUTHOR],
             standalone_mode=False,
         )
 
@@ -591,7 +591,7 @@ class TestAddConnectionLocalWhenNoLocalRegistryExists:
         os.chdir(cls.t)
         result = cls.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR],
+            [*CLI_LOG_OPTION, "init", "--author", AUTHOR],
             standalone_mode=False,
         )
         assert result.exit_code == 0, result.stdout

--- a/tests/test_cli/test_add/test_protocol.py
+++ b/tests/test_cli/test_add/test_protocol.py
@@ -67,7 +67,7 @@ class TestAddProtocolFailsWhenProtocolAlreadyExists:
         os.chdir(cls.t)
 
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -132,7 +132,7 @@ class TestAddProtocolFailsWhenProtocolWithSameAuthorAndNameButDifferentVersion:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -232,7 +232,7 @@ class TestAddProtocolFailsWhenProtocolNotInRegistry:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -288,7 +288,7 @@ class TestAddProtocolFailsWhenDifferentPublicId:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -341,7 +341,7 @@ class TestAddProtocolFailsWhenConfigFileIsNotCompliant:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -410,7 +410,7 @@ class TestAddProtocolFailsWhenDirectoryAlreadyExists:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 

--- a/tests/test_cli/test_add/test_protocol.py
+++ b/tests/test_cli/test_add/test_protocol.py
@@ -66,9 +66,7 @@ class TestAddProtocolFailsWhenProtocolAlreadyExists:
 
         os.chdir(cls.t)
 
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -131,9 +129,7 @@ class TestAddProtocolFailsWhenProtocolWithSameAuthorAndNameButDifferentVersion:
         shutil.copytree(Path(CUR_PATH, "..", "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -231,9 +227,7 @@ class TestAddProtocolFailsWhenProtocolNotInRegistry:
         shutil.copytree(Path(CUR_PATH, "..", "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -287,9 +281,7 @@ class TestAddProtocolFailsWhenDifferentPublicId:
         shutil.copytree(Path(CUR_PATH, "..", "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -340,9 +332,7 @@ class TestAddProtocolFailsWhenConfigFileIsNotCompliant:
         shutil.copytree(Path(CUR_PATH, "..", "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -409,9 +399,7 @@ class TestAddProtocolFailsWhenDirectoryAlreadyExists:
         shutil.copytree(Path(CUR_PATH, "..", "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(

--- a/tests/test_cli/test_add/test_skill.py
+++ b/tests/test_cli/test_add/test_skill.py
@@ -75,9 +75,7 @@ class TestAddSkillFailsWhenSkillAlreadyExists:
         shutil.copytree(Path(CUR_PATH, "..", "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -163,9 +161,7 @@ class TestAddSkillFailsWhenSkillWithSameAuthorAndNameButDifferentVersion:
         shutil.copytree(Path(CUR_PATH, "..", "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -243,9 +239,7 @@ class TestAddSkillFailsWhenSkillNotInRegistry:
         shutil.copytree(Path(CUR_PATH, "..", "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -300,9 +294,7 @@ class TestAddSkillFailsWhenDifferentPublicId:
         shutil.copytree(Path(CUR_PATH, "..", "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -354,9 +346,7 @@ class TestAddSkillFailsWhenConfigFileIsNotCompliant:
         shutil.copytree(Path(CUR_PATH, "..", "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -426,9 +416,7 @@ class TestAddSkillFailsWhenDirectoryAlreadyExists:
         shutil.copytree(Path(CUR_PATH, "..", "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(

--- a/tests/test_cli/test_add/test_skill.py
+++ b/tests/test_cli/test_add/test_skill.py
@@ -76,7 +76,7 @@ class TestAddSkillFailsWhenSkillAlreadyExists:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -164,7 +164,7 @@ class TestAddSkillFailsWhenSkillWithSameAuthorAndNameButDifferentVersion:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -244,7 +244,7 @@ class TestAddSkillFailsWhenSkillNotInRegistry:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -301,7 +301,7 @@ class TestAddSkillFailsWhenDifferentPublicId:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -355,7 +355,7 @@ class TestAddSkillFailsWhenConfigFileIsNotCompliant:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -427,7 +427,7 @@ class TestAddSkillFailsWhenDirectoryAlreadyExists:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 

--- a/tests/test_cli/test_add_key.py
+++ b/tests/test_cli/test_add_key.py
@@ -65,7 +65,7 @@ class TestAddFetchKey:
         os.chdir(cls.t)
 
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
 
         result = cls.runner.invoke(
@@ -127,7 +127,7 @@ class TestAddEthereumhKey:
         os.chdir(cls.t)
 
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
 
         result = cls.runner.invoke(
@@ -189,7 +189,7 @@ class TestAddManyKeys:
         os.chdir(cls.t)
 
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
 
         result = cls.runner.invoke(
@@ -266,7 +266,7 @@ def test_add_key_fails_bad_key():
         ) as mock_logger_error:
 
             result = runner.invoke(
-                cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+                cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
             )
 
             result = runner.invoke(
@@ -312,7 +312,7 @@ def test_add_key_fails_bad_ledger_id():
     os.chdir(tmpdir)
     try:
         result = runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
 
         result = runner.invoke(cli, [*CLI_LOG_OPTION, "create", "--local", agent_name])

--- a/tests/test_cli/test_add_key.py
+++ b/tests/test_cli/test_add_key.py
@@ -64,9 +64,7 @@ class TestAddFetchKey:
         cls.agent_folder = Path(cls.t, cls.agent_name)
         os.chdir(cls.t)
 
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
 
         result = cls.runner.invoke(
             cli, [*CLI_LOG_OPTION, "create", "--local", cls.agent_name]
@@ -126,9 +124,7 @@ class TestAddEthereumhKey:
         shutil.copytree(str(src_dir), str(tmp_dir))
         os.chdir(cls.t)
 
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
 
         result = cls.runner.invoke(
             cli, [*CLI_LOG_OPTION, "create", "--local", cls.agent_name]
@@ -188,9 +184,7 @@ class TestAddManyKeys:
         cls.agent_folder = Path(cls.t, cls.agent_name)
         os.chdir(cls.t)
 
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
 
         result = cls.runner.invoke(
             cli, [*CLI_LOG_OPTION, "create", "--local", cls.agent_name]
@@ -265,9 +259,7 @@ def test_add_key_fails_bad_key():
             aea.crypto.helpers._default_logger, "error"
         ) as mock_logger_error:
 
-            result = runner.invoke(
-                cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-            )
+            result = runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
 
             result = runner.invoke(
                 cli, [*CLI_LOG_OPTION, "create", "--local", agent_name]
@@ -311,9 +303,7 @@ def test_add_key_fails_bad_ledger_id():
     shutil.copytree(str(src_dir), str(tmp_dir))
     os.chdir(tmpdir)
     try:
-        result = runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
 
         result = runner.invoke(cli, [*CLI_LOG_OPTION, "create", "--local", agent_name])
         assert result.exit_code == 0

--- a/tests/test_cli/test_create.py
+++ b/tests/test_cli/test_create.py
@@ -82,7 +82,7 @@ class TestCreate:
         )
         cls.cli_config_patch.start()
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0, result.stdout
 
@@ -266,7 +266,7 @@ class TestCreateFailsWhenDirectoryAlreadyExists:
         # create a directory with the agent name -> make 'aea create fail.
         os.mkdir(cls.agent_name)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -322,7 +322,7 @@ class TestCreateFailsWhenConfigFileIsNotCompliant:
         os.chdir(cls.t)
 
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -372,7 +372,7 @@ class TestCreateFailsWhenExceptionOccurs:
         shutil.copytree(str(src_dir), str(tmp_dir))
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -418,7 +418,7 @@ class TestCreateFailsWhenAlreadyInAEAProject:
         cls.runner = CliRunner()
         cls.agent_name = "myagent"
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 

--- a/tests/test_cli/test_create.py
+++ b/tests/test_cli/test_create.py
@@ -81,9 +81,7 @@ class TestCreate:
             "aea.cli.utils.config.CLI_CONFIG_PATH", cls.cli_config_file
         )
         cls.cli_config_patch.start()
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0, result.stdout
 
         cls.result = cls.runner.invoke(
@@ -265,9 +263,7 @@ class TestCreateFailsWhenDirectoryAlreadyExists:
 
         # create a directory with the agent name -> make 'aea create fail.
         os.mkdir(cls.agent_name)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         cls.result = cls.runner.invoke(
@@ -321,9 +317,7 @@ class TestCreateFailsWhenConfigFileIsNotCompliant:
         shutil.copytree(str(src_dir), str(tmp_dir))
         os.chdir(cls.t)
 
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         cls.result = cls.runner.invoke(
@@ -371,9 +365,7 @@ class TestCreateFailsWhenExceptionOccurs:
         src_dir = cls.cwd / Path(ROOT_DIR, dir_path)
         shutil.copytree(str(src_dir), str(tmp_dir))
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         cls.result = cls.runner.invoke(
@@ -417,9 +409,7 @@ class TestCreateFailsWhenAlreadyInAEAProject:
 
         cls.runner = CliRunner()
         cls.agent_name = "myagent"
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         cls.result = cls.runner.invoke(

--- a/tests/test_cli/test_delete.py
+++ b/tests/test_cli/test_delete.py
@@ -118,9 +118,7 @@ class TestDeleteFailsWhenDirectoryCannotBeDeleted:
         shutil.copytree(str(src_dir), str(tmp_dir))
         os.chdir(cls.t)
 
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(

--- a/tests/test_cli/test_delete.py
+++ b/tests/test_cli/test_delete.py
@@ -45,7 +45,7 @@ class TestDelete:
         src_dir = cls.cwd / Path(ROOT_DIR, dir_path)
         shutil.copytree(str(src_dir), str(tmp_dir))
         os.chdir(cls.t)
-        cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR])
+        cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
 
         cls.runner.invoke(
             cli,
@@ -119,7 +119,7 @@ class TestDeleteFailsWhenDirectoryCannotBeDeleted:
         os.chdir(cls.t)
 
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 

--- a/tests/test_cli/test_generate/test_protocols.py
+++ b/tests/test_cli/test_generate/test_protocols.py
@@ -74,9 +74,7 @@ class TestGenerateProtocolFullMode:
 
         # create an agent
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         cls.create_result = cls.runner.invoke(
@@ -154,9 +152,7 @@ class TestGenerateProtocolProtobufOnlyMode:
 
         # create an agent
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         cls.create_result = cls.runner.invoke(
@@ -251,9 +247,7 @@ class TestGenerateProtocolFailsWhenDirectoryAlreadyExists:
 
         # create an agent
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         cls.create_result = cls.runner.invoke(
@@ -335,9 +329,7 @@ class TestGenerateProtocolFailsWhenProtocolAlreadyExists:
 
         # create an agent
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         cls.create_result = cls.runner.invoke(
@@ -429,9 +421,7 @@ class TestGenerateProtocolFailsWhenConfigFileIsNotCompliant:
 
         # create an agent
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         cls.create_result = cls.runner.invoke(
@@ -506,9 +496,7 @@ class TestGenerateProtocolFailsWhenExceptionOccurs:
 
         # create an agent
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         cls.create_result = cls.runner.invoke(

--- a/tests/test_cli/test_generate/test_protocols.py
+++ b/tests/test_cli/test_generate/test_protocols.py
@@ -75,7 +75,7 @@ class TestGenerateProtocolFullMode:
         # create an agent
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -155,7 +155,7 @@ class TestGenerateProtocolProtobufOnlyMode:
         # create an agent
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -252,7 +252,7 @@ class TestGenerateProtocolFailsWhenDirectoryAlreadyExists:
         # create an agent
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -336,7 +336,7 @@ class TestGenerateProtocolFailsWhenProtocolAlreadyExists:
         # create an agent
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -430,7 +430,7 @@ class TestGenerateProtocolFailsWhenConfigFileIsNotCompliant:
         # create an agent
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -507,7 +507,7 @@ class TestGenerateProtocolFailsWhenExceptionOccurs:
         # create an agent
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -89,7 +89,7 @@ class TestDoInit:
         author = "test_author" + random_string()
         result = self.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--author", author],
+            [*CLI_LOG_OPTION, "init", "--register", "--author", author],
             input=f"n\n{email}\n{pwd}\n{pwd}\n\n",
         )
         assert result.exit_code == 0, result.output
@@ -105,7 +105,7 @@ class TestDoInit:
         author = "test_author" + random_string()
         result = self.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--author", author],
+            [*CLI_LOG_OPTION, "init", "--register", "--author", author],
             input="y\nsome fake password\n",
         )
 
@@ -117,7 +117,7 @@ class TestDoInit:
         """Registered and logged in (has token)."""
         result = self.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--author", "test_author"],
+            [*CLI_LOG_OPTION, "init", "--register", "--author", "test_author"],
         )
         assert result.exit_code == 0
 

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -55,7 +55,7 @@ class TestDoInit:
 
         result = self.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--local", "--author", author],
+            [*CLI_LOG_OPTION, "init", "--author", author],
         )
 
         assert result.exit_code == 0
@@ -75,10 +75,10 @@ class TestDoInit:
         """Test author already registered."""
         result = self.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--local", "--author", "author"],
+            [*CLI_LOG_OPTION, "init", "--author", "author"],
         )
         assert result.exit_code == 0
-        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--local"])
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "init"])
         assert "AEA configurations already initialized" in result.output
 
     @patch("aea.cli.register.register_new_account", return_value="TOKEN")

--- a/tests/test_cli/test_launch.py
+++ b/tests/test_cli/test_launch.py
@@ -120,9 +120,7 @@ class BaseLaunchTestCase:
         shutil.copytree(str(src_dir), str(tmp_dir))
         os.chdir(cls.t)
         password_option = cls.get_password_args(cls.PASSWORD)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli, [*CLI_LOG_OPTION, "create", "--local", cls.agent_name_1]

--- a/tests/test_cli/test_launch.py
+++ b/tests/test_cli/test_launch.py
@@ -121,7 +121,7 @@ class BaseLaunchTestCase:
         os.chdir(cls.t)
         password_option = cls.get_password_args(cls.PASSWORD)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(

--- a/tests/test_cli/test_remove/test_base.py
+++ b/tests/test_cli/test_remove/test_base.py
@@ -208,9 +208,7 @@ class TestRemoveWithIncompatibleAEAVersion:
         cls.connection_name = "http_client"
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,

--- a/tests/test_cli/test_remove/test_base.py
+++ b/tests/test_cli/test_remove/test_base.py
@@ -209,7 +209,7 @@ class TestRemoveWithIncompatibleAEAVersion:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(

--- a/tests/test_cli/test_remove/test_connection.py
+++ b/tests/test_cli/test_remove/test_connection.py
@@ -59,7 +59,7 @@ class TestRemoveConnectionWithPublicId:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(
@@ -121,7 +121,7 @@ class TestRemoveConnectionFailsWhenConnectionDoesNotExist:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(
@@ -177,7 +177,7 @@ class TestRemoveConnectionFailsWhenExceptionOccurs:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(

--- a/tests/test_cli/test_remove/test_connection.py
+++ b/tests/test_cli/test_remove/test_connection.py
@@ -58,9 +58,7 @@ class TestRemoveConnectionWithPublicId:
         cls.connection_name = "http_client"
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,
@@ -120,9 +118,7 @@ class TestRemoveConnectionFailsWhenConnectionDoesNotExist:
         cls.connection_id = str(LOCAL_CONNECTION_PUBLIC_ID)
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,
@@ -176,9 +172,7 @@ class TestRemoveConnectionFailsWhenExceptionOccurs:
         cls.connection_name = "http_client"
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,

--- a/tests/test_cli/test_remove/test_dependencies.py
+++ b/tests/test_cli/test_remove/test_dependencies.py
@@ -77,7 +77,7 @@ class TestRemoveAndDependencies:  # pylint: disable=attribute-defined-outside-in
         os.chdir(self.t)
         result = self.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR],
+            [*CLI_LOG_OPTION, "init", "--author", AUTHOR],
             standalone_mode=False,
         )
         assert result.exit_code == 0

--- a/tests/test_cli/test_remove/test_protocol.py
+++ b/tests/test_cli/test_remove/test_protocol.py
@@ -54,7 +54,7 @@ class TestRemoveProtocolWithPublicId:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(
@@ -116,7 +116,7 @@ class TestRemoveProtocolFailsWhenProtocolDoesNotExist:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(
@@ -172,7 +172,7 @@ class TestRemoveProtocolFailsWhenExceptionOccurs:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(

--- a/tests/test_cli/test_remove/test_protocol.py
+++ b/tests/test_cli/test_remove/test_protocol.py
@@ -53,9 +53,7 @@ class TestRemoveProtocolWithPublicId:
         cls.protocol_name = "gym"
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,
@@ -115,9 +113,7 @@ class TestRemoveProtocolFailsWhenProtocolDoesNotExist:
         cls.protocol_id = str(GymMessage.protocol_id)
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,
@@ -171,9 +167,7 @@ class TestRemoveProtocolFailsWhenExceptionOccurs:
         cls.protocol_id = str(GymMessage.protocol_id)
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,

--- a/tests/test_cli/test_remove/test_skill.py
+++ b/tests/test_cli/test_remove/test_skill.py
@@ -56,7 +56,7 @@ class TestRemoveSkillWithPublicId:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -128,7 +128,7 @@ class TestRemoveSkillFailsWhenSkillIsNotSupported:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -187,7 +187,7 @@ class TestRemoveSkillFailsWhenExceptionOccurs:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 

--- a/tests/test_cli/test_remove/test_skill.py
+++ b/tests/test_cli/test_remove/test_skill.py
@@ -55,9 +55,7 @@ class TestRemoveSkillWithPublicId:
         cls.skill_name = "gym"
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -127,9 +125,7 @@ class TestRemoveSkillFailsWhenSkillIsNotSupported:
         cls.skill_id = str(GYM_SKILL_PUBLIC_ID)
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -186,9 +182,7 @@ class TestRemoveSkillFailsWhenExceptionOccurs:
         cls.skill_name = "gym"
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(

--- a/tests/test_cli/test_run.py
+++ b/tests/test_cli/test_run.py
@@ -74,7 +74,7 @@ def test_run(password_or_none):
 
     os.chdir(t)
     result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
     )
     assert result.exit_code == 0
 
@@ -154,7 +154,7 @@ def test_run_with_profiling():
 
     os.chdir(t)
     result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
     )
     assert result.exit_code == 0
 
@@ -228,7 +228,7 @@ def test_run_with_default_connection():
 
     os.chdir(t)
     result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
     )
     assert result.exit_code == 0
 
@@ -290,7 +290,7 @@ def test_run_multiple_connections(connection_ids):
 
     os.chdir(t)
     result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
     )
     assert result.exit_code == 0
 
@@ -374,7 +374,7 @@ def test_run_unknown_private_key():
 
     os.chdir(t)
     result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
     )
     assert result.exit_code == 0
 
@@ -449,7 +449,7 @@ def test_run_fet_private_key_config():
 
     os.chdir(t)
     result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
     )
     assert result.exit_code == 0
 
@@ -508,7 +508,7 @@ def test_run_ethereum_private_key_config():
 
     os.chdir(t)
     result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
     )
     assert result.exit_code == 0
 
@@ -570,7 +570,7 @@ def test_run_with_install_deps():
 
     os.chdir(t)
     result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
     )
     assert result.exit_code == 0
 
@@ -650,7 +650,7 @@ def test_run_with_install_deps_and_requirement_file():
 
     os.chdir(t)
     result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
     )
     assert result.exit_code == 0
 
@@ -737,7 +737,7 @@ class TestRunFailsWhenExceptionOccursInSkill:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -808,7 +808,7 @@ class TestRunFailsWhenConfigurationFileNotFound:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -864,7 +864,7 @@ class TestRunFailsWhenConfigurationFileIsEmpty:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -917,7 +917,7 @@ class TestRunFailsWhenConfigurationFileInvalid:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -998,7 +998,7 @@ class TestRunFailsWhenConnectionConfigFileNotFound:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -1171,7 +1171,7 @@ class TestRunFailsWhenProtocolConfigFileNotFound:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -1246,7 +1246,7 @@ class TestRunFailsWhenProtocolNotComplete:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 

--- a/tests/test_cli/test_run.py
+++ b/tests/test_cli/test_run.py
@@ -73,9 +73,7 @@ def test_run(password_or_none):
     password_options = _get_password_option_args(password_or_none)
 
     os.chdir(t)
-    result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-    )
+    result = runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
     assert result.exit_code == 0
 
     result = runner.invoke(cli, [*CLI_LOG_OPTION, "create", "--local", agent_name])
@@ -153,9 +151,7 @@ def test_run_with_profiling():
     shutil.copytree(Path(ROOT_DIR, "packages"), Path(t, "packages"))
 
     os.chdir(t)
-    result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-    )
+    result = runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
     assert result.exit_code == 0
 
     result = runner.invoke(cli, [*CLI_LOG_OPTION, "create", "--local", agent_name])
@@ -227,9 +223,7 @@ def test_run_with_default_connection():
     shutil.copytree(Path(ROOT_DIR, "packages"), Path(t, "packages"))
 
     os.chdir(t)
-    result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-    )
+    result = runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
     assert result.exit_code == 0
 
     result = runner.invoke(cli, [*CLI_LOG_OPTION, "create", "--local", agent_name])
@@ -289,9 +283,7 @@ def test_run_multiple_connections(connection_ids):
     shutil.copytree(Path(ROOT_DIR, "packages"), Path(t, "packages"))
 
     os.chdir(t)
-    result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-    )
+    result = runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
     assert result.exit_code == 0
 
     result = runner.invoke(cli, [*CLI_LOG_OPTION, "create", "--local", agent_name])
@@ -373,9 +365,7 @@ def test_run_unknown_private_key():
     shutil.copytree(Path(ROOT_DIR, "packages"), Path(t, "packages"))
 
     os.chdir(t)
-    result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-    )
+    result = runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
     assert result.exit_code == 0
 
     result = runner.invoke(cli, [*CLI_LOG_OPTION, "create", "--local", agent_name])
@@ -448,9 +438,7 @@ def test_run_fet_private_key_config():
     shutil.copytree(Path(ROOT_DIR, "packages"), Path(t, "packages"))
 
     os.chdir(t)
-    result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-    )
+    result = runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
     assert result.exit_code == 0
 
     result = runner.invoke(cli, [*CLI_LOG_OPTION, "create", "--local", agent_name])
@@ -507,9 +495,7 @@ def test_run_ethereum_private_key_config():
     shutil.copytree(Path(ROOT_DIR, "packages"), Path(t, "packages"))
 
     os.chdir(t)
-    result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-    )
+    result = runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
     assert result.exit_code == 0
 
     result = runner.invoke(cli, [*CLI_LOG_OPTION, "create", "--local", agent_name])
@@ -569,9 +555,7 @@ def test_run_with_install_deps():
     shutil.copytree(packages_src, packages_dst)
 
     os.chdir(t)
-    result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-    )
+    result = runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
     assert result.exit_code == 0
 
     result = runner.invoke(cli, [*CLI_LOG_OPTION, "create", "--local", agent_name])
@@ -649,9 +633,7 @@ def test_run_with_install_deps_and_requirement_file():
     shutil.copytree(Path(ROOT_DIR, "packages"), Path(t, "packages"))
 
     os.chdir(t)
-    result = runner.invoke(
-        cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-    )
+    result = runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
     assert result.exit_code == 0
 
     result = runner.invoke(cli, [*CLI_LOG_OPTION, "create", "--local", agent_name])
@@ -736,9 +718,7 @@ class TestRunFailsWhenExceptionOccursInSkill:
         shutil.copytree(Path(ROOT_DIR, "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -807,9 +787,7 @@ class TestRunFailsWhenConfigurationFileNotFound:
         shutil.copytree(Path(ROOT_DIR, "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -863,9 +841,7 @@ class TestRunFailsWhenConfigurationFileIsEmpty:
         shutil.copytree(Path(ROOT_DIR, "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -916,9 +892,7 @@ class TestRunFailsWhenConfigurationFileInvalid:
         shutil.copytree(Path(ROOT_DIR, "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -997,9 +971,7 @@ class TestRunFailsWhenConnectionConfigFileNotFound:
         shutil.copytree(Path(ROOT_DIR, "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -1170,9 +1142,7 @@ class TestRunFailsWhenProtocolConfigFileNotFound:
         shutil.copytree(Path(ROOT_DIR, "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -1245,9 +1215,7 @@ class TestRunFailsWhenProtocolNotComplete:
         shutil.copytree(Path(ROOT_DIR, "packages"), Path(cls.t, "packages"))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(

--- a/tests/test_cli/test_scaffold/test_connection.py
+++ b/tests/test_cli/test_scaffold/test_connection.py
@@ -67,7 +67,7 @@ class TestScaffoldConnection:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -143,7 +143,7 @@ class TestScaffoldConnectionWithSymlinks:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -230,7 +230,7 @@ class TestScaffoldConnectionFailsWhenDirectoryAlreadyExists:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -298,7 +298,7 @@ class TestScaffoldConnectionFailsWhenConnectionAlreadyExists:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -372,7 +372,7 @@ class TestScaffoldConnectionFailsWhenConfigFileIsNotCompliant:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 
@@ -446,7 +446,7 @@ class TestScaffoldConnectionFailsWhenExceptionOccurs:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 

--- a/tests/test_cli/test_scaffold/test_connection.py
+++ b/tests/test_cli/test_scaffold/test_connection.py
@@ -66,9 +66,7 @@ class TestScaffoldConnection:
         cls.validator = Draft4Validator(cls.schema, resolver=cls.resolver)
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -142,9 +140,7 @@ class TestScaffoldConnectionWithSymlinks:
         cls.validator = Draft4Validator(cls.schema, resolver=cls.resolver)
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -229,9 +225,7 @@ class TestScaffoldConnectionFailsWhenDirectoryAlreadyExists:
         shutil.copytree(str(src_dir), str(tmp_dir))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -297,9 +291,7 @@ class TestScaffoldConnectionFailsWhenConnectionAlreadyExists:
         shutil.copytree(str(src_dir), str(tmp_dir))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -371,9 +363,7 @@ class TestScaffoldConnectionFailsWhenConfigFileIsNotCompliant:
         shutil.copytree(str(src_dir), str(tmp_dir))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(
@@ -445,9 +435,7 @@ class TestScaffoldConnectionFailsWhenExceptionOccurs:
         shutil.copytree(str(src_dir), str(tmp_dir))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = cls.runner.invoke(

--- a/tests/test_cli/test_scaffold/test_protocols.py
+++ b/tests/test_cli/test_scaffold/test_protocols.py
@@ -69,7 +69,7 @@ class TestScaffoldProtocol:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(
@@ -148,7 +148,7 @@ class TestScaffoldProtocolFailsWhenDirectoryAlreadyExists:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(
@@ -216,7 +216,7 @@ class TestScaffoldProtocolFailsWhenProtocolAlreadyExists:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(
@@ -291,7 +291,7 @@ class TestScaffoldProtocolFailsWhenConfigFileIsNotCompliant:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(
@@ -365,7 +365,7 @@ class TestScaffoldProtocolFailsWhenExceptionOccurs:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(

--- a/tests/test_cli/test_scaffold/test_protocols.py
+++ b/tests/test_cli/test_scaffold/test_protocols.py
@@ -68,9 +68,7 @@ class TestScaffoldProtocol:
         cls.validator = Draft4Validator(cls.schema, resolver=cls.resolver)
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,
@@ -147,9 +145,7 @@ class TestScaffoldProtocolFailsWhenDirectoryAlreadyExists:
         shutil.copytree(str(src_dir), str(tmp_dir))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,
@@ -215,9 +211,7 @@ class TestScaffoldProtocolFailsWhenProtocolAlreadyExists:
         shutil.copytree(str(src_dir), str(tmp_dir))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,
@@ -290,9 +284,7 @@ class TestScaffoldProtocolFailsWhenConfigFileIsNotCompliant:
         shutil.copytree(str(src_dir), str(tmp_dir))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,
@@ -364,9 +356,7 @@ class TestScaffoldProtocolFailsWhenExceptionOccurs:
         shutil.copytree(str(src_dir), str(tmp_dir))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,

--- a/tests/test_cli/test_scaffold/test_skills.py
+++ b/tests/test_cli/test_scaffold/test_skills.py
@@ -71,9 +71,7 @@ class TestScaffoldSkill:
         cls.validator = Draft4Validator(cls.schema, resolver=cls.resolver)
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,
@@ -162,9 +160,7 @@ class TestScaffoldSkillFailsWhenDirectoryAlreadyExists:
         shutil.copytree(str(src_dir), str(tmp_dir))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,
@@ -229,9 +225,7 @@ class TestScaffoldSkillFailsWhenSkillAlreadyExists:
         shutil.copytree(str(src_dir), str(tmp_dir))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,
@@ -302,9 +296,7 @@ class TestScaffoldSkillFailsWhenConfigFileIsNotCompliant:
         shutil.copytree(str(src_dir), str(tmp_dir))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,
@@ -374,9 +366,7 @@ class TestScaffoldSkillFailsWhenExceptionOccurs:
         shutil.copytree(str(src_dir), str(tmp_dir))
 
         os.chdir(cls.t)
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,

--- a/tests/test_cli/test_scaffold/test_skills.py
+++ b/tests/test_cli/test_scaffold/test_skills.py
@@ -72,7 +72,7 @@ class TestScaffoldSkill:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(
@@ -163,7 +163,7 @@ class TestScaffoldSkillFailsWhenDirectoryAlreadyExists:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(
@@ -230,7 +230,7 @@ class TestScaffoldSkillFailsWhenSkillAlreadyExists:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(
@@ -303,7 +303,7 @@ class TestScaffoldSkillFailsWhenConfigFileIsNotCompliant:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(
@@ -375,7 +375,7 @@ class TestScaffoldSkillFailsWhenExceptionOccurs:
 
         os.chdir(cls.t)
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(

--- a/tests/test_cli/test_search.py
+++ b/tests/test_cli/test_search.py
@@ -181,9 +181,7 @@ class TestSearchAgentsLocal:
             "aea.cli.utils.config.CLI_CONFIG_PATH", cls.cli_config_file
         )
         cls.cli_config_patch.start()
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
         result = cls.runner.invoke(
             cli,
@@ -414,9 +412,7 @@ class TestSearchInAgentDirectoryLocal:
             if p.name not in ["echo", "error"] and p.is_dir():
                 shutil.rmtree(p)
 
-        result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = cls.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         # create an AEA proejct and enter into it.

--- a/tests/test_cli/test_search.py
+++ b/tests/test_cli/test_search.py
@@ -182,7 +182,7 @@ class TestSearchAgentsLocal:
         )
         cls.cli_config_patch.start()
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
         result = cls.runner.invoke(
@@ -415,7 +415,7 @@ class TestSearchInAgentDirectoryLocal:
                 shutil.rmtree(p)
 
         result = cls.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 

--- a/tests/test_cli/test_upgrade.py
+++ b/tests/test_cli/test_upgrade.py
@@ -117,7 +117,7 @@ class BaseTestCase:
         os.chdir(cls.t)
         result = cls.runner.invoke(
             cli,
-            [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR],
+            [*CLI_LOG_OPTION, "init", "--author", AUTHOR],
             standalone_mode=False,
         )
         assert result.exit_code == 0

--- a/tests/test_docs/test_bash_yaml/md_files/bash-generic-skills-step-by-step.md
+++ b/tests/test_docs/test_bash_yaml/md_files/bash-generic-skills-step-by-step.md
@@ -17,7 +17,7 @@ aea eject skill fetchai/generic_buyer:0.27.3
 cd ..
 ```
 ``` bash
-aea init --reset --local --author fetchai
+aea init --reset --author fetchai
 ```
 ``` bash
 aea create my_generic_seller

--- a/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
+++ b/tests/test_docs/test_bash_yaml/md_files/bash-quickstart.md
@@ -43,6 +43,9 @@ sudo apt-get install python3.7-dev
 aea init
 ```
 ``` bash
+aea register
+```
+``` bash
 Do you have a Registry account? [y/N]: n
 Create a new account on the Registry now:
 Username: fetchai
@@ -56,7 +59,7 @@ Confirm password:
  / ___ \ | |___  / ___ \
 /_/   \_\|_____|/_/   \_\
 
-v1.1.1
+v1.2.2
 
 AEA configurations successfully initialized: {'author': 'fetchai'}
 ```

--- a/tests/test_docs/test_quickstart.py
+++ b/tests/test_docs/test_quickstart.py
@@ -36,7 +36,7 @@ def test_correct_echo_string():
     """Test the echo string in the quickstart is using the correct protocol specification id."""
     file_path = Path(ROOT_DIR, "docs", "quickstart.md")
     bash_code_blocks = extract_code_blocks(filepath=file_path, filter_="bash")
-    echo_bloc = bash_code_blocks[18]
+    echo_bloc = bash_code_blocks[19]
     default_protocol_spec_id = echo_bloc.split(",")[2]
     assert (
         str(DefaultMessage.protocol_specification_id) == default_protocol_spec_id

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -898,9 +898,7 @@ class TestMultiplexerDisconnectsOnTermination:  # pylint: disable=attribute-defi
         self.key_path = os.path.join(self.t, "fetchai_private_key.txt")
         self.conn_key_path = os.path.join(self.t, "conn_private_key.txt")
 
-        result = self.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
-        )
+        result = self.runner.invoke(cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR])
         assert result.exit_code == 0
 
         result = self.runner.invoke(

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -899,7 +899,7 @@ class TestMultiplexerDisconnectsOnTermination:  # pylint: disable=attribute-defi
         self.conn_key_path = os.path.join(self.t, "conn_private_key.txt")
 
         result = self.runner.invoke(
-            cli, [*CLI_LOG_OPTION, "init", "--local", "--author", AUTHOR]
+            cli, [*CLI_LOG_OPTION, "init", "--author", AUTHOR]
         )
         assert result.exit_code == 0
 


### PR DESCRIPTION
## Proposed changes

Authors should not need to register to get started developing AEAs.

With this change, users can still register with:
``` bash
aea init --register
```
or
``` bash
aea register
```
but by default, only the author handle will be setup (previously `aea init --local`).

## Types of changes

What types of changes does your code introduce to agents-aea?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/agents-aea/blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes and CI passes too
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease.
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules